### PR TITLE
fix players being counted for entity caps

### DIFF
--- a/src/main/java/com/plotsquared/bukkit/util/BukkitChunkManager.java
+++ b/src/main/java/com/plotsquared/bukkit/util/BukkitChunkManager.java
@@ -968,7 +968,11 @@ public class BukkitChunkManager extends ChunkManager {
         boolean doWhole = false;
         List<Entity> entities = null;
         if (size > 200) {
-            entities = world.getEntities();
+            for (Entity worldEntity : world.getEntities()) {
+                if (!(worldEntity instanceof Player)) {
+                    entities.add(worldEntity);
+                }
+            }
             if (entities.size() < (16 + ((size * size) / 64))) {
                 doWhole = true;
             }


### PR DESCRIPTION
There might be a better way. I've changed the general `countEntities` method as it is used to calculate the amount of entities on a plot.

**REASON**
Players do not bypass the entity cap limit for a plot