### PR TITLE
Cleanup

### DIFF
--- a/src/main/java/com/intellectualcrafters/configuration/MemorySection.java
+++ b/src/main/java/com/intellectualcrafters/configuration/MemorySection.java
@@ -11,7 +11,7 @@ import java.util.Set;
  * A type of {@link ConfigurationSection} that is stored in memory.
  */
 public class MemorySection implements ConfigurationSection {
-    protected final Map<String, Object> map = new LinkedHashMap<String, Object>();
+    protected final Map<String, Object> map = new LinkedHashMap<>();
     private final Configuration root;
     private final ConfigurationSection parent;
     private final String path;
@@ -24,7 +24,8 @@ public class MemorySection implements ConfigurationSection {
         if (obj instanceof String) {
             try {
                 return Double.parseDouble((String) obj);
-            } catch (final Exception e) {}
+            } catch (NumberFormatException ignored) {
+            }
         } else if (obj instanceof List) {
             final List<?> val = ((List<?>) obj);
             if (val.size() > 0) {
@@ -41,7 +42,8 @@ public class MemorySection implements ConfigurationSection {
         if (obj instanceof String) {
             try {
                 return Integer.parseInt((String) obj);
-            } catch (final Exception e) {}
+            } catch (NumberFormatException ignored) {
+            }
         } else if (obj instanceof List) {
             final List<?> val = ((List<?>) obj);
             if (val.size() > 0) {
@@ -58,7 +60,8 @@ public class MemorySection implements ConfigurationSection {
         if (obj instanceof String) {
             try {
                 return Long.parseLong((String) obj);
-            } catch (final Exception e) {}
+            } catch (NumberFormatException ignored) {
+            }
         } else if (obj instanceof List) {
             final List<?> val = ((List<?>) obj);
             if (val.size() > 0) {
@@ -119,7 +122,7 @@ public class MemorySection implements ConfigurationSection {
     
     @Override
     public Set<String> getKeys(final boolean deep) {
-        final Set<String> result = new LinkedHashSet<String>();
+        final Set<String> result = new LinkedHashSet<>();
         
         final Configuration root = getRoot();
         if ((root != null) && root.options().copyDefaults()) {
@@ -137,7 +140,7 @@ public class MemorySection implements ConfigurationSection {
     
     @Override
     public Map<String, Object> getValues(final boolean deep) {
-        final Map<String, Object> result = new LinkedHashMap<String, Object>();
+        final Map<String, Object> result = new LinkedHashMap<>();
         
         final Configuration root = getRoot();
         if ((root != null) && root.options().copyDefaults()) {
@@ -462,10 +465,10 @@ public class MemorySection implements ConfigurationSection {
         final List<?> list = getList(path);
         
         if (list == null) {
-            return new ArrayList<String>(0);
+            return new ArrayList<>(0);
         }
         
-        final List<String> result = new ArrayList<String>();
+        final List<String> result = new ArrayList<>();
         
         for (final Object object : list) {
             if ((object instanceof String) || (isPrimitiveWrapper(object))) {
@@ -481,10 +484,10 @@ public class MemorySection implements ConfigurationSection {
         final List<?> list = getList(path);
         
         if (list == null) {
-            return new ArrayList<Integer>(0);
+            return new ArrayList<>(0);
         }
         
-        final List<Integer> result = new ArrayList<Integer>();
+        final List<Integer> result = new ArrayList<>();
         
         for (final Object object : list) {
             if (object instanceof Integer) {
@@ -492,9 +495,10 @@ public class MemorySection implements ConfigurationSection {
             } else if (object instanceof String) {
                 try {
                     result.add(Integer.valueOf((String) object));
-                } catch (final Exception ex) {}
+                } catch (NumberFormatException ignored) {
+                }
             } else if (object instanceof Character) {
-                result.add((int) ((Character) object).charValue());
+                result.add((int) (Character) object);
             } else if (object instanceof Number) {
                 result.add(((Number) object).intValue());
             }
@@ -508,10 +512,10 @@ public class MemorySection implements ConfigurationSection {
         final List<?> list = getList(path);
         
         if (list == null) {
-            return new ArrayList<Boolean>(0);
+            return new ArrayList<>(0);
         }
         
-        final List<Boolean> result = new ArrayList<Boolean>();
+        final List<Boolean> result = new ArrayList<>();
         
         for (final Object object : list) {
             if (object instanceof Boolean) {
@@ -533,10 +537,10 @@ public class MemorySection implements ConfigurationSection {
         final List<?> list = getList(path);
         
         if (list == null) {
-            return new ArrayList<Double>(0);
+            return new ArrayList<>(0);
         }
         
-        final List<Double> result = new ArrayList<Double>();
+        final List<Double> result = new ArrayList<>();
         
         for (final Object object : list) {
             if (object instanceof Double) {
@@ -544,9 +548,10 @@ public class MemorySection implements ConfigurationSection {
             } else if (object instanceof String) {
                 try {
                     result.add(Double.valueOf((String) object));
-                } catch (final Exception ex) {}
+                } catch (NumberFormatException ignored) {
+                }
             } else if (object instanceof Character) {
-                result.add((double) ((Character) object).charValue());
+                result.add((double) (Character) object);
             } else if (object instanceof Number) {
                 result.add(((Number) object).doubleValue());
             }
@@ -560,10 +565,10 @@ public class MemorySection implements ConfigurationSection {
         final List<?> list = getList(path);
         
         if (list == null) {
-            return new ArrayList<Float>(0);
+            return new ArrayList<>(0);
         }
         
-        final List<Float> result = new ArrayList<Float>();
+        final List<Float> result = new ArrayList<>();
         
         for (final Object object : list) {
             if (object instanceof Float) {
@@ -571,9 +576,10 @@ public class MemorySection implements ConfigurationSection {
             } else if (object instanceof String) {
                 try {
                     result.add(Float.valueOf((String) object));
-                } catch (final Exception ex) {}
+                } catch (NumberFormatException ignored) {
+                }
             } else if (object instanceof Character) {
-                result.add((float) ((Character) object).charValue());
+                result.add((float) (Character) object);
             } else if (object instanceof Number) {
                 result.add(((Number) object).floatValue());
             }
@@ -587,10 +593,10 @@ public class MemorySection implements ConfigurationSection {
         final List<?> list = getList(path);
         
         if (list == null) {
-            return new ArrayList<Long>(0);
+            return new ArrayList<>(0);
         }
         
-        final List<Long> result = new ArrayList<Long>();
+        final List<Long> result = new ArrayList<>();
         
         for (final Object object : list) {
             if (object instanceof Long) {
@@ -598,9 +604,10 @@ public class MemorySection implements ConfigurationSection {
             } else if (object instanceof String) {
                 try {
                     result.add(Long.valueOf((String) object));
-                } catch (final Exception ex) {}
+                } catch (NumberFormatException ignored) {
+                }
             } else if (object instanceof Character) {
-                result.add((long) ((Character) object).charValue());
+                result.add((long) (Character) object);
             } else if (object instanceof Number) {
                 result.add(((Number) object).longValue());
             }
@@ -614,10 +621,10 @@ public class MemorySection implements ConfigurationSection {
         final List<?> list = getList(path);
         
         if (list == null) {
-            return new ArrayList<Byte>(0);
+            return new ArrayList<>(0);
         }
         
-        final List<Byte> result = new ArrayList<Byte>();
+        final List<Byte> result = new ArrayList<>();
         
         for (final Object object : list) {
             if (object instanceof Byte) {
@@ -625,7 +632,8 @@ public class MemorySection implements ConfigurationSection {
             } else if (object instanceof String) {
                 try {
                     result.add(Byte.valueOf((String) object));
-                } catch (final Exception ex) {}
+                } catch (NumberFormatException ignored) {
+                }
             } else if (object instanceof Character) {
                 result.add((byte) ((Character) object).charValue());
             } else if (object instanceof Number) {
@@ -641,10 +649,10 @@ public class MemorySection implements ConfigurationSection {
         final List<?> list = getList(path);
         
         if (list == null) {
-            return new ArrayList<Character>(0);
+            return new ArrayList<>(0);
         }
         
-        final List<Character> result = new ArrayList<Character>();
+        final List<Character> result = new ArrayList<>();
         
         for (final Object object : list) {
             if (object instanceof Character) {
@@ -668,10 +676,10 @@ public class MemorySection implements ConfigurationSection {
         final List<?> list = getList(path);
         
         if (list == null) {
-            return new ArrayList<Short>(0);
+            return new ArrayList<>(0);
         }
         
-        final List<Short> result = new ArrayList<Short>();
+        final List<Short> result = new ArrayList<>();
         
         for (final Object object : list) {
             if (object instanceof Short) {
@@ -679,7 +687,8 @@ public class MemorySection implements ConfigurationSection {
             } else if (object instanceof String) {
                 try {
                     result.add(Short.valueOf((String) object));
-                } catch (final Exception ex) {}
+                } catch (NumberFormatException ignored) {
+                }
             } else if (object instanceof Character) {
                 result.add((short) ((Character) object).charValue());
             } else if (object instanceof Number) {
@@ -693,7 +702,7 @@ public class MemorySection implements ConfigurationSection {
     @Override
     public List<Map<?, ?>> getMapList(final String path) {
         final List<?> list = getList(path);
-        final List<Map<?, ?>> result = new ArrayList<Map<?, ?>>();
+        final List<Map<?, ?>> result = new ArrayList<>();
         
         if (list == null) {
             return result;
@@ -827,16 +836,14 @@ public class MemorySection implements ConfigurationSection {
         final char separator = root.options().pathSeparator();
         
         final StringBuilder builder = new StringBuilder();
-        if (section != null) {
-            for (ConfigurationSection parent = section; (parent != null) && (parent != relativeTo); parent = parent.getParent()) {
-                if (builder.length() > 0) {
-                    builder.insert(0, separator);
-                }
-                
-                builder.insert(0, parent.getName());
+        for (ConfigurationSection parent = section; (parent != null) && (parent != relativeTo); parent = parent.getParent()) {
+            if (builder.length() > 0) {
+                builder.insert(0, separator);
             }
+
+            builder.insert(0, parent.getName());
         }
-        
+
         if ((key != null) && (key.length() > 0)) {
             if (builder.length() > 0) {
                 builder.append(separator);
@@ -851,7 +858,7 @@ public class MemorySection implements ConfigurationSection {
     @Override
     public String toString() {
         final Configuration root = getRoot();
-        return new StringBuilder().append(getClass().getSimpleName()).append("[path='").append(getCurrentPath()).append("', root='").append(root == null ? null : root.getClass().getSimpleName())
-        .append("']").toString();
+        return getClass().getSimpleName() + "[path='" + getCurrentPath() + "', root='" + (root == null ? null : root.getClass().getSimpleName()) +
+                "']";
     }
 }

--- a/src/main/java/com/intellectualcrafters/configuration/file/FileConfiguration.java
+++ b/src/main/java/com/intellectualcrafters/configuration/file/FileConfiguration.java
@@ -1,5 +1,10 @@
 package com.intellectualcrafters.configuration.file;
 
+import com.intellectualcrafters.configuration.Configuration;
+import com.intellectualcrafters.configuration.InvalidConfigurationException;
+import com.intellectualcrafters.configuration.MemoryConfiguration;
+import org.yaml.snakeyaml.external.biz.base64Coder.Base64Coder;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -13,12 +18,6 @@ import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-
-import org.yaml.snakeyaml.external.biz.base64Coder.Base64Coder;
-
-import com.intellectualcrafters.configuration.Configuration;
-import com.intellectualcrafters.configuration.InvalidConfigurationException;
-import com.intellectualcrafters.configuration.MemoryConfiguration;
 
 /**
  * This is a base class for all File based implementations of {@link
@@ -99,13 +98,10 @@ public abstract class FileConfiguration extends MemoryConfiguration {
         file.getParentFile().mkdirs();
         
         final String data = saveToString();
-        
-        final Writer writer = new OutputStreamWriter(new FileOutputStream(file), UTF8_OVERRIDE && !UTF_BIG ? StandardCharsets.UTF_8 : Charset.defaultCharset());
-        
-        try {
+
+        try (Writer writer = new OutputStreamWriter(new FileOutputStream(file),
+                UTF8_OVERRIDE && !UTF_BIG ? StandardCharsets.UTF_8 : Charset.defaultCharset())) {
             writer.write(data);
-        } finally {
-            writer.close();
         }
     }
     
@@ -212,19 +208,16 @@ public abstract class FileConfiguration extends MemoryConfiguration {
      * @throws IllegalArgumentException thrown when reader is null
      */
     public void load(final Reader reader) throws IOException, InvalidConfigurationException {
-        final BufferedReader input = reader instanceof BufferedReader ? (BufferedReader) reader : new BufferedReader(reader);
-        
+
         final StringBuilder builder = new StringBuilder();
-        
-        try {
+
+        try (BufferedReader input = reader instanceof BufferedReader ? (BufferedReader) reader : new BufferedReader(reader)) {
             String line;
-            
+
             while ((line = input.readLine()) != null) {
                 builder.append(line);
                 builder.append('\n');
             }
-        } finally {
-            input.close();
         }
         
         loadFromString(builder.toString());

--- a/src/main/java/com/intellectualcrafters/plot/PS.java
+++ b/src/main/java/com/intellectualcrafters/plot/PS.java
@@ -1,34 +1,5 @@
 package com.intellectualcrafters.plot;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.URL;
-import java.net.URLConnection;
-import java.nio.file.Files;
-import java.sql.Connection;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Pattern;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
-
 import com.intellectualcrafters.configuration.ConfigurationSection;
 import com.intellectualcrafters.configuration.file.YamlConfiguration;
 import com.intellectualcrafters.plot.commands.MainCommand;
@@ -79,6 +50,34 @@ import com.intellectualcrafters.plot.util.TaskManager;
 import com.intellectualcrafters.plot.util.UUIDHandler;
 import com.plotsquared.listener.WESubscriber;
 import com.sk89q.worldedit.WorldEdit;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.Files;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 /**
  * An implementation of the core,
@@ -390,7 +389,7 @@ public class PS {
         if (!plots.containsKey(world)) {
             plots.put(world, new ConcurrentHashMap<PlotId, Plot>());
         }
-        plots.get(world).put(plot.id, plot);
+        plots.get(world).put(plot.getId(), plot);
         for (PlotPlayer pp : plot.getPlayersInPlot()) {
             pp.setMeta("lastplot", plot);
         }
@@ -633,7 +632,7 @@ public class PS {
         }
         hardmax = Math.min(hardmax, max);
         final Plot[] cache = new Plot[hardmax + 1];
-        final List<Plot> overflow = new ArrayList<Plot>(overflowSize);
+        final List<Plot> overflow = new ArrayList<>(overflowSize);
         final ArrayList<Plot> extra = new ArrayList<>();
         for (final Plot plot : plots) {
             final int hash = MathMan.getPositiveId(plot.hashCode());
@@ -643,7 +642,7 @@ public class PS {
                 } else {
                     extra.add(plot);
                 }
-            } else if ((Math.abs(plot.id.x) > 15446) || (Math.abs(plot.id.y) > 15446)) {
+            } else if ((Math.abs(plot.getId().x) > 15446) || (Math.abs(plot.getId().y) > 15446)) {
                 extra.add(plot);
             } else {
                 overflow.add(plot);
@@ -651,15 +650,13 @@ public class PS {
         }
         final Plot[] overflowArray = overflow.toArray(new Plot[overflow.size()]);
         sortPlotsByHash(overflowArray);
-        final ArrayList<Plot> result = new ArrayList<Plot>(cache.length + overflowArray.length);
+        final ArrayList<Plot> result = new ArrayList<>(cache.length + overflowArray.length);
         for (final Plot plot : cache) {
             if (plot != null) {
                 result.add(plot);
             }
         }
-        for (final Plot plot : overflowArray) {
-            result.add(plot);
-        }
+        Collections.addAll(result, overflowArray);
         for (final Plot plot : extra) {
             result.add(plot);
         }
@@ -678,14 +675,13 @@ public class PS {
         if (input instanceof ArrayList<?>) {
             list = (List<Plot>) input;
         } else {
-            list = new ArrayList<Plot>(input);
+            list = new ArrayList<>(input);
         }
         long min = Integer.MAX_VALUE;
         long max = 0;
         final int size = list.size();
         final int limit = Math.min(1048576, size * 2);
-        for (int i = 0; i < size; i++) {
-            final Plot plot = list.get(i);
+        for (final Plot plot : list) {
             final long time = plot.getTimestamp();
             if (time < min) {
                 min = time;
@@ -701,8 +697,7 @@ public class PS {
             if ((range > limit) && (size > 1024)) {
                 plots = new Plot[limit];
                 final int factor = (int) ((range / limit));
-                for (int i = 0; i < size; i++) {
-                    Plot plot = list.get(i);
+                for (Plot plot : list) {
                     int index = (int) (plot.getTimestamp() - min) / factor;
                     if (index < 0) {
                         index = 0;
@@ -730,7 +725,7 @@ public class PS {
                     }
                 }
             } else if ((range < size) || (size < 1024)) {
-                final ArrayList<Plot> result = new ArrayList<Plot>(list);
+                final ArrayList<Plot> result = new ArrayList<>(list);
                 Collections.sort(result, new Comparator<Plot>() {
                     @Override
                     public int compare(final Plot a, final Plot b) {
@@ -745,8 +740,7 @@ public class PS {
                 return result;
             } else if (min != 0) {
                 plots = new Plot[(int) range];
-                for (int i = 0; i < size; i++) {
-                    Plot plot = list.get(i);
+                for (Plot plot : list) {
                     int index = (int) (plot.getTimestamp() - min);
                     if (index >= plots.length) {
                         overflow.add(plot);
@@ -772,8 +766,7 @@ public class PS {
                 }
             } else {
                 plots = new Plot[(int) range];
-                for (int i = 0; i < size; i++) {
-                    Plot plot = list.get(i);
+                for (Plot plot : list) {
                     int index = (int) (plot.getTimestamp());
                     if (index >= plots.length) {
                         overflow.add(plot);
@@ -824,7 +817,7 @@ public class PS {
             return result;
         } catch (final Exception e) {
             e.printStackTrace();
-            final ArrayList<Plot> result = new ArrayList<Plot>(list);
+            final ArrayList<Plot> result = new ArrayList<>(list);
             Collections.sort(result, new Comparator<Plot>() {
                 @Override
                 public int compare(final Plot a, final Plot b) {
@@ -848,10 +841,10 @@ public class PS {
     public void sortPlotsByHash(final Plot[] input) {
         final List<Plot>[] bucket = new ArrayList[32];
         for (int i = 0; i < bucket.length; i++) {
-            bucket[i] = new ArrayList<Plot>();
+            bucket[i] = new ArrayList<>();
         }
         boolean maxLength = false;
-        int tmp = -1, placement = 1;
+        int tmp, placement = 1;
         while (!maxLength) {
             maxLength = true;
             for (final Plot i : input) {
@@ -882,7 +875,7 @@ public class PS {
         final int SIZE = 100;
         final List<Plot>[] bucket = new ArrayList[SIZE];
         for (int i = 0; i < bucket.length; i++) {
-            bucket[i] = new ArrayList<Plot>();
+            bucket[i] = new ArrayList<>();
         }
         boolean maxLength = false;
         int tmp = -1, placement = 1;
@@ -907,7 +900,7 @@ public class PS {
     }
     
     public enum SortType {
-        CREATION_DATE, CREATION_DATE_TIMESTAMP, DISTANCE_FROM_ORIGIN;
+        CREATION_DATE, CREATION_DATE_TIMESTAMP, DISTANCE_FROM_ORIGIN
     }
     
     /**
@@ -921,7 +914,7 @@ public class PS {
         // group by world
         // sort each
         final HashMap<String, Collection<Plot>> map = new HashMap<>();
-        final ArrayList<String> worlds = new ArrayList<String>(getPlotWorlds());
+        final ArrayList<String> worlds = new ArrayList<>(getPlotWorlds());
         int totalSize = 0;
         for (final Entry<String, ConcurrentHashMap<PlotId, Plot>> entry : this.plots.entrySet()) {
             totalSize += entry.getValue().size();
@@ -955,7 +948,7 @@ public class PS {
                 return a.hashCode() - b.hashCode();
             }
         });
-        final ArrayList<Plot> toReturn = new ArrayList<Plot>(plots.size());
+        final ArrayList<Plot> toReturn = new ArrayList<>(plots.size());
         for (final String world : worlds) {
             switch (type) {
                 case CREATION_DATE:
@@ -1080,7 +1073,7 @@ public class PS {
     public HashMap<PlotId, Plot> getPlots(final String world) {
         final ConcurrentHashMap<PlotId, Plot> myplots = plots.get(world);
         if (myplots != null) {
-            if (world == lastWorld) {
+            if (world.equals(lastWorld)) {
                 return new HashMap<>(lastMap);
             }
             return new HashMap<>(myplots);
@@ -1097,7 +1090,7 @@ public class PS {
             return map.values();
         }
         catch (Throwable e) {e.printStackTrace();}
-        HashSet<Plot> toReturn = new HashSet<Plot>(map.entrySet().size());
+        HashSet<Plot> toReturn = new HashSet<>(map.entrySet().size());
         for (Entry<PlotId, Plot> entry : map.entrySet()) {
             toReturn.add(entry.getValue());
         }
@@ -1105,7 +1098,7 @@ public class PS {
     }
     
     public Plot getPlot(final String world, final PlotId id) {
-        if (world == lastWorld) {
+        if (world.equals(lastWorld)) {
             if (lastMap != null) {
                 return lastMap.get(id);
             }
@@ -1336,12 +1329,14 @@ public class PS {
                         }
                         case "f":
                         case "floor": {
-                            config.set(base + "plot.floor", new ArrayList<String>(Arrays.asList(StringMan.join(Configuration.BLOCKLIST.parseString(value), ",").split(","))));
+                            config.set(base + "plot.floor",
+                                    new ArrayList<>(Arrays.asList(StringMan.join(Configuration.BLOCKLIST.parseString(value), ",").split(","))));
                             break;
                         }
                         case "m":
                         case "main": {
-                            config.set(base + "plot.filling", new ArrayList<String>(Arrays.asList(StringMan.join(Configuration.BLOCKLIST.parseString(value), ",").split(","))));
+                            config.set(base + "plot.filling",
+                                    new ArrayList<>(Arrays.asList(StringMan.join(Configuration.BLOCKLIST.parseString(value), ",").split(","))));
                             break;
                         }
                         case "w":

--- a/src/main/java/com/intellectualcrafters/plot/api/PlotAPI.java
+++ b/src/main/java/com/intellectualcrafters/plot/api/PlotAPI.java
@@ -21,17 +21,6 @@
 
 package com.intellectualcrafters.plot.api;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Set;
-import java.util.UUID;
-
-import org.bukkit.Location;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.World;
-import org.bukkit.entity.Player;
-import org.bukkit.plugin.java.JavaPlugin;
-
 import com.intellectualcrafters.configuration.file.YamlConfiguration;
 import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.commands.MainCommand;
@@ -53,6 +42,16 @@ import com.intellectualcrafters.plot.util.UUIDHandler;
 import com.intellectualcrafters.plot.uuid.UUIDWrapper;
 import com.plotsquared.bukkit.util.BukkitSetBlockManager;
 import com.plotsquared.bukkit.util.BukkitUtil;
+import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * PlotSquared API
@@ -262,7 +261,7 @@ public class PlotAPI {
                 perms.add(c.s());
             }
         }
-        return perms.toArray(new String[0]);
+        return perms.toArray(new String[perms.size()]);
     }
     
     /**
@@ -376,7 +375,7 @@ public class PlotAPI {
      *
      * @param msg Message that should be sent to the console
      *
-     * @see MainUtil#sendConsoleMessage(String)
+     * @see MainUtil#sendConsoleMessage(C, String...)
      */
     public void sendConsoleMessage(final String msg) {
         PS.log(msg);;
@@ -553,9 +552,9 @@ public class PlotAPI {
      */
     public Location[] getLocations(final Plot p) {
         return new Location[] {
-        BukkitUtil.getLocation(MainUtil.getPlotBottomLocAbs(p.world, p.id).subtract(1, 0, 1)),
-        BukkitUtil.getLocation(MainUtil.getPlotTopLocAbs(p.world, p.id)),
-        BukkitUtil.getLocation(MainUtil.getPlotHome(p.world, p.id)) };
+        BukkitUtil.getLocation(MainUtil.getPlotBottomLocAbs(p.world, p.getId()).subtract(1, 0, 1)),
+        BukkitUtil.getLocation(MainUtil.getPlotTopLocAbs(p.world, p.getId())),
+        BukkitUtil.getLocation(MainUtil.getPlotHome(p.world, p.getId())) };
     }
     
     /**
@@ -569,7 +568,7 @@ public class PlotAPI {
      * @see Plot
      */
     public Location getHomeLocation(final Plot p) {
-        return BukkitUtil.getLocation(MainUtil.getPlotHome(p.world, p.id));
+        return BukkitUtil.getLocation(MainUtil.getPlotHome(p.world, p.getId()));
     }
     
     /**
@@ -583,7 +582,7 @@ public class PlotAPI {
      * @see Plot
      */
     public Location getBottomLocation(final Plot p) {
-        return BukkitUtil.getLocation(MainUtil.getPlotBottomLocAbs(p.world, p.id).subtract(1, 0, 1));
+        return BukkitUtil.getLocation(MainUtil.getPlotBottomLocAbs(p.world, p.getId()).subtract(1, 0, 1));
     }
     
     /**
@@ -597,7 +596,7 @@ public class PlotAPI {
      * @see Plot
      */
     public Location getTopLocation(final Plot p) {
-        return BukkitUtil.getLocation(MainUtil.getPlotTopLocAbs(p.world, p.id));
+        return BukkitUtil.getLocation(MainUtil.getPlotTopLocAbs(p.world, p.getId()));
     }
     
     /**

--- a/src/main/java/com/intellectualcrafters/plot/commands/Add.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Add.java
@@ -20,9 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.commands;
 
-import java.util.UUID;
-
-import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.C;
 import com.intellectualcrafters.plot.database.DBFunc;
 import com.intellectualcrafters.plot.object.Location;
@@ -34,6 +31,8 @@ import com.intellectualcrafters.plot.util.Permissions;
 import com.intellectualcrafters.plot.util.UUIDHandler;
 import com.plotsquared.general.commands.Argument;
 import com.plotsquared.general.commands.CommandDeclaration;
+
+import java.util.UUID;
 
 @CommandDeclaration(
 command = "add",
@@ -87,7 +86,7 @@ public class Add extends SubCommand {
         if (plot.removeTrusted(uuid)) {
             plot.addMember(uuid);
         } else {
-            if ((plot.getMembers().size() + plot.getTrusted().size()) >= PS.get().getPlotWorld(plot.world).MAX_PLOT_MEMBERS) {
+            if ((plot.getMembers().size() + plot.getTrusted().size()) >= plot.getWorld().MAX_PLOT_MEMBERS) {
                 MainUtil.sendMessage(plr, C.PLOT_MAX_MEMBERS);
                 return false;
             }

--- a/src/main/java/com/intellectualcrafters/plot/commands/Auto.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Auto.java
@@ -202,16 +202,12 @@ public class Auto extends SubCommand {
                 MainUtil.lastPlot.put(worldname, getNextPlot(getLastPlot(worldname), 1));
             }
         } else {
-            boolean lastPlot = true;
             while (!br) {
                 final PlotId start = getNextPlot(getLastPlot(worldname), 1);
                 // Checking if the current set of plots is a viable option.
                 MainUtil.lastPlot.put(worldname, start);
-                if (lastPlot) {}
                 if ((PS.get().getPlot(worldname, start) != null) && (PS.get().getPlot(worldname, start).owner != null)) {
                     continue;
-                } else {
-                    lastPlot = false;
                 }
                 final PlotId end = new PlotId((start.x + size_x) - 1, (start.y + size_z) - 1);
                 if (MainUtil.canClaim(plr, worldname, start, end)) {

--- a/src/main/java/com/intellectualcrafters/plot/commands/Buy.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Buy.java
@@ -20,8 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.commands;
 
-import java.util.Set;
-
 import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.C;
 import com.intellectualcrafters.plot.flag.Flag;
@@ -34,6 +32,8 @@ import com.intellectualcrafters.plot.util.EconHandler;
 import com.intellectualcrafters.plot.util.MainUtil;
 import com.intellectualcrafters.plot.util.UUIDHandler;
 import com.plotsquared.general.commands.CommandDeclaration;
+
+import java.util.Set;
 
 @CommandDeclaration(
 command = "buy",
@@ -97,7 +97,7 @@ public class Buy extends SubCommand {
             EconHandler.manager.depositMoney(UUIDHandler.getUUIDWrapper().getOfflinePlayer(plot.owner), price);
             final PlotPlayer owner = UUIDHandler.getPlayer(plot.owner);
             if (owner != null) {
-                sendMessage(plr, C.PLOT_SOLD, plot.id + "", plr.getName(), price + "");
+                sendMessage(plr, C.PLOT_SOLD, plot.getId() + "", plr.getName(), price + "");
             }
             FlagManager.removePlotFlag(plot, "price");
         }

--- a/src/main/java/com/intellectualcrafters/plot/commands/Claim.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Claim.java
@@ -64,11 +64,11 @@ public class Claim extends SubCommand {
                 MainUtil.teleportPlayer(player, loc, plot);
             }
             final String world = plot.world;
-            final PlotWorld plotworld = PS.get().getPlotWorld(world);
-            final Plot plot2 = PS.get().getPlot(world, plot.id);
+            final PlotWorld plotworld = plot.getWorld();
+            final Plot plot2 = PS.get().getPlot(world, plot.getId());
             if (plotworld.SCHEMATIC_ON_CLAIM) {
                 Schematic sch;
-                if (schematic.equals("")) {
+                if (schematic.isEmpty()) {
                     sch = SchematicHandler.manager.getSchematic(plotworld.SCHEMATIC_FILE);
                 } else {
                     sch = SchematicHandler.manager.getSchematic(schematic);
@@ -110,7 +110,7 @@ public class Claim extends SubCommand {
         if (!MainUtil.canClaim(plr, plot)) {
             return sendMessage(plr, C.PLOT_IS_CLAIMED);
         }
-        final PlotWorld world = PS.get().getPlotWorld(plot.world);
+        final PlotWorld world = plot.getWorld();
         if ((EconHandler.manager != null) && world.USE_ECONOMY) {
             final double cost = world.PLOT_PRICE;
             if (cost > 0d) {

--- a/src/main/java/com/intellectualcrafters/plot/commands/Clear.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Clear.java
@@ -114,7 +114,7 @@ public class Clear extends SubCommand {
             }
         };
         if (Settings.CONFIRM_CLEAR && !(Permissions.hasPermission(plr, "plots.confirm.bypass"))) {
-            CmdConfirm.addPending(plr, "/plot clear " + plot.id, runnable);
+            CmdConfirm.addPending(plr, "/plot clear " + plot.getId(), runnable);
         } else {
             TaskManager.runTask(runnable);
         }

--- a/src/main/java/com/intellectualcrafters/plot/commands/Cluster.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Cluster.java
@@ -249,7 +249,7 @@ public class Cluster extends SubCommand {
                         return false;
                     }
                 }
-                final PlotWorld plotworld = PS.get().getPlotWorld(plr.getLocation().getWorld());
+                final PlotWorld plotworld = plr.getLocation().getPlotWorld();
                 if (plotworld.TYPE == 2) {
                     final ArrayList<Plot> toRemove = new ArrayList<>();
                     for (final Plot plot : PS.get().getPlotsInWorld(plr.getLocation().getWorld())) {

--- a/src/main/java/com/intellectualcrafters/plot/commands/Condense.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Condense.java
@@ -121,7 +121,7 @@ public class Condense extends SubCommand {
                 while ((start.x <= minimum_radius) && (start.y <= minimum_radius)) {
                     final Plot plot = MainUtil.getPlotAbs(worldname, start);
                     if (!plot.hasOwner()) {
-                        free.add(plot.id);
+                        free.add(plot.getId());
                     }
                     start = Auto.getNextPlot(start, 1);
                 }
@@ -225,8 +225,8 @@ public class Condense extends SubCommand {
     public Set<PlotId> getPlots(final Collection<Plot> plots, final int radius) {
         final HashSet<PlotId> outside = new HashSet<>();
         for (final Plot plot : plots) {
-            if ((plot.id.x > radius) || (plot.id.x < -radius) || (plot.id.y > radius) || (plot.id.y < -radius)) {
-                outside.add(plot.id);
+            if ((plot.getId().x > radius) || (plot.getId().x < -radius) || (plot.getId().y > radius) || (plot.getId().y < -radius)) {
+                outside.add(plot.getId());
             }
         }
         return outside;

--- a/src/main/java/com/intellectualcrafters/plot/commands/CreateRoadSchematic.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/CreateRoadSchematic.java
@@ -20,7 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.commands;
 
-import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.C;
 import com.intellectualcrafters.plot.generator.HybridPlotWorld;
 import com.intellectualcrafters.plot.generator.HybridUtils;
@@ -47,7 +46,7 @@ public class CreateRoadSchematic extends SubCommand {
         if (plot == null) {
             return sendMessage(player, C.NOT_IN_PLOT);
         }
-        if (!(PS.get().getPlotWorld(loc.getWorld()) instanceof HybridPlotWorld)) {
+        if (!(loc.getPlotWorld() instanceof HybridPlotWorld)) {
             return sendMessage(player, C.NOT_IN_PLOT_WORLD);
         }
         HybridUtils.manager.setupRoadSchematic(plot);

--- a/src/main/java/com/intellectualcrafters/plot/commands/Database.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Database.java
@@ -1,11 +1,5 @@
 package com.intellectualcrafters.plot.commands;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
-
 import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.database.DBFunc;
 import com.intellectualcrafters.plot.database.MySQL;
@@ -17,6 +11,12 @@ import com.intellectualcrafters.plot.object.PlotPlayer;
 import com.intellectualcrafters.plot.util.MainUtil;
 import com.intellectualcrafters.plot.util.TaskManager;
 import com.plotsquared.general.commands.CommandDeclaration;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 
 @CommandDeclaration(
 command = "database",
@@ -95,7 +95,7 @@ public class Database extends SubCommand {
                     for (final Entry<String, ConcurrentHashMap<PlotId, Plot>> entry : map.entrySet()) {
                         for (final Entry<PlotId, Plot> entry2 : entry.getValue().entrySet()) {
                             final Plot plot = entry2.getValue();
-                            if (PS.get().getPlot(plot.world, plot.id) != null) {
+                            if (PS.get().getPlot(plot.world, plot.getId()) != null) {
                                 MainUtil.sendMessage(player, "Skipping duplicate plot: " + plot + " | id=" + plot.temp);
                                 continue;
                             }

--- a/src/main/java/com/intellectualcrafters/plot/commands/DebugClaimTest.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/DebugClaimTest.java
@@ -96,8 +96,8 @@ public class DebugClaimTest extends SubCommand {
         final ArrayList<Plot> plots = new ArrayList<>();
         for (final PlotId id : MainUtil.getPlotSelectionIds(min, max)) {
             final Plot plot = MainUtil.getPlotAbs(world, id);
-            if (PS.get().getPlot(world, plot.id) != null) {
-                MainUtil.sendMessage(plr, " - &cDB Already contains: " + plot.id);
+            if (PS.get().getPlot(world, plot.getId()) != null) {
+                MainUtil.sendMessage(plr, " - &cDB Already contains: " + plot.getId());
                 continue;
             }
             final Location loc = manager.getSignLoc(plotworld, plot);
@@ -125,11 +125,11 @@ public class DebugClaimTest extends SubCommand {
                         uuid = UUIDHandler.getUUID(line, null);
                     }
                     if (uuid != null) {
-                        MainUtil.sendMessage(plr, " - &aFound plot: " + plot.id + " : " + line);
+                        MainUtil.sendMessage(plr, " - &aFound plot: " + plot.getId() + " : " + line);
                         plot.owner = uuid;
                         plots.add(plot);
                     } else {
-                        MainUtil.sendMessage(plr, " - &cInvalid playername: " + plot.id + " : " + line);
+                        MainUtil.sendMessage(plr, " - &cInvalid playername: " + plot.getId() + " : " + line);
                     }
                 }
             }

--- a/src/main/java/com/intellectualcrafters/plot/commands/DebugExec.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/DebugExec.java
@@ -20,26 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.commands;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.UUID;
-
-import javax.script.Bindings;
-import javax.script.ScriptContext;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
-import javax.script.ScriptException;
-import javax.script.SimpleScriptContext;
-
 import com.google.common.io.Files;
 import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.C;
@@ -73,6 +53,26 @@ import com.intellectualcrafters.plot.util.UUIDHandler;
 import com.plotsquared.bukkit.util.BukkitHybridUtils;
 import com.plotsquared.general.commands.Command;
 import com.plotsquared.general.commands.CommandDeclaration;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+import javax.script.SimpleScriptContext;
 
 @CommandDeclaration(command = "debugexec", permission = "plots.admin", description = "Mutli-purpose debug command", aliases = { "exec" }, category = CommandCategory.DEBUG)
 public class DebugExec extends SubCommand {
@@ -286,7 +286,7 @@ public class DebugExec extends SubCommand {
                         }
                         MainUtil.sendMessage(player, "Expired plots (" + ExpireManager.expiredPlots.get(args[1]).size() + "):");
                         for (final Plot plot : ExpireManager.expiredPlots.get(args[1])) {
-                            MainUtil.sendMessage(player, " - " + plot.world + ";" + plot.id.x + ";" + plot.id.y + ";" + UUIDHandler.getName(plot.owner) + " : " + ExpireManager.dates.get(plot.owner));
+                            MainUtil.sendMessage(player, " - " + plot.world + ";" + plot.getId().x + ";" + plot.getId().y + ";" + UUIDHandler.getName(plot.owner) + " : " + ExpireManager.dates.get(plot.owner));
                         }
                         return true;
                     }

--- a/src/main/java/com/intellectualcrafters/plot/commands/DebugRoadRegen.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/DebugRoadRegen.java
@@ -47,7 +47,7 @@ public class DebugRoadRegen extends SubCommand {
     public boolean onCommand(final PlotPlayer player, final String... args) {
         final Location loc = player.getLocation();
         final String world = loc.getWorld();
-        final PlotWorld plotworld = PS.get().getPlotWorld(world);
+        final PlotWorld plotworld = loc.getPlotWorld();
         if (!(plotworld instanceof HybridPlotWorld)) {
             return sendMessage(player, C.NOT_IN_PLOT_WORLD);
         }
@@ -66,14 +66,14 @@ public class DebugRoadRegen extends SubCommand {
                 }
             }
             final boolean result = HybridUtils.manager.regenerateRoad(world, chunk, extend);
-            MainUtil.sendMessage(player, "&6Regenerating chunk: " + chunk.x + "," + chunk.z + "\n&6 - Result: " + (result == true ? "&aSuccess" : "&cFailed"));
+            MainUtil.sendMessage(player, "&6Regenerating chunk: " + chunk.x + "," + chunk.z + "\n&6 - Result: " + (result ? "&aSuccess" : "&cFailed"));
             MainUtil.sendMessage(player, "&cTo regenerate all roads: /plot regenallroads");
         } else {
             final HybridPlotManager manager = (HybridPlotManager) PS.get().getPlotManager(world);
             manager.createRoadEast(plotworld, plot);
             manager.createRoadSouth(plotworld, plot);
             manager.createRoadSouthEast(plotworld, plot);
-            MainUtil.sendMessage(player, "&6Regenerating plot south/east roads: " + plot.id + "\n&6 - Result: &aSuccess");
+            MainUtil.sendMessage(player, "&6Regenerating plot south/east roads: " + plot.getId() + "\n&6 - Result: &aSuccess");
             MainUtil.sendMessage(player, "&cTo regenerate all roads: /plot regenallroads");
         }
         return true;

--- a/src/main/java/com/intellectualcrafters/plot/commands/Delete.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Delete.java
@@ -20,9 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.commands;
 
-import java.util.HashSet;
-
-import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.C;
 import com.intellectualcrafters.plot.config.Settings;
 import com.intellectualcrafters.plot.object.Location;
@@ -35,6 +32,8 @@ import com.intellectualcrafters.plot.util.MainUtil;
 import com.intellectualcrafters.plot.util.Permissions;
 import com.intellectualcrafters.plot.util.TaskManager;
 import com.plotsquared.general.commands.CommandDeclaration;
+
+import java.util.HashSet;
 
 @CommandDeclaration(
 command = "delete",
@@ -60,7 +59,7 @@ public class Delete extends SubCommand {
         if (!plot.isOwner(plr.getUUID()) && !Permissions.hasPermission(plr, "plots.admin.command.delete")) {
             return !sendMessage(plr, C.NO_PLOT_PERMS);
         }
-        final PlotWorld plotworld = PS.get().getPlotWorld(plot.world);
+        final PlotWorld plotworld = plot.getWorld();
         final HashSet<Plot> plots = MainUtil.getConnectedPlots(plot);
         final Runnable run = new Runnable() {
             @Override
@@ -93,7 +92,7 @@ public class Delete extends SubCommand {
             }
         };
         if (Settings.CONFIRM_DELETE && !(Permissions.hasPermission(plr, "plots.confirm.bypass"))) {
-            CmdConfirm.addPending(plr, "/plot delete " + plot.id, run);
+            CmdConfirm.addPending(plr, "/plot delete " + plot.getId(), run);
         } else {
             TaskManager.runTask(run);
         }

--- a/src/main/java/com/intellectualcrafters/plot/commands/Download.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Download.java
@@ -48,7 +48,7 @@ public class Download extends SubCommand {
         }
         plot.addRunning();
         MainUtil.sendMessage(plr, C.GENERATING_LINK);
-        SchematicHandler.manager.getCompoundTag(plot.world, plot.id, new RunnableVal<CompoundTag>() {
+        SchematicHandler.manager.getCompoundTag(plot.world, plot.getId(), new RunnableVal<CompoundTag>() {
             @Override
             public void run() {
                 TaskManager.runTaskAsync(new Runnable() {

--- a/src/main/java/com/intellectualcrafters/plot/commands/Info.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Info.java
@@ -94,17 +94,20 @@ public class Info extends SubCommand {
             };
             final UUID uuid = player.getUUID();
             final String name = MainUtil.getName(plot.owner);
-            inv.setItem(1, new PlotItemStack(388, (short) 0, 1, "&cPlot Info", new String[] {
-            "&cID: &6" + plot.getId().toString(),
-            "&cOwner: &6" + name,
-            "&cAlias: &6" + plot.getAlias(),
-            "&cBiome: &6" + plot.getBiome().toString().replaceAll("_", "").toLowerCase(),
-            "&cCan Build: &6" + plot.isAdded(uuid),
-            "&cIs Denied: &6" + plot.isDenied(uuid) }));
-            inv.setItem(1, new PlotItemStack(388, (short) 0, 1, "&cTrusted", new String[] { "&cAmount: &6" + plot.getTrusted().size(), "&8Click to view a list of the trusted users" }));
-            inv.setItem(1, new PlotItemStack(388, (short) 0, 1, "&cMembers", new String[] { "&cAmount: &6" + plot.getMembers().size(), "&8Click to view a list of plot members" }));
-            inv.setItem(1, new PlotItemStack(388, (short) 0, 1, "&cDenied", new String[] { "&cDenied", "&cAmount: &6" + plot.getDenied().size(), "&8Click to view a list of denied players" }));
-            inv.setItem(1, new PlotItemStack(388, (short) 0, 1, "&cFlags", new String[] { "&cFlags", "&cAmount: &6" + plot.getFlags().size(), "&8Click to view a list of plot flags" }));
+            inv.setItem(1, new PlotItemStack(388, (short) 0, 1, "&cPlot Info", "&cID: &6" + plot.getId().toString(),
+                    "&cOwner: &6" + name,
+                    "&cAlias: &6" + plot.getAlias(),
+                    "&cBiome: &6" + plot.getBiome().replaceAll("_", "").toLowerCase(),
+                    "&cCan Build: &6" + plot.isAdded(uuid),
+                    "&cIs Denied: &6" + plot.isDenied(uuid)));
+            inv.setItem(1, new PlotItemStack(388, (short) 0, 1, "&cTrusted", "&cAmount: &6" + plot.getTrusted().size(),
+                    "&8Click to view a list of the trusted users"));
+            inv.setItem(1, new PlotItemStack(388, (short) 0, 1, "&cMembers", "&cAmount: &6" + plot.getMembers().size(),
+                    "&8Click to view a list of plot members"));
+            inv.setItem(1, new PlotItemStack(388, (short) 0, 1, "&cDenied", "&cDenied", "&cAmount: &6" + plot.getDenied().size(),
+                    "&8Click to view a list of denied players"));
+            inv.setItem(1, new PlotItemStack(388, (short) 0, 1, "&cFlags", "&cFlags", "&cAmount: &6" + plot.getFlags().size(),
+                    "&8Click to view a list of plot flags"));
             inv.openInventory();
             return true;
         }
@@ -118,7 +121,7 @@ public class Info extends SubCommand {
         }
         // Unclaimed?
         if (!hasOwner && !containsEveryone && !trustedEveryone) {
-            MainUtil.sendMessage(player, C.PLOT_INFO_UNCLAIMED, (plot.id.x + ";" + plot.id.y));
+            MainUtil.sendMessage(player, C.PLOT_INFO_UNCLAIMED, (plot.getId().x + ";" + plot.getId().y));
             return true;
         }
         String info = C.PLOT_INFO.s();

--- a/src/main/java/com/intellectualcrafters/plot/commands/Kick.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Kick.java
@@ -40,7 +40,7 @@ public class Kick extends SubCommand {
         if (plot == null) {
             return !sendMessage(plr, C.NOT_IN_PLOT);
         }
-        if ((plot == null) || ((!plot.hasOwner() || !plot.isOwner(plr.getUUID())) && !Permissions.hasPermission(plr, "plots.admin.command.kick"))) {
+        if (((!plot.hasOwner() || !plot.isOwner(plr.getUUID())) && !Permissions.hasPermission(plr, "plots.admin.command.kick"))) {
             MainUtil.sendMessage(plr, C.NO_PLOT_PERMS);
             return false;
         }

--- a/src/main/java/com/intellectualcrafters/plot/commands/MainCommand.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/MainCommand.java
@@ -20,12 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.commands;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-
 import com.intellectualcrafters.plot.config.C;
 import com.intellectualcrafters.plot.config.Settings;
 import com.intellectualcrafters.plot.object.ConsolePlayer;
@@ -43,9 +37,17 @@ import com.plotsquared.general.commands.Command;
 import com.plotsquared.general.commands.CommandHandlingOutput;
 import com.plotsquared.general.commands.CommandManager;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+
 /**
  * PlotSquared command class
- *
+ *
+
  */
 public class MainCommand extends CommandManager<PlotPlayer> {
     
@@ -325,9 +327,7 @@ public class MainCommand extends CommandManager<PlotPlayer> {
                 count += 5;
             }
         }
-        for (String word : cmd.getDescription().split(" ")) {
-            desc.add(word);
-        }
+        Collections.addAll(desc, cmd.getDescription().split(" "));
         for (String arg : args) {
             if (perm.startsWith(arg)) {
                 count++;

--- a/src/main/java/com/intellectualcrafters/plot/commands/Merge.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Merge.java
@@ -20,10 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.commands;
 
-import java.util.HashSet;
-import java.util.UUID;
-
-import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.C;
 import com.intellectualcrafters.plot.config.Settings;
 import com.intellectualcrafters.plot.object.Location;
@@ -37,6 +33,9 @@ import com.intellectualcrafters.plot.util.Permissions;
 import com.intellectualcrafters.plot.util.StringMan;
 import com.intellectualcrafters.plot.util.UUIDHandler;
 import com.plotsquared.general.commands.CommandDeclaration;
+
+import java.util.HashSet;
+import java.util.UUID;
 
 @CommandDeclaration(
 command = "merge",
@@ -79,7 +78,7 @@ public class Merge extends SubCommand {
         if (plot == null) {
             return !sendMessage(plr, C.NOT_IN_PLOT);
         }
-        if ((plot == null) || !plot.hasOwner()) {
+        if (!plot.hasOwner()) {
             MainUtil.sendMessage(plr, C.PLOT_UNOWNED);
             return false;
         }
@@ -93,7 +92,7 @@ public class Merge extends SubCommand {
                 uuid = plot.owner;
             }
         }
-        final PlotWorld plotworld = PS.get().getPlotWorld(plot.world);
+        final PlotWorld plotworld = plot.getWorld();
         if ((EconHandler.manager != null) && plotworld.USE_ECONOMY && plotworld.MERGE_PRICE > 0d && EconHandler.manager.getMoney(plr) < plotworld.MERGE_PRICE) {
             sendMessage(plr, C.CANNOT_AFFORD_MERGE, plotworld.MERGE_PRICE + "");
             return false;
@@ -164,7 +163,7 @@ public class Merge extends SubCommand {
             MainUtil.sendMessage(plr, C.SUCCESS_MERGE);
             return true;
         }
-        Plot adjacent = MainUtil.getPlotAbs(plot.world, MainUtil.getPlotIdRelative(plot.id, direction));
+        Plot adjacent = MainUtil.getPlotAbs(plot.world, MainUtil.getPlotIdRelative(plot.getId(), direction));
         if (adjacent == null || !adjacent.hasOwner() || adjacent.getMerged((direction + 2) % 4) || adjacent.isOwner(uuid)) {
             MainUtil.sendMessage(plr, C.NO_AVAILABLE_AUTOMERGE);
             return false;
@@ -204,7 +203,7 @@ public class Merge extends SubCommand {
                 }
             });
         }
-        if (isOnline == false) {
+        if (!isOnline) {
             MainUtil.sendMessage(plr, C.NO_AVAILABLE_AUTOMERGE);
             return false;
         }

--- a/src/main/java/com/intellectualcrafters/plot/commands/Owner.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Owner.java
@@ -83,7 +83,7 @@ public class Owner extends SetCommand {
         MainUtil.setSign(name, plot);
         MainUtil.sendMessage(plr, C.SET_OWNER);
         if (other != null) {
-            MainUtil.sendMessage(other, C.NOW_OWNER, plot.world + ";" + plot.id);
+            MainUtil.sendMessage(other, C.NOW_OWNER, plot.world + ";" + plot.getId());
         }
         return true;
     }

--- a/src/main/java/com/intellectualcrafters/plot/commands/Purge.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Purge.java
@@ -116,7 +116,7 @@ public class Purge extends SubCommand {
                 if (plot.owner != null) {
                     final String name = UUIDHandler.getName(plot.owner);
                     if (name == null) {
-                        ids.add(plot.id);
+                        ids.add(plot.getId());
                     }
                 }
             }
@@ -132,7 +132,7 @@ public class Purge extends SubCommand {
             final Set<PlotId> ids = new HashSet<>();
             for (final Plot plot : plots) {
                 if (plot.owner == null) {
-                    ids.add(plot.id);
+                    ids.add(plot.getId());
                 }
             }
             final int length = ids.size();
@@ -147,7 +147,7 @@ public class Purge extends SubCommand {
             final Set<Plot> plots = PS.get().getPlots(worldname, uuid);
             final Set<PlotId> ids = new HashSet<>();
             for (final Plot plot : plots) {
-                ids.add(plot.id);
+                ids.add(plot.getId());
             }
             final int length = ids.size();
             DBFunc.purge(worldname, ids);

--- a/src/main/java/com/intellectualcrafters/plot/commands/Save.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Save.java
@@ -50,7 +50,7 @@ public class Save extends SubCommand {
             return false;
         }
         plot.addRunning();
-        SchematicHandler.manager.getCompoundTag(plot.world, plot.id, new RunnableVal<CompoundTag>() {
+        SchematicHandler.manager.getCompoundTag(plot.world, plot.getId(), new RunnableVal<CompoundTag>() {
             @Override
             public void run() {
                 TaskManager.runTaskAsync(new Runnable() {
@@ -60,7 +60,7 @@ public class Save extends SubCommand {
                         final String name = PS.get().IMP.getServerName().replaceAll("[^A-Za-z0-9]", "");
                         Location[] corners = MainUtil.getCorners(plot);
                         final int size = (corners[1].getX() - corners[0].getX()) + 1;
-                        final PlotId id = plot.id;
+                        final PlotId id = plot.getId();
                         final String world = plot.world.replaceAll("[^A-Za-z0-9]", "");
                         final String file = time + "_" + world + "_" + id.x + "_" + id.y + "_" + size + "_" + name;
                         final UUID uuid = plr.getUUID();

--- a/src/main/java/com/intellectualcrafters/plot/commands/Set.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Set.java
@@ -20,11 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.commands;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-
-import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.C;
 import com.intellectualcrafters.plot.config.Configuration;
 import com.intellectualcrafters.plot.flag.AbstractFlag;
@@ -42,6 +37,10 @@ import com.intellectualcrafters.plot.util.StringComparison;
 import com.intellectualcrafters.plot.util.StringMan;
 import com.plotsquared.general.commands.Command;
 import com.plotsquared.general.commands.CommandDeclaration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 
 @CommandDeclaration(
 command = "set",
@@ -67,10 +66,9 @@ public class Set extends SubCommand {
 
             @Override
             public boolean set(PlotPlayer plr, final Plot plot, String value) {
-                final String world = plr.getLocation().getWorld();
-                final PlotWorld plotworld = PS.get().getPlotWorld(world);
-                final PlotManager manager = PS.get().getPlotManager(world);
-                final String[] components = manager.getPlotComponents(plotworld, plot.id);
+                final PlotWorld plotworld = plr.getLocation().getPlotWorld();
+                final PlotManager manager = plr.getLocation().getPlotManager();
+                final String[] components = manager.getPlotComponents(plotworld, plot.getId());
                 final boolean allowUnsafe = DebugAllowUnsafe.unsafeAllowed.contains(plr.getUUID());
                 
                 String[] args = value.split(" ");
@@ -131,7 +129,7 @@ public class Set extends SubCommand {
                         }
                         plot.addRunning();
                         for (Plot current : MainUtil.getConnectedPlots(plot)) {
-                            manager.setComponent(plotworld, current.id, component, blocks);
+                            manager.setComponent(plotworld, current.getId(), component, blocks);
                         }
                         MainUtil.sendMessage(plr, C.GENERATING_COMPONENT);
                         SetBlockQueue.addNotify(new Runnable() {
@@ -149,11 +147,11 @@ public class Set extends SubCommand {
     }
 
     public boolean noArgs(PlotPlayer plr) {
-        final ArrayList<String> newValues = new ArrayList<String>();
+        final ArrayList<String> newValues = new ArrayList<>();
         newValues.addAll(Arrays.asList("biome", "alias", "home", "flag"));
         Plot plot = plr.getCurrentPlot();
         if (plot != null) {
-            newValues.addAll(Arrays.asList(plot.getManager().getPlotComponents(plot.getWorld(), plot.id)));
+            newValues.addAll(Arrays.asList(plot.getManager().getPlotComponents(plot.getWorld(), plot.getId())));
         }
         MainUtil.sendMessage(plr, C.SUBCOMMAND_SET_OPTIONS_HEADER.s() + StringMan.join(newValues, C.BLOCK_LIST_SEPARATER.formatted()));
         return false;
@@ -175,7 +173,7 @@ public class Set extends SubCommand {
             return false;
         }
         // components
-        HashSet<String> components = new HashSet<String>(Arrays.asList(plot.getManager().getPlotComponents(plot.getWorld(), plot.id)));
+        HashSet<String> components = new HashSet<>(Arrays.asList(plot.getManager().getPlotComponents(plot.getWorld(), plot.getId())));
         if (components.contains(args[0].toLowerCase())) {
             return component.onCommand(plr, Arrays.copyOfRange(args, 0, args.length));
         }

--- a/src/main/java/com/intellectualcrafters/plot/commands/Setup.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Setup.java
@@ -20,11 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.commands;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map.Entry;
-
 import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.C;
 import com.intellectualcrafters.plot.config.ConfigurationNode;
@@ -38,6 +33,11 @@ import com.intellectualcrafters.plot.util.SetupUtils;
 import com.intellectualcrafters.plot.util.StringMan;
 import com.plotsquared.general.commands.CommandDeclaration;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map.Entry;
+
 @CommandDeclaration(
 command = "setup",
 permission = "plots.admin.command.setup",
@@ -48,15 +48,15 @@ category = CommandCategory.ACTIONS)
 public class Setup extends SubCommand {
     
     public void displayGenerators(final PlotPlayer plr) {
-        final StringBuffer message = new StringBuffer();
+        final StringBuilder message = new StringBuilder();
         message.append("&6What generator do you want?");
         for (final Entry<String, PlotGenerator<?>> entry : SetupUtils.generators.entrySet()) {
             if (entry.getKey().equals("PlotSquared")) {
-                message.append("\n&8 - &2" + entry.getKey() + " (Default Generator)");
+                message.append("\n&8 - &2").append(entry.getKey()).append(" (Default Generator)");
             } else if (entry.getValue().isFull()) {
-                message.append("\n&8 - &7" + entry.getKey() + " (Plot Generator)");
+                message.append("\n&8 - &7").append(entry.getKey()).append(" (Plot Generator)");
             } else {
-                message.append("\n&8 - &7" + entry.getKey() + " (Unknown structure)");
+                message.append("\n&8 - &7").append(entry.getKey()).append(" (Unknown structure)");
             }
         }
         MainUtil.sendMessage(plr, message.toString());
@@ -109,8 +109,9 @@ public class Setup extends SubCommand {
                 break;
             }
             case 1: { // choose world type
-                final List<String> allTypes = Arrays.asList(new String[] { "default", "augmented", "partial" });
-                final List<String> allDesc = Arrays.asList(new String[] { "Standard plot generation", "Plot generation with vanilla terrain", "Vanilla with clusters of plots" });
+                final List<String> allTypes = Arrays.asList("default", "augmented", "partial");
+                final List<String> allDesc = Arrays.asList("Standard plot generation", "Plot generation with vanilla terrain",
+                        "Vanilla with clusters of plots");
                 final ArrayList<String> types = new ArrayList<>();
                 if (SetupUtils.generators.get(object.setupGenerator).isFull()) {
                     types.add("default");
@@ -170,7 +171,7 @@ public class Setup extends SubCommand {
                 break;
             }
             case 2: { // Choose terrain
-                final List<String> terrain = Arrays.asList(new String[] { "none", "ore", "road", "all" });
+                final List<String> terrain = Arrays.asList("none", "ore", "road", "all");
                 if ((args.length != 1) || !terrain.contains(args[0].toLowerCase())) {
                     MainUtil.sendMessage(plr, "&cYou must choose the terrain!"
                     + "\n&8 - &2NONE&8 - &7No terrain at all"

--- a/src/main/java/com/intellectualcrafters/plot/commands/Target.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Target.java
@@ -58,7 +58,7 @@ public class Target extends SubCommand {
                         closest = plot;
                     }
                 }
-                id = closest.id;
+                id = closest.getId();
             } else {
                 MainUtil.sendMessage(plr, C.NOT_VALID_PLOT_ID);
                 return false;

--- a/src/main/java/com/intellectualcrafters/plot/commands/Trim.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Trim.java
@@ -20,14 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.commands;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
-import java.util.HashSet;
-
 import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.C;
 import com.intellectualcrafters.plot.object.ChunkLoc;
@@ -41,6 +33,15 @@ import com.intellectualcrafters.plot.util.ChunkManager;
 import com.intellectualcrafters.plot.util.MainUtil;
 import com.intellectualcrafters.plot.util.TaskManager;
 import com.plotsquared.general.commands.CommandDeclaration;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.HashSet;
 
 @CommandDeclaration(
 command = "trim",
@@ -96,7 +97,8 @@ public class Trim extends SubCommand {
                                         PS.debug("INVALID MCA: " + name);
                                     }
                                 }
-                            } catch (final Exception e) {}
+                            } catch (IOException e) {
+                            }
                         }
                     }
                 }
@@ -134,8 +136,8 @@ public class Trim extends SubCommand {
                     }
                     final Plot plot = plots.remove(0);
                     
-                    final Location pos1 = MainUtil.getPlotBottomLocAbs(world, plot.id);
-                    final Location pos2 = MainUtil.getPlotTopLocAbs(world, plot.id);
+                    final Location pos1 = MainUtil.getPlotBottomLocAbs(world, plot.getId());
+                    final Location pos2 = MainUtil.getPlotTopLocAbs(world, plot.getId());
                     
                     final int ccx1 = (pos1.getX() >> 9);
                     final int ccz1 = (pos1.getZ() >> 9);

--- a/src/main/java/com/intellectualcrafters/plot/commands/Trust.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Trust.java
@@ -20,9 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.commands;
 
-import java.util.UUID;
-
-import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.C;
 import com.intellectualcrafters.plot.database.DBFunc;
 import com.intellectualcrafters.plot.object.Location;
@@ -35,6 +32,8 @@ import com.intellectualcrafters.plot.util.UUIDHandler;
 import com.plotsquared.bukkit.uuid.SQLUUIDHandler;
 import com.plotsquared.general.commands.Argument;
 import com.plotsquared.general.commands.CommandDeclaration;
+
+import java.util.UUID;
 
 @CommandDeclaration(
 command = "trust",
@@ -91,7 +90,7 @@ public class Trust extends SubCommand {
         if (plot.removeMember(uuid)) {
             plot.addTrusted(uuid);
         } else {
-            if ((plot.getMembers().size() + plot.getTrusted().size()) >= PS.get().getPlotWorld(plot.world).MAX_PLOT_MEMBERS) {
+            if ((plot.getMembers().size() + plot.getTrusted().size()) >= plot.getWorld().MAX_PLOT_MEMBERS) {
                 MainUtil.sendMessage(plr, C.PLOT_MAX_MEMBERS);
                 return false;
             }

--- a/src/main/java/com/intellectualcrafters/plot/commands/Unlink.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Unlink.java
@@ -62,7 +62,7 @@ public class Unlink extends SubCommand {
             }
         };
         if (Settings.CONFIRM_UNLINK && !(Permissions.hasPermission(plr, "plots.confirm.bypass"))) {
-            CmdConfirm.addPending(plr, "/plot unlink " + plot.id, runnable);
+            CmdConfirm.addPending(plr, "/plot unlink " + plot.getId(), runnable);
         } else {
             TaskManager.runTask(runnable);
         }

--- a/src/main/java/com/intellectualcrafters/plot/commands/Visit.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/Visit.java
@@ -20,14 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.commands;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.UUID;
-
 import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.C;
 import com.intellectualcrafters.plot.object.Plot;
@@ -38,6 +30,14 @@ import com.intellectualcrafters.plot.util.Permissions;
 import com.intellectualcrafters.plot.util.UUIDHandler;
 import com.plotsquared.general.commands.Argument;
 import com.plotsquared.general.commands.CommandDeclaration;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
 
 @CommandDeclaration(
 command = "visit",
@@ -93,7 +93,7 @@ public class Visit extends SubCommand {
                 } else {
                     final Plot plot = MainUtil.getPlotFromString(player, args[0], true);
                     if (plot != null) {
-                        unsorted = new HashSet<>(Arrays.asList(plot.getBasePlot(false)));
+                        unsorted = new HashSet<>(Collections.singletonList(plot.getBasePlot(false)));
                     }
                 }
                 break;

--- a/src/main/java/com/intellectualcrafters/plot/commands/WE_Anywhere.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/WE_Anywhere.java
@@ -36,7 +36,7 @@ public class WE_Anywhere extends SubCommand {
     
     @Override
     public boolean onCommand(final PlotPlayer player, final String[] arguments) {
-        return MainCommand.onCommand(player, "plot", new String[] { "toggle", "worldedit" });
+        return MainCommand.onCommand(player, "plot", "toggle", "worldedit");
     }
     
 }

--- a/src/main/java/com/intellectualcrafters/plot/commands/list.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/list.java
@@ -379,10 +379,12 @@ public class list extends SubCommand {
             
             final PlotMessage flags = new PlotMessage().text(C.color(C.PLOT_INFO_FLAGS.s().replaceAll("%flags%", strFlags))).color("$1");
             
-            PlotMessage message = new PlotMessage().text("[").color("$3").text(i + "").command("/plot visit " + plot.world + ";" + plot.id).tooltip("/plot visit " + plot.world + ";" + plot.id)
+            PlotMessage message = new PlotMessage().text("[").color("$3").text(i + "").command("/plot visit " + plot.world + ";" + plot.getId()).tooltip("/plot visit " + plot.world + ";" + plot
+
+                    .getId())
             .color("$1").text("]").color("$3").text(" " + plot.toString())
             
-            .tooltip(trusted, members, flags).command("/plot info " + plot.world + ";" + plot.id)
+            .tooltip(trusted, members, flags).command("/plot info " + plot.world + ";" + plot.getId())
             
             .color(color).text(" - ").color("$2");
             String prefix = "";

--- a/src/main/java/com/intellectualcrafters/plot/commands/plugin.java
+++ b/src/main/java/com/intellectualcrafters/plot/commands/plugin.java
@@ -32,9 +32,10 @@ public class plugin extends SubCommand {
     @Override
     public boolean onCommand(final PlotPlayer plr, final String[] args) {
         MainUtil.sendMessage(plr, String.format("$2>> $1&lPlotSquared $2($1Version$2: $1%s$2)", StringMan.join(PS.get().IMP.getPluginVersion(), ".")));
-        MainUtil.sendMessage(plr, String.format("$2>> $1&lAuthors$2: $1Citymonstret $2& $1Empire92"));
-        MainUtil.sendMessage(plr, String.format("$2>> $1&lWiki$2: $1https://github.com/IntellectualCrafters/PlotSquared/wiki"));
-        MainUtil.sendMessage(plr, String.format("$2>> $1&lNewest Version$2: $1" + (PS.get().update == null ? StringMan.join(PS.get().IMP.getPluginVersion(), ".") : PS.get().update)));
+        MainUtil.sendMessage(plr, "$2>> $1&lAuthors$2: $1Citymonstret $2& $1Empire92");
+        MainUtil.sendMessage(plr, "$2>> $1&lWiki$2: $1https://github.com/IntellectualCrafters/PlotSquared/wiki");
+        MainUtil.sendMessage(plr,
+                "$2>> $1&lNewest Version$2: $1" + (PS.get().update == null ? StringMan.join(PS.get().IMP.getPluginVersion(), ".") : PS.get().update));
         return true;
     }
 }

--- a/src/main/java/com/intellectualcrafters/plot/flag/FlagManager.java
+++ b/src/main/java/com/intellectualcrafters/plot/flag/FlagManager.java
@@ -20,13 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.flag;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.C;
 import com.intellectualcrafters.plot.database.DBFunc;
@@ -38,6 +31,13 @@ import com.intellectualcrafters.plot.object.PlotWorld;
 import com.intellectualcrafters.plot.util.EventUtil;
 import com.intellectualcrafters.plot.util.MainUtil;
 import com.intellectualcrafters.plot.util.Permissions;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Flag Manager Utility
@@ -415,8 +415,7 @@ public class FlagManager {
      */
     public static AbstractFlag getFlag(final String string, final boolean create) {
         if ((getFlag(string) == null) && create) {
-            final AbstractFlag flag = new AbstractFlag(string);
-            return flag;
+            return new AbstractFlag(string);
         }
         return getFlag(string);
     }
@@ -433,7 +432,7 @@ public class FlagManager {
     }
     
     public static HashMap<String, Flag> parseFlags(final List<String> flagstrings) {
-        final HashMap<String, Flag> map = new HashMap<String, Flag>();
+        final HashMap<String, Flag> map = new HashMap<>();
         for (final String key : flagstrings) {
             final String[] split;
             if (key.contains(";")) {

--- a/src/main/java/com/intellectualcrafters/plot/generator/ClassicPlotManager.java
+++ b/src/main/java/com/intellectualcrafters/plot/generator/ClassicPlotManager.java
@@ -1,7 +1,5 @@
 package com.intellectualcrafters.plot.generator;
 
-import java.util.ArrayList;
-
 import com.intellectualcrafters.plot.object.Location;
 import com.intellectualcrafters.plot.object.Plot;
 import com.intellectualcrafters.plot.object.PlotBlock;
@@ -11,6 +9,8 @@ import com.intellectualcrafters.plot.object.PseudoRandom;
 import com.intellectualcrafters.plot.object.RegionWrapper;
 import com.intellectualcrafters.plot.util.MainUtil;
 import com.intellectualcrafters.plot.util.SetBlockQueue;
+
+import java.util.ArrayList;
 
 /**
  * A plot manager with square plots which tesselate on a square grid with the following sections: ROAD, WALL, BORDER (wall), PLOT, FLOOR (plot)
@@ -58,9 +58,9 @@ public class ClassicPlotManager extends SquarePlotManager {
     @Override
     public boolean unclaimPlot(final PlotWorld plotworld, final Plot plot, final Runnable whenDone) {
         final ClassicPlotWorld dpw = ((ClassicPlotWorld) plotworld);
-        setWallFilling(dpw, plot.id, new PlotBlock[] { dpw.WALL_FILLING });
+        setWallFilling(dpw, plot.getId(), new PlotBlock[] { dpw.WALL_FILLING });
         if ((dpw.WALL_BLOCK.id != 0) || !dpw.WALL_BLOCK.equals(dpw.CLAIMED_WALL_BLOCK)) {
-            setWall(dpw, plot.id, new PlotBlock[] { dpw.WALL_BLOCK });
+            setWall(dpw, plot.getId(), new PlotBlock[] { dpw.WALL_BLOCK });
         }
         SetBlockQueue.addNotify(whenDone);
         return true;
@@ -84,7 +84,6 @@ public class ClassicPlotManager extends SquarePlotManager {
         if (!plot.isBasePlot()) {
             return false;
         }
-        final ClassicPlotWorld dpw = (ClassicPlotWorld) plotworld;
         for (RegionWrapper region : MainUtil.getRegions(plot)) {
             Location pos1 = new Location(plot.world, region.minX, 1, region.minZ);
             Location pos2 = new Location(plot.world, region.maxX, 255, region.maxZ);
@@ -271,8 +270,8 @@ public class ClassicPlotManager extends SquarePlotManager {
     @Override
     public boolean createRoadEast(final PlotWorld plotworld, final Plot plot) {
         final ClassicPlotWorld dpw = (ClassicPlotWorld) plotworld;
-        final Location pos1 = getPlotBottomLocAbs(plotworld, plot.id);
-        final Location pos2 = getPlotTopLocAbs(plotworld, plot.id);
+        final Location pos1 = getPlotBottomLocAbs(plotworld, plot.getId());
+        final Location pos2 = getPlotTopLocAbs(plotworld, plot.getId());
         final int sx = pos2.getX() + 1;
         final int ex = (sx + dpw.ROAD_WIDTH) - 1;
         final int sz = pos1.getZ() - 2;
@@ -293,8 +292,8 @@ public class ClassicPlotManager extends SquarePlotManager {
     @Override
     public boolean createRoadSouth(final PlotWorld plotworld, final Plot plot) {
         final ClassicPlotWorld dpw = (ClassicPlotWorld) plotworld;
-        final Location pos1 = getPlotBottomLocAbs(plotworld, plot.id);
-        final Location pos2 = getPlotTopLocAbs(plotworld, plot.id);
+        final Location pos1 = getPlotBottomLocAbs(plotworld, plot.getId());
+        final Location pos2 = getPlotTopLocAbs(plotworld, plot.getId());
         final int sz = pos2.getZ() + 1;
         final int ez = (sz + dpw.ROAD_WIDTH) - 1;
         final int sx = pos1.getX() - 2;
@@ -314,7 +313,7 @@ public class ClassicPlotManager extends SquarePlotManager {
     @Override
     public boolean createRoadSouthEast(final PlotWorld plotworld, final Plot plot) {
         final ClassicPlotWorld dpw = (ClassicPlotWorld) plotworld;
-        final Location pos2 = getPlotTopLocAbs(plotworld, plot.id);
+        final Location pos2 = getPlotTopLocAbs(plotworld, plot.getId());
         final int sx = pos2.getX() + 1;
         final int ex = (sx + dpw.ROAD_WIDTH) - 1;
         final int sz = pos2.getZ() + 1;
@@ -329,8 +328,8 @@ public class ClassicPlotManager extends SquarePlotManager {
     @Override
     public boolean removeRoadEast(final PlotWorld plotworld, final Plot plot) {
         final ClassicPlotWorld dpw = (ClassicPlotWorld) plotworld;
-        final Location pos1 = getPlotBottomLocAbs(plotworld, plot.id);
-        final Location pos2 = getPlotTopLocAbs(plotworld, plot.id);
+        final Location pos1 = getPlotBottomLocAbs(plotworld, plot.getId());
+        final Location pos2 = getPlotTopLocAbs(plotworld, plot.getId());
         final int sx = pos2.getX() + 1;
         final int ex = (sx + dpw.ROAD_WIDTH) - 1;
         final int sz = pos1.getZ() - 1;
@@ -344,8 +343,8 @@ public class ClassicPlotManager extends SquarePlotManager {
     @Override
     public boolean removeRoadSouth(final PlotWorld plotworld, final Plot plot) {
         final ClassicPlotWorld dpw = (ClassicPlotWorld) plotworld;
-        final Location pos1 = getPlotBottomLocAbs(plotworld, plot.id);
-        final Location pos2 = getPlotTopLocAbs(plotworld, plot.id);
+        final Location pos1 = getPlotBottomLocAbs(plotworld, plot.getId());
+        final Location pos2 = getPlotTopLocAbs(plotworld, plot.getId());
         final int sz = pos2.getZ() + 1;
         final int ez = (sz + dpw.ROAD_WIDTH) - 1;
         final int sx = pos1.getX() - 1;
@@ -359,7 +358,7 @@ public class ClassicPlotManager extends SquarePlotManager {
     @Override
     public boolean removeRoadSouthEast(final PlotWorld plotworld, final Plot plot) {
         final ClassicPlotWorld dpw = (ClassicPlotWorld) plotworld;
-        final Location loc = getPlotTopLocAbs(dpw, plot.id);
+        final Location loc = getPlotTopLocAbs(dpw, plot.getId());
         final int sx = loc.getX() + 1;
         final int ex = (sx + dpw.ROAD_WIDTH) - 1;
         final int sz = loc.getZ() + 1;
@@ -412,7 +411,7 @@ public class ClassicPlotManager extends SquarePlotManager {
         final PlotBlock unclaim = ((ClassicPlotWorld) plotworld).WALL_BLOCK;
         final PlotBlock claim = ((ClassicPlotWorld) plotworld).CLAIMED_WALL_BLOCK;
         if ((claim.id != 0) || !claim.equals(unclaim)) {
-            setWall(plotworld, plot.id, new PlotBlock[] { claim });
+            setWall(plotworld, plot.getId(), new PlotBlock[] { claim });
         }
         return true;
     }

--- a/src/main/java/com/intellectualcrafters/plot/generator/HybridPlotManager.java
+++ b/src/main/java/com/intellectualcrafters/plot/generator/HybridPlotManager.java
@@ -20,13 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.generator;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-
 import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.commands.Template;
 import com.intellectualcrafters.plot.object.ChunkLoc;
@@ -43,11 +36,19 @@ import com.intellectualcrafters.plot.util.ChunkManager;
 import com.intellectualcrafters.plot.util.MainUtil;
 import com.intellectualcrafters.plot.util.SetBlockQueue;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+
 public class HybridPlotManager extends ClassicPlotManager {
     
     @Override
     public void exportTemplate(final PlotWorld plotworld) throws IOException {
-        final HashSet<FileBytes> files = new HashSet<>(Arrays.asList(new FileBytes("templates/" + "tmp-data.yml", Template.getBytes(plotworld))));
+        final HashSet<FileBytes> files = new HashSet<>(
+                Collections.singletonList(new FileBytes("templates/" + "tmp-data.yml", Template.getBytes(plotworld))));
         final String psRoot = PS.get().IMP.getDirectory() + File.separator;
         final String dir = "schematics" + File.separator + "GEN_ROAD_SCHEMATIC" + File.separator + plotworld.worldname + File.separator;
         final String newDir = "schematics" + File.separator + "GEN_ROAD_SCHEMATIC" + File.separator + "__TEMP_DIR__" + File.separator;
@@ -77,7 +78,7 @@ public class HybridPlotManager extends ClassicPlotManager {
         if (!hpw.ROAD_SCHEMATIC_ENABLED) {
             return true;
         }
-        final PlotId id = plot.id;
+        final PlotId id = plot.getId();
         final PlotId id2 = new PlotId(id.x + 1, id.y);
         final Location bot = getPlotBottomLocAbs(hpw, id2);
         final Location top = getPlotTopLocAbs(hpw, id);
@@ -133,7 +134,7 @@ public class HybridPlotManager extends ClassicPlotManager {
         if (!hpw.ROAD_SCHEMATIC_ENABLED) {
             return true;
         }
-        final PlotId id = plot.id;
+        final PlotId id = plot.getId();
         final PlotId id2 = new PlotId(id.x, id.y + 1);
         final Location bot = getPlotBottomLocAbs(hpw, id2);
         final Location top = getPlotTopLocAbs(hpw, id);
@@ -150,7 +151,7 @@ public class HybridPlotManager extends ClassicPlotManager {
         if (!hpw.ROAD_SCHEMATIC_ENABLED) {
             return true;
         }
-        final PlotId id = plot.id;
+        final PlotId id = plot.getId();
         final PlotId id2 = new PlotId(id.x + 1, id.y + 1);
         final Location pos1 = getPlotTopLocAbs(hpw, id).add(1, 0, 1);
         final Location pos2 = getPlotBottomLocAbs(hpw, id2);
@@ -171,7 +172,7 @@ public class HybridPlotManager extends ClassicPlotManager {
         final String world = plotworld.worldname;
         final HybridPlotWorld dpw = ((HybridPlotWorld) plotworld);
         
-        final Location pos1 = MainUtil.getPlotBottomLocAbs(world, plot.id);
+        final Location pos1 = MainUtil.getPlotBottomLocAbs(world, plot.getId());
         final Location pos2 = MainUtil.getPlotTopLoc_(plot);
         // If augmented
         final boolean canRegen = (plotworld.TYPE == 0) && (plotworld.TERRAIN == 0);

--- a/src/main/java/com/intellectualcrafters/plot/generator/SquarePlotManager.java
+++ b/src/main/java/com/intellectualcrafters/plot/generator/SquarePlotManager.java
@@ -1,8 +1,5 @@
 package com.intellectualcrafters.plot.generator;
 
-import java.util.HashSet;
-import java.util.Iterator;
-
 import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.object.Location;
 import com.intellectualcrafters.plot.object.Plot;
@@ -11,6 +8,10 @@ import com.intellectualcrafters.plot.object.PlotWorld;
 import com.intellectualcrafters.plot.object.RegionWrapper;
 import com.intellectualcrafters.plot.util.ChunkManager;
 import com.intellectualcrafters.plot.util.MainUtil;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
 
 /**
  * A plot manager with a square grid layout, with square shaped plots
@@ -169,7 +170,7 @@ public abstract class SquarePlotManager extends GridPlotManager {
                     // northwest
                     return plot.getMerged(7) ? id : null;
             }
-            PS.debug("invalid location: " + merged);
+            PS.debug("invalid location: " + Arrays.toString(merged));
         } catch (Exception e) {
             PS.debug("Invalid plot / road width in settings.yml for world: " + plotworld.worldname);
         }

--- a/src/main/java/com/intellectualcrafters/plot/object/Plot.java
+++ b/src/main/java/com/intellectualcrafters/plot/object/Plot.java
@@ -20,17 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.object;
 
-import java.io.File;
-import java.net.URL;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-
 import com.intellectualcrafters.jnbt.CompoundTag;
 import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.Configuration;
@@ -46,6 +35,17 @@ import com.intellectualcrafters.plot.util.MainUtil;
 import com.intellectualcrafters.plot.util.SchematicHandler;
 import com.intellectualcrafters.plot.util.StringMan;
 import com.intellectualcrafters.plot.util.TaskManager;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The plot class
@@ -384,7 +384,7 @@ public class Plot {
      * @return boolean false if the player is allowed to enter
      */
     public boolean isDenied(final UUID uuid) {
-        return (getDenied() != null) && ((denied.contains(DBFunc.everyone) && !isAdded(uuid)) || (!isAdded(uuid) && denied.contains(uuid)));
+        return (getDenied() != null) && ((getDenied().contains(DBFunc.everyone) && !isAdded(uuid)) || (!isAdded(uuid) && getDenied().contains(uuid)));
     }
     
     /**
@@ -462,11 +462,11 @@ public class Plot {
             return origin;
         }
         origin = this;
-        PlotId min = id;
+        PlotId min = getId();
         for (Plot plot : MainUtil.getConnectedPlots(this)) {
-            if (plot.id.y < min.y || (plot.id.y == min.y && plot.id.x < min.x)) {
+            if (plot.getId().y < min.y || (plot.getId().y.equals(min.y) && plot.getId().x < min.x)) {
                 origin = plot;
-                min = plot.id;
+                min = plot.getId();
             }
         }
         for (Plot plot : MainUtil.getConnectedPlots(this)) {
@@ -529,13 +529,13 @@ public class Plot {
             case 7:
                 int i = direction - 4;
                 int i2 = 0;
-                return settings.getMerged(i2) && settings.getMerged(i) && MainUtil.getPlotAbs(world, MainUtil.getPlotIdRelative(id, i)).getMerged(i2) && settings.getMerged(i) && settings.getMerged(i2) && MainUtil.getPlotAbs(world, MainUtil.getPlotIdRelative(id, i2)).getMerged(i);
+                return settings.getMerged(i2) && settings.getMerged(i) && MainUtil.getPlotAbs(world, MainUtil.getPlotIdRelative(getId(), i)).getMerged(i2) && settings.getMerged(i) && settings.getMerged(i2) && MainUtil.getPlotAbs(world, MainUtil.getPlotIdRelative(getId(), i2)).getMerged(i);
             case 4:
             case 5:
             case 6:
                 i = direction - 4;
                 i2 = direction - 3;
-                return settings.getMerged(i2) && settings.getMerged(i) && MainUtil.getPlotAbs(world, MainUtil.getPlotIdRelative(id, i)).getMerged(i2) && settings.getMerged(i) && settings.getMerged(i2) && MainUtil.getPlotAbs(world, MainUtil.getPlotIdRelative(id, i2)).getMerged(i);
+                return settings.getMerged(i2) && settings.getMerged(i) && MainUtil.getPlotAbs(world, MainUtil.getPlotIdRelative(getId(), i)).getMerged(i2) && settings.getMerged(i) && settings.getMerged(i2) && MainUtil.getPlotAbs(world, MainUtil.getPlotIdRelative(getId(), i2)).getMerged(i);
                 
         }
         return false;
@@ -930,7 +930,7 @@ public class Plot {
      * @return
      */
     public Location getTopAbs() {
-        return MainUtil.getPlotTopLocAbs(world, id);
+        return MainUtil.getPlotTopLocAbs(world, getId());
     }
     
     /**
@@ -938,7 +938,7 @@ public class Plot {
      * @return
      */
     public Location getBottomAbs() {
-        return MainUtil.getPlotBottomLocAbs(world, id);
+        return MainUtil.getPlotBottomLocAbs(world, getId());
     }
     
     /**
@@ -1109,7 +1109,7 @@ public class Plot {
      * @return
      */
     public void export(final RunnableVal<Boolean> whenDone) {
-        SchematicHandler.manager.getCompoundTag(world, id, new RunnableVal<CompoundTag>() {
+        SchematicHandler.manager.getCompoundTag(world, getId(), new RunnableVal<CompoundTag>() {
             @Override
             public void run() {
                 if (value == null) {
@@ -1121,7 +1121,7 @@ public class Plot {
                     TaskManager.runTaskAsync(new Runnable() {
                         @Override
                         public void run() {
-                            final String name = id + "," + world + "," + MainUtil.getName(owner);
+                            final String name = getId() + "," + world + "," + MainUtil.getName(owner);
                             final boolean result = SchematicHandler.manager.save(value, Settings.SCHEMATIC_SAVE_PATH + File.separator + name + ".schematic");
                             if (whenDone != null) {
                                 whenDone.value = result;
@@ -1154,7 +1154,7 @@ public class Plot {
      * @param whenDone value will be null if uploading fails
      */
     public void upload(final RunnableVal<URL> whenDone) {
-        SchematicHandler.manager.getCompoundTag(world, id, new RunnableVal<CompoundTag>() {
+        SchematicHandler.manager.getCompoundTag(world, getId(), new RunnableVal<CompoundTag>() {
             @Override
             public void run() {
                 TaskManager.runTaskAsync(new Runnable() {
@@ -1186,7 +1186,7 @@ public class Plot {
         if (hashCode() != other.hashCode()) {
             return false;
         }
-        return ((id.x.equals(other.id.x)) && (id.y.equals(other.id.y)) && (StringMan.isEqual(world, other.world)));
+        return ((getId().x.equals(other.getId().x)) && (getId().y.equals(other.getId().y)) && (StringMan.isEqual(world, other.world)));
     }
     
     /**
@@ -1196,7 +1196,7 @@ public class Plot {
      */
     @Override
     public int hashCode() {
-        return id.hashCode();
+        return getId().hashCode();
     }
 
     /**
@@ -1238,7 +1238,7 @@ public class Plot {
      * @param merged
      */
     public void setMerged(boolean[] merged) {
-        getSettings().merged = merged;
+        getSettings().setMerged(merged);
         DBFunc.setMerged(this, merged);
         MainUtil.connected_cache = null;
         MainUtil.regions_cache = null;
@@ -1266,7 +1266,7 @@ public class Plot {
             if (value) {
                 Plot other = MainUtil.getPlotRelative(this, direction).getBasePlot(false);
                 if (!other.equals(getBasePlot(false))) {
-                    Plot base = ((other.id.y < id.y) || ((other.id.y == id.y) && (other.id.x < id.x))) ? other : origin;
+                    Plot base = ((other.getId().y < getId().y) || ((other.getId().y.equals(getId().y)) && (other.getId().x < getId().x))) ? other : origin;
                     origin.origin = base;
                     other.origin = base;
                     origin = base;

--- a/src/main/java/com/intellectualcrafters/plot/object/PlotHandler.java
+++ b/src/main/java/com/intellectualcrafters/plot/object/PlotHandler.java
@@ -1,6 +1,7 @@
 package com.intellectualcrafters.plot.object;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -28,7 +29,7 @@ public class PlotHandler {
             }
             return owners;
         }
-        return new HashSet<>(Arrays.asList(plot.owner));
+        return new HashSet<>(Collections.singletonList(plot.owner));
     }
     
     public static boolean isOwner(final Plot plot, final UUID uuid) {
@@ -237,7 +238,7 @@ public class PlotHandler {
             return false;
         }
         for (Plot current : MainUtil.getConnectedPlots(plot)) {
-            PS.get().removePlot(current.world, current.id, true);
+            PS.get().removePlot(current.world, current.getId(), true);
             DBFunc.delete(current);
             current.settings = null;
         }

--- a/src/main/java/com/intellectualcrafters/plot/object/PlotManager.java
+++ b/src/main/java/com/intellectualcrafters/plot/object/PlotManager.java
@@ -20,12 +20,12 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.object;
 
+import com.intellectualcrafters.plot.commands.Template;
+
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
-
-import com.intellectualcrafters.plot.commands.Template;
 
 public abstract class PlotManager {
     /*
@@ -86,7 +86,8 @@ public abstract class PlotManager {
     public abstract boolean finishPlotUnlink(final PlotWorld plotworld, final ArrayList<PlotId> plotIds);
     
     public void exportTemplate(final PlotWorld plotworld) throws IOException {
-        final HashSet<FileBytes> files = new HashSet<>(Arrays.asList(new FileBytes("templates/" + "tmp-data.yml", Template.getBytes(plotworld))));
+        final HashSet<FileBytes> files = new HashSet<>(
+                Collections.singletonList(new FileBytes("templates/" + "tmp-data.yml", Template.getBytes(plotworld))));
         Template.zipAll(plotworld.worldname, files);
     }
     

--- a/src/main/java/com/intellectualcrafters/plot/object/PlotWorld.java
+++ b/src/main/java/com/intellectualcrafters/plot/object/PlotWorld.java
@@ -20,11 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.object;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
-
 import com.intellectualcrafters.configuration.ConfigurationSection;
 import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.Configuration;
@@ -35,6 +30,11 @@ import com.intellectualcrafters.plot.flag.FlagManager;
 import com.intellectualcrafters.plot.util.EconHandler;
 import com.intellectualcrafters.plot.util.PlotGamemode;
 import com.intellectualcrafters.plot.util.StringMan;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
 
 /**
  * @author Jesse Boyd
@@ -198,7 +198,7 @@ public abstract class PlotWorld {
         if ((flags == null) || (flags.size() == 0)) {
             flags = config.getStringList("flags");
             if ((flags == null) || (flags.size() == 0)) {
-                flags = new ArrayList<String>();
+                flags = new ArrayList<>();
                 final ConfigurationSection section = config.getConfigurationSection("flags");
                 final Set<String> keys = section.getKeys(false);
                 for (final String key : keys) {
@@ -233,7 +233,7 @@ public abstract class PlotWorld {
         options.put("natural_mob_spawning", PlotWorld.MOB_SPAWNING_DEFAULT);
         options.put("plot.auto_merge", PlotWorld.AUTO_MERGE_DEFAULT);
         options.put("plot.create_signs", PlotWorld.ALLOW_SIGNS_DEFAULT);
-        options.put("plot.biome", PlotWorld.PLOT_BIOME_DEFAULT.toString());
+        options.put("plot.biome", PlotWorld.PLOT_BIOME_DEFAULT);
         options.put("schematic.on_claim", PlotWorld.SCHEMATIC_ON_CLAIM_DEFAULT);
         options.put("schematic.file", PlotWorld.SCHEMATIC_FILE_DEFAULT);
         options.put("schematic.specify_on_claim", PlotWorld.SCHEMATIC_CLAIM_SPECIFY_DEFAULT);

--- a/src/main/java/com/intellectualcrafters/plot/util/BO3Handler.java
+++ b/src/main/java/com/intellectualcrafters/plot/util/BO3Handler.java
@@ -1,14 +1,5 @@
 package com.intellectualcrafters.plot.util;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.StandardOpenOption;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map.Entry;
-
 import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.Settings;
 import com.intellectualcrafters.plot.flag.FlagManager;
@@ -18,10 +9,18 @@ import com.intellectualcrafters.plot.object.ChunkLoc;
 import com.intellectualcrafters.plot.object.Location;
 import com.intellectualcrafters.plot.object.Plot;
 import com.intellectualcrafters.plot.object.PlotBlock;
-import com.intellectualcrafters.plot.object.PlotId;
 import com.intellectualcrafters.plot.object.PlotPlayer;
 import com.intellectualcrafters.plot.object.PlotWorld;
 import com.intellectualcrafters.plot.object.RegionWrapper;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map.Entry;
 
 public class BO3Handler {
     
@@ -51,7 +50,7 @@ public class BO3Handler {
      * @return
      */
     public static boolean saveBO3(final PlotPlayer plr, final Plot plot) {
-        final PlotWorld plotworld = PS.get().getPlotWorld(plot.world);
+        final PlotWorld plotworld = plot.getWorld();
         if (!(plotworld instanceof ClassicPlotWorld) || (plotworld.TYPE != 0)) {
             MainUtil.sendMessage(plr, "BO3 exporting only supports type 0 classic generation.");
             return false;

--- a/src/main/java/com/intellectualcrafters/plot/util/ClusterManager.java
+++ b/src/main/java/com/intellectualcrafters/plot/util/ClusterManager.java
@@ -148,7 +148,7 @@ public class ClusterManager {
     }
     
     public static PlotCluster getCluster(final Plot plot) {
-        return getCluster(plot.world, plot.id);
+        return getCluster(plot.world, plot.getId());
     }
     
     public static PlotCluster getClusterAbs(final Location loc) {
@@ -238,7 +238,7 @@ public class ClusterManager {
     public static PlotId estimatePlotId(final Location loc) {
         final Plot plot = MainUtil.getPlotAbs(loc);
         if (plot != null) {
-            return plot.id;
+            return plot.getId();
         }
         final PlotId a = new PlotId(0, 0);
         final PlotId b = new PlotId(1, 1);

--- a/src/main/java/com/intellectualcrafters/plot/util/ExpireManager.java
+++ b/src/main/java/com/intellectualcrafters/plot/util/ExpireManager.java
@@ -100,13 +100,13 @@ public class ExpireManager {
                         for (final UUID helper : plot.getTrusted()) {
                             final PlotPlayer player = UUIDHandler.getPlayer(helper);
                             if (player != null) {
-                                MainUtil.sendMessage(player, C.PLOT_REMOVED_USER, plot.id.toString());
+                                MainUtil.sendMessage(player, C.PLOT_REMOVED_USER, plot.getId().toString());
                             }
                         }
                         for (final UUID helper : plot.getMembers()) {
                             final PlotPlayer player = UUIDHandler.getPlayer(helper);
                             if (player != null) {
-                                MainUtil.sendMessage(player, C.PLOT_REMOVED_USER, plot.id.toString());
+                                MainUtil.sendMessage(player, C.PLOT_REMOVED_USER, plot.getId().toString());
                             }
                         }
                         final PlotManager manager = PS.get().getPlotManager(world);

--- a/src/main/java/com/intellectualcrafters/plot/util/HastebinUtility.java
+++ b/src/main/java/com/intellectualcrafters/plot/util/HastebinUtility.java
@@ -31,7 +31,7 @@ public class HastebinUtility {
         
         final BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
         String inputLine;
-        final StringBuffer response = new StringBuffer();
+        final StringBuilder response = new StringBuilder();
         
         while ((inputLine = in.readLine()) != null) {
             response.append(inputLine);

--- a/src/main/java/com/intellectualcrafters/plot/util/MainUtil.java
+++ b/src/main/java/com/intellectualcrafters/plot/util/MainUtil.java
@@ -20,23 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.intellectualcrafters.plot.util;
 
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.regex.Matcher;
-
 import com.google.common.collect.BiMap;
 import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.C;
@@ -60,6 +43,23 @@ import com.intellectualcrafters.plot.object.RegionWrapper;
 import com.intellectualcrafters.plot.object.RunnableVal;
 import com.intellectualcrafters.plot.object.StringWrapper;
 import com.plotsquared.listener.PlotListener;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
 
 /**
  * plot functions
@@ -152,9 +152,9 @@ public class MainUtil {
             return regions_cache;
         }
         if (!origin.isMerged()) {
-            final Location pos1 = MainUtil.getPlotBottomLocAbs(origin.world, origin.id);  
-            final Location pos2 = MainUtil.getPlotTopLocAbs(origin.world, origin.id);
-            connected_cache = new HashSet<>(Arrays.asList(origin));
+            final Location pos1 = MainUtil.getPlotBottomLocAbs(origin.world, origin.getId());
+            final Location pos2 = MainUtil.getPlotTopLocAbs(origin.world, origin.getId());
+            connected_cache = new HashSet<>(Collections.singletonList(origin));
             regions_cache = new HashSet<>(1);
             regions_cache.add(new RegionWrapper(pos1.getX(), pos2.getX(), pos1.getY(), pos2.getY(), pos1.getZ(), pos2.getZ()));
             return regions_cache;
@@ -164,20 +164,20 @@ public class MainUtil {
         HashSet<PlotId> visited = new HashSet<>();
         ArrayList<PlotId> ids;
         for (Plot current : plots) {
-            if (visited.contains(current.id)) {
+            if (visited.contains(current.getId())) {
                 continue;
             }
             boolean merge = true;
             boolean tmp = true;
-            PlotId bot = new PlotId(current.id.x, current.id.y);
-            PlotId top = new PlotId(current.id.x, current.id.y);
+            PlotId bot = new PlotId(current.getId().x, current.getId().y);
+            PlotId top = new PlotId(current.getId().x, current.getId().y);
             while (merge) {
                 merge = false;
                 ids = getPlotSelectionIds(new PlotId(bot.x, bot.y - 1), new PlotId(top.x, bot.y - 1));
                 tmp = true;
                 for (PlotId id : ids) {
                     Plot plot = MainUtil.getPlotAbs(origin.world, id);
-                    if (plot == null || !plot.getMerged(2) || (visited.contains(plot.id))) {
+                    if (plot == null || !plot.getMerged(2) || (visited.contains(plot.getId()))) {
                         tmp = false;
                     }
                 }
@@ -189,7 +189,7 @@ public class MainUtil {
                 tmp = true;
                 for (PlotId id : ids) {
                     Plot plot = MainUtil.getPlotAbs(origin.world, id);
-                    if (plot == null || !plot.getMerged(3) || (visited.contains(plot.id))) {
+                    if (plot == null || !plot.getMerged(3) || (visited.contains(plot.getId()))) {
                         tmp = false;
                     }
                 }
@@ -201,7 +201,7 @@ public class MainUtil {
                 tmp = true;
                 for (PlotId id : ids) {
                     Plot plot = MainUtil.getPlotAbs(origin.world, id);
-                    if (plot == null || !plot.getMerged(0) || (visited.contains(plot.id))) {
+                    if (plot == null || !plot.getMerged(0) || (visited.contains(plot.getId()))) {
                         tmp = false;
                     }
                 }
@@ -213,7 +213,7 @@ public class MainUtil {
                 tmp = true;
                 for (PlotId id : ids) {
                     Plot plot = MainUtil.getPlotAbs(origin.world, id);
-                    if (plot == null || !plot.getMerged(1) || (visited.contains(plot.id))) {
+                    if (plot == null || !plot.getMerged(1) || (visited.contains(plot.getId()))) {
                         tmp = false;
                     }
                 }
@@ -436,7 +436,7 @@ public class MainUtil {
                 }
             }
             if (id != null) {
-                if (plot.id.equals(id)) {
+                if (plot.getId().equals(id)) {
                     count++;
                 }
             }
@@ -568,7 +568,7 @@ public class MainUtil {
         ArrayList<PlotId> ids = new ArrayList<>(plots.size());
         for (Plot current : plots) {
             current.setHome(null);
-            ids.add(current.id);
+            ids.add(current.getId());
         }
         final boolean result = EventUtil.manager.callUnlink(plot.world, ids);
         if (!result) {
@@ -578,8 +578,8 @@ public class MainUtil {
         if (createSign) {
             plot.removeSign();
         }
-        final PlotManager manager = PS.get().getPlotManager(plot.world);
-        final PlotWorld plotworld = PS.get().getPlotWorld(plot.world);
+        final PlotManager manager = plot.getManager();
+        final PlotWorld plotworld = plot.getWorld();
         if (createRoad) {
             manager.startPlotUnlink(plotworld, ids);
         }
@@ -652,14 +652,14 @@ public class MainUtil {
     /**
      * Check if a plot is in a plot area.<br>
      *  - Useful as plot objects can be created with any location which may not be valid.
-     * @param location
+     * @param plot
      * @return
      */
     public static boolean isPlotArea(final Plot plot) {
         if (!Settings.ENABLE_CLUSTERS) {
             return true;
         }
-        final PlotWorld plotworld = PS.get().getPlotWorld(plot.world);
+        final PlotWorld plotworld = plot.getWorld();
         if (plotworld.TYPE == 2) {
             return plot.getCluster() != null;
         }
@@ -743,7 +743,7 @@ public class MainUtil {
      */
     public static Location getDefaultHome(Plot plot) {
         plot = plot.getBasePlot(false);
-        final PlotWorld plotworld = PS.get().getPlotWorld(plot.world);
+        final PlotWorld plotworld = plot.getWorld();
         if (plotworld.DEFAULT_HOME != null) {
             final int x;
             final int z;
@@ -765,8 +765,8 @@ public class MainUtil {
         RegionWrapper largest = getLargestRegion(plot);
         final int x = ((largest.maxX - largest.minX) / 2) + largest.minX;
         final int z = largest.minZ - 1;
-        final PlotManager manager = PS.get().getPlotManager(plot.world);
-        final int y = Math.max(getHeighestBlock(plot.world, x, z), manager.getSignLoc(PS.get().getPlotWorld(plot.world), plot).getY());
+        final PlotManager manager = plot.getManager();
+        final int y = Math.max(getHeighestBlock(plot.world, x, z), manager.getSignLoc(plot.getWorld(), plot).getY());
         return new Location(plot.world, x, y + 1, z);
     }
     
@@ -782,7 +782,7 @@ public class MainUtil {
         final boolean result = EventUtil.manager.callTeleport(player, from, plot);
         if (result) {
             final Location location;
-            if (PS.get().getPlotWorld(plot.world).HOME_ALLOW_NONMEMBER || plot.isAdded(player.getUUID())) {
+            if (plot.getWorld().HOME_ALLOW_NONMEMBER || plot.isAdded(player.getUUID())) {
                 location = MainUtil.getPlotHome(plot);
             } else {
                 location = getDefaultHome(plot);
@@ -855,7 +855,7 @@ public class MainUtil {
      * @param loc
      */
     public static void update(final String world, final ChunkLoc loc) {
-        BlockUpdateUtil.setBlockManager.update(world, Arrays.asList(loc));
+        BlockUpdateUtil.setBlockManager.update(world, Collections.singletonList(loc));
     }
     
     /**
@@ -910,7 +910,7 @@ public class MainUtil {
      * @return Plot relative
      */
     public static Plot getPlotRelative(final Plot plot, final int direction) {
-        return getPlotAbs(plot.world, getPlotIdRelative(plot.id, direction));
+        return getPlotAbs(plot.world, getPlotIdRelative(plot.getId(), direction));
     }
     
     /**
@@ -944,14 +944,14 @@ public class MainUtil {
                 for (final PlotId pid : MainUtil.getPlotSelectionIds(pos1, pos2)) {
                     final Plot plot = MainUtil.getPlotAbs(world, pid);
                     if (plot.hasOwner()) {
-                        if ((plot.id.x > pos1.x) || (plot.id.y > pos1.y) || (plot.id.x < pos2.x) || (plot.id.y < pos2.y)) {
+                        if ((plot.getId().x > pos1.x) || (plot.getId().y > pos1.y) || (plot.getId().x < pos2.x) || (plot.getId().y < pos2.y)) {
                             result.add(plot);
                         }
                     }
                 }
             } else {
                 for (final Plot plot : PS.get().getPlotsInWorld(world)) {
-                    if ((plot.id.x > pos1.x) || (plot.id.y > pos1.y) || (plot.id.x < pos2.x) || (plot.id.y < pos2.y)) {
+                    if ((plot.getId().x > pos1.x) || (plot.getId().y > pos1.y) || (plot.getId().x < pos2.x) || (plot.getId().y < pos2.y)) {
                         result.add(plot);
                     }
                 }
@@ -1051,7 +1051,7 @@ public class MainUtil {
             if (plotworld.TERRAIN == 3) {
                 return;
             }
-            final PlotId id = plot.id;
+            final PlotId id = plot.getId();
             final PlotId id2 = new PlotId(id.x + 1, id.y + 1);
             final Location pos1 = getPlotTopLocAbs(plot.world, id).add(1, 0, 1);
             final Location pos2 = getPlotBottomLocAbs(plot.world, id2).subtract(1, 0, 1);
@@ -1059,7 +1059,7 @@ public class MainUtil {
             pos2.setY(256);
             ChunkManager.manager.regenerateRegion(pos1, pos2, null);
         } else {
-            PS.get().getPlotManager(plot.world).removeRoadSouthEast(plotworld, plot);
+            plot.getManager().removeRoadSouthEast(plotworld, plot);
         }
     }
     
@@ -1074,7 +1074,7 @@ public class MainUtil {
             if (plotworld.TERRAIN == 3) {
                 return;
             }
-            final PlotId id = plot.id;
+            final PlotId id = plot.getId();
             final PlotId id2 = new PlotId(id.x + 1, id.y);
             final Location bot = getPlotBottomLocAbs(plot.world, id2);
             final Location top = getPlotTopLocAbs(plot.world, id);
@@ -1082,7 +1082,7 @@ public class MainUtil {
             final Location pos2 = new Location(plot.world, bot.getX(), 256, top.getZ());
             ChunkManager.manager.regenerateRegion(pos1, pos2, null);
         } else {
-            PS.get().getPlotManager(plot.world).removeRoadEast(plotworld, plot);
+            plot.getManager().removeRoadEast(plotworld, plot);
         }
     }
     
@@ -1097,7 +1097,7 @@ public class MainUtil {
             if (plotworld.TERRAIN == 3) {
                 return;
             }
-            final PlotId id = plot.id;
+            final PlotId id = plot.getId();
             final PlotId id2 = new PlotId(id.x, id.y + 1);
             final Location bot = getPlotBottomLocAbs(plot.world, id2);
             final Location top = getPlotTopLocAbs(plot.world, id);
@@ -1105,7 +1105,7 @@ public class MainUtil {
             final Location pos2 = new Location(plot.world, top.getX(), 256, bot.getZ());
             ChunkManager.manager.regenerateRegion(pos1, pos2, null);
         } else {
-            PS.get().getPlotManager(plot.world).removeRoadSouth(plotworld, plot);
+            plot.getManager().removeRoadSouth(plotworld, plot);
         }
     }
     
@@ -1118,8 +1118,8 @@ public class MainUtil {
      */
     public static void mergePlot(final String world, Plot lesserPlot, Plot greaterPlot, final boolean removeRoads) {
         final PlotWorld plotworld = PS.get().getPlotWorld(world);
-        if (lesserPlot.id.x.equals(greaterPlot.id.x)) {
-            if (lesserPlot.id.y > greaterPlot.id.y) {
+        if (lesserPlot.getId().x.equals(greaterPlot.getId().x)) {
+            if (lesserPlot.getId().y > greaterPlot.getId().y) {
                 Plot tmp = lesserPlot;
                 lesserPlot = greaterPlot;
                 greaterPlot = tmp;
@@ -1135,15 +1135,15 @@ public class MainUtil {
                         removeRoadSouthEast(plotworld, lesserPlot);
                     }
                     MainUtil.removeRoadSouth(plotworld, lesserPlot);
-                    Plot other = getPlotAbs(world, getPlotIdRelative(lesserPlot.id, 3));
+                    Plot other = getPlotAbs(world, getPlotIdRelative(lesserPlot.getId(), 3));
                     if (other.getMerged(2) && other.getMerged(1)) {
                         MainUtil.removeRoadSouthEast(plotworld, other);
-                        mergePlot(world, greaterPlot, getPlotAbs(world, getPlotIdRelative(greaterPlot.id, 3)), removeRoads);
+                        mergePlot(world, greaterPlot, getPlotAbs(world, getPlotIdRelative(greaterPlot.getId(), 3)), removeRoads);
                     }
                 }
             }
         } else {
-            if (lesserPlot.id.x > greaterPlot.id.x) {
+            if (lesserPlot.getId().x > greaterPlot.getId().x) {
                 Plot tmp = lesserPlot;
                 lesserPlot = greaterPlot;
                 greaterPlot = tmp;
@@ -1159,10 +1159,10 @@ public class MainUtil {
                     if (lesserPlot.getMerged(5)) {
                         removeRoadSouthEast(plotworld, lesserPlot);
                     }
-                    Plot other = getPlotAbs(world, getPlotIdRelative(lesserPlot.id, 0));
+                    Plot other = getPlotAbs(world, getPlotIdRelative(lesserPlot.getId(), 0));
                     if (other.getMerged(2) && other.getMerged(1)) {
                         MainUtil.removeRoadSouthEast(plotworld, other);
-                        mergePlot(world, greaterPlot, getPlotAbs(world, getPlotIdRelative(greaterPlot.id, 0)), removeRoads);
+                        mergePlot(world, greaterPlot, getPlotAbs(world, getPlotIdRelative(greaterPlot.getId(), 0)), removeRoads);
                     }
                 }
             }
@@ -1269,11 +1269,11 @@ public class MainUtil {
             return;
         }
         final String rename = name == null ? "unknown" : name;
-        final PlotManager manager = PS.get().getPlotManager(p.world);
-        final PlotWorld plotworld = PS.get().getPlotWorld(p.world);
+        final PlotManager manager = p.getManager();
+        final PlotWorld plotworld = p.getWorld();
         if (plotworld.ALLOW_SIGNS) {
             final Location loc = manager.getSignLoc(plotworld, p);
-            final String id = p.id.x + ";" + p.id.y;
+            final String id = p.getId().x + ";" + p.getId().y;
             final String[] lines = new String[] {
             C.OWNER_SIGN_LINE_1.formatted().replaceAll("%id%", id),
             C.OWNER_SIGN_LINE_2.formatted().replaceAll("%id%", id).replaceAll("%plr%", rename),
@@ -1314,7 +1314,7 @@ public class MainUtil {
      * Get the corner locations for a list of regions<br>
      * @see Plot#getCorners() 
      * @param world
-     * @param region
+     * @param regions
      * @return
      */
     public static Location[] getCorners(String world, Collection<RegionWrapper> regions) {
@@ -1353,22 +1353,22 @@ public class MainUtil {
      */
     public static PlotId[] getCornerIds(Plot plot) {
         if (!plot.isMerged()) {
-            return new PlotId[] { plot.id, plot.id };
+            return new PlotId[] { plot.getId(), plot.getId() };
         }
-        PlotId min = new PlotId(plot.id.x, plot.id.y);
-        PlotId max = new PlotId(plot.id.x, plot.id.y);
+        PlotId min = new PlotId(plot.getId().x, plot.getId().y);
+        PlotId max = new PlotId(plot.getId().x, plot.getId().y);
         for (Plot current : getConnectedPlots(plot)) {
-            if (current.id.x < min.x) {
-                min.x = current.id.x;
+            if (current.getId().x < min.x) {
+                min.x = current.getId().x;
             }
-            else if (current.id.x > max.x) {
-                max.x = current.id.x;
+            else if (current.getId().x > max.x) {
+                max.x = current.getId().x;
             }
-            if (current.id.y < min.y) {
-                min.y = current.id.y;
+            if (current.getId().y < min.y) {
+                min.y = current.getId().y;
             }
-            else if (current.id.y > max.y) {
-                max.y = current.id.y;
+            else if (current.getId().y > max.y) {
+                max.y = current.getId().y;
             }
         }
         return new PlotId[] { min, max };
@@ -1398,7 +1398,7 @@ public class MainUtil {
         HashSet<Plot> visited = new HashSet<>();
         HashSet<PlotId> merged = new HashSet<>();
         for (Plot current : getConnectedPlots(plot)) {
-            merged.add(current.id);
+            merged.add(current.getId());
         }
         ArrayDeque<Plot> frontier = new ArrayDeque<>(getConnectedPlots(plot));
         Plot current;
@@ -1413,8 +1413,8 @@ public class MainUtil {
                 Plot other = getPlotRelative(current, 0);
                 if (other.isOwner(uuid) && (other.getBasePlot(false).equals(current.getBasePlot(false)) || ((plots = other.getConnectedPlots()).size() <= max && frontier.addAll(plots) && (max -= plots.size()) != -1))) {
                     mergePlot(current.world, current, other, removeRoads);
-                    merged.add(current.id);
-                    merged.add(other.id);
+                    merged.add(current.getId());
+                    merged.add(other.getId());
                     toReturn = true;
                 }
             }
@@ -1422,8 +1422,8 @@ public class MainUtil {
                 Plot other = getPlotRelative(current, 1);
                 if (other.isOwner(uuid) && (other.getBasePlot(false).equals(current.getBasePlot(false)) || ((plots = other.getConnectedPlots()).size() <= max && frontier.addAll(plots) && (max -= plots.size()) != -1))) {
                     mergePlot(current.world, current, other, removeRoads);
-                    merged.add(current.id);
-                    merged.add(other.id);
+                    merged.add(current.getId());
+                    merged.add(other.getId());
                     toReturn = true;
                 }
             }
@@ -1431,8 +1431,8 @@ public class MainUtil {
                 Plot other = getPlotRelative(current, 2);
                 if (other.isOwner(uuid) && (other.getBasePlot(false).equals(current.getBasePlot(false)) || ((plots = other.getConnectedPlots()).size() <= max && frontier.addAll(plots) && (max -= plots.size()) != -1))) {
                     mergePlot(current.world, current, other, removeRoads);
-                    merged.add(current.id);
-                    merged.add(other.id);
+                    merged.add(current.getId());
+                    merged.add(other.getId());
                     toReturn = true;
                 }
             }
@@ -1440,14 +1440,14 @@ public class MainUtil {
                 Plot other = getPlotRelative(current, 3);
                 if (other.isOwner(uuid) && (other.getBasePlot(false).equals(current.getBasePlot(false)) || ((plots = other.getConnectedPlots()).size() <= max && frontier.addAll(plots) && (max -= plots.size()) != -1))) {
                     mergePlot(current.world, current, other, removeRoads);
-                    merged.add(current.id);
-                    merged.add(other.id);
+                    merged.add(current.getId());
+                    merged.add(other.getId());
                     toReturn = true;
                 }
             }
         }
         if (removeRoads && toReturn) {
-            PlotManager manager = PS.get().getPlotManager(plot.world);
+            PlotManager manager = plot.getManager();
             ArrayList<PlotId> ids = new ArrayList<>(merged);
             manager.finishPlotMerge(plot.getWorld(), ids);
         }
@@ -1465,7 +1465,7 @@ public class MainUtil {
         final String world = plot.world;
         final PlotManager manager = PS.get().getPlotManager(world);
         final PlotWorld plotworld = PS.get().getPlotWorld(world);
-        final PlotId id = new PlotId(Math.abs(plot.id.x) + 1, Math.abs(plot.id.x) + 1);
+        final PlotId id = new PlotId(Math.abs(plot.getId().x) + 1, Math.abs(plot.getId().x) + 1);
         final Location bot = manager.getPlotBottomLocAbs(plotworld, id);
         final Location top = manager.getPlotTopLocAbs(plotworld, id);
         final int border = worldBorder.get(plot.world);
@@ -1485,10 +1485,10 @@ public class MainUtil {
             updateWorldBorder(plot);
         }
         final String w = plot.world;
-        if (PS.get().getPlot(plot.world, plot.id) != null) {
+        if (PS.get().getPlot(plot.world, plot.getId()) != null) {
             return true;
         }
-        final Plot p = new Plot(w, plot.id, uuid);
+        final Plot p = new Plot(w, plot.getId(), uuid);
         if (p.owner == null) {
             return false;
         }
@@ -1496,7 +1496,7 @@ public class MainUtil {
         DBFunc.createPlotAndSettings(p, new Runnable() {
             @Override
             public void run() {
-                final PlotWorld plotworld = PS.get().getPlotWorld(plot.world);
+                final PlotWorld plotworld = plot.getWorld();
                 if (plotworld.AUTO_MERGE) {
                     autoMerge(p, -1, Integer.MAX_VALUE, uuid, true);
                 }
@@ -1510,11 +1510,11 @@ public class MainUtil {
      */
     public static Plot createPlotAbs(final UUID uuid, final Plot plot) {
         final String w = plot.world;
-        Plot p = PS.get().getPlot(plot.world, plot.id);
+        Plot p = PS.get().getPlot(plot.world, plot.getId());
         if (p != null) {
             return p;
         }
-        p = new Plot(w, plot.id, uuid);
+        p = new Plot(w, plot.getId(), uuid);
         if (p.owner == null) {
             return null;
         }
@@ -1598,7 +1598,7 @@ public class MainUtil {
      * @return
      */
     public static boolean clear(final Plot plot, final boolean isDelete, final Runnable whenDone) {
-        if (!EventUtil.manager.callClear(plot.world, plot.id)) {
+        if (!EventUtil.manager.callClear(plot.world, plot.getId())) {
             return false;
         }
         final HashSet<RegionWrapper> regions = getRegions(plot);
@@ -1608,8 +1608,8 @@ public class MainUtil {
             removeSign(plot);
         }
         MainUtil.unlinkPlot(plot, true, !isDelete);
-        final PlotManager manager = PS.get().getPlotManager(plot.world);
-        final PlotWorld plotworld = PS.get().getPlotWorld(plot.world);
+        final PlotManager manager = plot.getManager();
+        final PlotWorld plotworld = plot.getWorld();
         Runnable run = new Runnable() {
             @Override
             public void run() {
@@ -1864,7 +1864,7 @@ public class MainUtil {
      *
      */
     public static Location getPlotHome(final Plot plot) {
-        return getPlotHome(plot.world, plot.id);
+        return getPlotHome(plot.world, plot.getId());
     }
     
     /**
@@ -1905,17 +1905,17 @@ public class MainUtil {
      * @return Location top of mega plot
      */
     public static Location getPlotTopLoc_(Plot plot) {
-        Location top = getPlotTopLocAbs(plot.world, plot.id);
+        Location top = getPlotTopLocAbs(plot.world, plot.getId());
         if (!plot.isMerged()) {
             return top;
         }
         PlotId id;
         if (plot.getMerged(2)) {
-            id = getPlotIdRelative(plot.id, 2);
+            id = getPlotIdRelative(plot.getId(), 2);
             top.setZ(getPlotBottomLocAbs(plot.world, id).getZ() - 1);
         }
         if (plot.getMerged(1)) {
-            id = getPlotIdRelative(plot.id, 1);
+            id = getPlotIdRelative(plot.getId(), 1);
             top.setX(getPlotBottomLocAbs(plot.world, id).getX() - 1);
         }
         return top;
@@ -1931,17 +1931,17 @@ public class MainUtil {
      * @return Location bottom of mega plot
      */
     public static Location getPlotBottomLoc_(Plot plot) {
-        Location bot = getPlotBottomLocAbs(plot.world, plot.id);
+        Location bot = getPlotBottomLocAbs(plot.world, plot.getId());
         if (!plot.isMerged()) {
             return bot;
         }
         PlotId id;
         if (plot.getMerged(0)) {
-            id = getPlotIdRelative(plot.id, 0);
+            id = getPlotIdRelative(plot.getId(), 0);
             bot.setZ(getPlotTopLocAbs(plot.world, id).getZ() + 1);
         }
         if (plot.getMerged(3)) {
-            id = getPlotIdRelative(plot.id, 3);
+            id = getPlotIdRelative(plot.getId(), 3);
             bot.setX(getPlotTopLocAbs(plot.world, id).getX() + 1);
         }
         return bot;
@@ -2092,18 +2092,18 @@ public class MainUtil {
             return false;
         }
         // Swap cached
-        final PlotId temp = new PlotId(p1.id.x.intValue(), p1.id.y.intValue());
-        p1.id.x = p2.id.x.intValue();
-        p1.id.y = p2.id.y.intValue();
-        p2.id.x = temp.x;
-        p2.id.y = temp.y;
+        final PlotId temp = new PlotId(p1.getId().x, p1.getId().y);
+        p1.getId().x = p2.getId().x;
+        p1.getId().y = p2.getId().y;
+        p2.getId().x = temp.x;
+        p2.getId().y = temp.y;
         final Map<String, ConcurrentHashMap<PlotId, Plot>> raw = PS.get().getAllPlotsRaw();
-        raw.get(p1.world).remove(p1.id);
-        raw.get(p2.world).remove(p2.id);
-        p1.id.recalculateHash();
-        p2.id.recalculateHash();
-        raw.get(p1.world).put(p1.id, p1);
-        raw.get(p2.world).put(p2.id, p2);
+        raw.get(p1.world).remove(p1.getId());
+        raw.get(p2.world).remove(p2.getId());
+        p1.getId().recalculateHash();
+        p2.getId().recalculateHash();
+        raw.get(p1.world).put(p1.getId(), p1);
+        raw.get(p2.world).put(p2.getId(), p2);
         // Swap database
         DBFunc.dbManager.swapPlots(p2, p1);
         TaskManager.runTaskLater(whenDone, 1);
@@ -2129,11 +2129,11 @@ public class MainUtil {
             return false;
         }
         final Map<String, ConcurrentHashMap<PlotId, Plot>> raw = PS.get().getAllPlotsRaw();
-        raw.get(pos1.world).remove(pos1.id);
-        pos1.id.x = (int) pos2.id.x;
-        pos1.id.y = (int) pos2.id.y;
-        pos1.id.recalculateHash();
-        raw.get(pos2.world).put(pos1.id, pos1);
+        raw.get(pos1.world).remove(pos1.getId());
+        pos1.getId().x = (int) pos2.getId().x;
+        pos1.getId().y = (int) pos2.getId().y;
+        pos1.getId().recalculateHash();
+        raw.get(pos2.world).put(pos1.getId(), pos1);
         DBFunc.movePlot(pos1, pos2);
         TaskManager.runTaskLater(whenDone, 1);
         return true;
@@ -2148,7 +2148,7 @@ public class MainUtil {
      * @return
      */
     public static boolean move(final Plot origin, final Plot destination, final Runnable whenDone, boolean allowSwap) {
-        PlotId offset = new PlotId(destination.id.x - origin.id.x, destination.id.y - origin.id.y);
+        PlotId offset = new PlotId(destination.getId().x - origin.getId().x, destination.getId().y - origin.getId().y);
         Location db = destination.getBottomAbs();
         Location ob = origin.getBottomAbs();
         final int offsetX = db.getX() - ob.getX();
@@ -2160,7 +2160,7 @@ public class MainUtil {
         boolean occupied = false;
         HashSet<Plot> plots = MainUtil.getConnectedPlots(origin);
         for (Plot plot : plots) {
-            Plot other = MainUtil.getPlotAbs(destination.world, new PlotId(plot.id.x + offset.x, plot.id.y + offset.y));
+            Plot other = MainUtil.getPlotAbs(destination.world, new PlotId(plot.getId().x + offset.x, plot.getId().y + offset.y));
             if (other.owner != null) {
                 if (!allowSwap) {
                     TaskManager.runTaskLater(whenDone, 1);
@@ -2174,7 +2174,7 @@ public class MainUtil {
         final ArrayDeque<RegionWrapper> regions = new ArrayDeque<>(getRegions(origin));
         // move / swap data
         for (Plot plot : plots) {
-            Plot other = MainUtil.getPlotAbs(destination.world, new PlotId(plot.id.x + offset.x, plot.id.y + offset.y));
+            Plot other = MainUtil.getPlotAbs(destination.world, new PlotId(plot.getId().x + offset.x, plot.getId().y + offset.y));
             swapData(plot, other, null);
         }
         // copy terrain
@@ -2235,7 +2235,7 @@ public class MainUtil {
      * @return
      */
     public static boolean copy(final Plot origin, final Plot destination, final Runnable whenDone) {
-        PlotId offset = new PlotId(destination.id.x - origin.id.x, destination.id.y - origin.id.y);
+        PlotId offset = new PlotId(destination.getId().x - origin.getId().x, destination.getId().y - origin.getId().y);
         Location db = destination.getBottomAbs();
         Location ob = origin.getBottomAbs();
         final int offsetX = db.getX() - ob.getX();
@@ -2246,7 +2246,7 @@ public class MainUtil {
         }
         HashSet<Plot> plots = MainUtil.getConnectedPlots(origin);
         for (Plot plot : plots) {
-            Plot other = MainUtil.getPlotAbs(destination.world, new PlotId(plot.id.x + offset.x, plot.id.y + offset.y));
+            Plot other = MainUtil.getPlotAbs(destination.world, new PlotId(plot.getId().x + offset.x, plot.getId().y + offset.y));
             if (other.owner != null) {
                 TaskManager.runTaskLater(whenDone, 1);
                 return false;
@@ -2256,7 +2256,7 @@ public class MainUtil {
         updateWorldBorder(destination);
         // copy data
         for (Plot plot : plots) {
-            Plot other = MainUtil.getPlotAbs(destination.world , new PlotId(plot.id.x + offset.x, plot.id.y + offset.y));
+            Plot other = MainUtil.getPlotAbs(destination.world , new PlotId(plot.getId().x + offset.x, plot.getId().y + offset.y));
             other = createPlotAbs(plot.owner, other);
             if ((plot.getFlags() != null) && (plot.getFlags().size() > 0)) {
                 other.getSettings().flags = plot.getFlags();
@@ -2399,12 +2399,12 @@ public class MainUtil {
             return null;
         }
         if (plot.settings == null) {
-            return new HashSet<>(Arrays.asList(plot));
+            return new HashSet<>(Collections.singletonList(plot));
         }
         boolean[] merged = plot.getMerged();
         int hash = hash(merged);
         if (hash == 0) {
-            return new HashSet<>(Arrays.asList(plot));
+            return new HashSet<>(Collections.singletonList(plot));
         }
         if (connected_cache != null && connected_cache.contains(plot)) {
             return connected_cache;
@@ -2416,7 +2416,7 @@ public class MainUtil {
         connected_cache.add(plot);
         Plot tmp;
         if (merged[0]) {
-            tmp = getPlotAbs(plot.world, getPlotIdRelative(plot.id, 0));
+            tmp = getPlotAbs(plot.world, getPlotIdRelative(plot.getId(), 0));
             if (!tmp.getMerged(2)) {
                 // invalid merge
                 PS.debug("Fixing invalid merge: " + plot);
@@ -2432,7 +2432,7 @@ public class MainUtil {
             frontier.add(tmp);
         }
         if (merged[1]) {
-            tmp = getPlotAbs(plot.world, getPlotIdRelative(plot.id, 1));
+            tmp = getPlotAbs(plot.world, getPlotIdRelative(plot.getId(), 1));
             if (!tmp.getMerged(3)) {
                 // invalid merge
                 PS.debug("Fixing invalid merge: " + plot);
@@ -2448,7 +2448,7 @@ public class MainUtil {
             frontier.add(tmp);
         }
         if (merged[2]) {
-            tmp = getPlotAbs(plot.world, getPlotIdRelative(plot.id, 2));
+            tmp = getPlotAbs(plot.world, getPlotIdRelative(plot.getId(), 2));
             if (!tmp.getMerged(0)) {
                 // invalid merge
                 PS.debug("Fixing invalid merge: " + plot);
@@ -2464,7 +2464,7 @@ public class MainUtil {
             frontier.add(tmp);
         }
         if (merged[3]) {
-            tmp = getPlotAbs(plot.world, getPlotIdRelative(plot.id, 3));
+            tmp = getPlotAbs(plot.world, getPlotIdRelative(plot.getId(), 3));
             if (!tmp.getMerged(1)) {
                 // invalid merge
                 PS.debug("Fixing invalid merge: " + plot);
@@ -2491,28 +2491,28 @@ public class MainUtil {
             queuecache.remove(current);
             merged = current.getMerged();
             if (merged[0]) {
-                tmp = getPlotAbs(current.world, getPlotIdRelative(current.id, 0));
+                tmp = getPlotAbs(current.world, getPlotIdRelative(current.getId(), 0));
                 if (!queuecache.contains(tmp) && !connected_cache.contains(tmp)) {
                     queuecache.add(tmp);
                     frontier.add(tmp);
                 }
             }
             if (merged[1]) {
-                tmp = getPlotAbs(current.world, getPlotIdRelative(current.id, 1));
+                tmp = getPlotAbs(current.world, getPlotIdRelative(current.getId(), 1));
                 if (!queuecache.contains(tmp) && !connected_cache.contains(tmp)) {
                     queuecache.add(tmp);
                     frontier.add(tmp);
                 }
             }
             if (merged[2]) {
-                tmp = getPlotAbs(current.world, getPlotIdRelative(current.id, 2));
+                tmp = getPlotAbs(current.world, getPlotIdRelative(current.getId(), 2));
                 if (!queuecache.contains(tmp) && !connected_cache.contains(tmp)) {
                     queuecache.add(tmp);
                     frontier.add(tmp);
                 }
             }
             if (merged[3]) {
-                tmp = getPlotAbs(current.world, getPlotIdRelative(current.id, 3));
+                tmp = getPlotAbs(current.world, getPlotIdRelative(current.getId(), 3));
                 if (!queuecache.contains(tmp) && !connected_cache.contains(tmp)) {
                     queuecache.add(tmp);
                     frontier.add(tmp);
@@ -2547,7 +2547,7 @@ public class MainUtil {
         if (plot != null) {
             return getConnectedPlots(plot);
         }
-        return new HashSet<>(Arrays.asList(new Plot(world, id, null)));
+        return new HashSet<>(Collections.singletonList(new Plot(world, id, null)));
     }
     
     /**
@@ -2693,7 +2693,7 @@ public class MainUtil {
      * @return
      */
     public static boolean setComponent(final Plot plot, final String component, final PlotBlock[] blocks) {
-        return PS.get().getPlotManager(plot.world).setComponent(PS.get().getPlotWorld(plot.world), plot.id, component, blocks);
+        return plot.getManager().setComponent(plot.getWorld(), plot.getId(), component, blocks);
     }
     
     /**
@@ -2708,7 +2708,7 @@ public class MainUtil {
     public static void format(String info, final Plot plot, final PlotPlayer player, final boolean full, final RunnableVal<String> whenDone) {
         final int num = MainUtil.getConnectedPlots(plot).size();
         final String alias = plot.getAlias().length() > 0 ? plot.getAlias() : C.NONE.s();
-        final Location bot = plot.getBottom();
+        final Location bot = plot.getCorners()[0];
         final String biome = BlockManager.manager.getBiome(plot.world, bot.getX(), bot.getZ());
         final String trusted = getPlayerList(plot.getTrusted());
         final String members = getPlayerList(plot.getMembers());
@@ -2725,7 +2725,7 @@ public class MainUtil {
         
         final String owner = plot.owner == null ? "unowned" : getPlayerList(plot.getOwners());
         
-        info = info.replaceAll("%id%", plot.id.toString());
+        info = info.replaceAll("%id%", plot.getId().toString());
         info = info.replaceAll("%alias%", alias);
         info = info.replaceAll("%num%", num + "");
         info = info.replaceAll("%desc%", description);
@@ -2776,7 +2776,7 @@ public class MainUtil {
      */
     public static String getPlayerList(final Collection<UUID> uuids) {
         final ArrayList<UUID> l = new ArrayList<>(uuids);
-        if ((l == null) || (l.size() < 1)) {
+        if (l.size() < 1) {
             return C.NONE.s();
         }
         final String c = C.PLOT_USER_LIST.s();

--- a/src/main/java/com/intellectualcrafters/plot/util/NbtFactory.java
+++ b/src/main/java/com/intellectualcrafters/plot/util/NbtFactory.java
@@ -1,5 +1,20 @@
 package com.intellectualcrafters.plot.util;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.MapMaker;
+import com.google.common.io.Closeables;
+import com.google.common.io.Files;
+import com.google.common.io.InputSupplier;
+import com.google.common.io.OutputSupplier;
+import com.google.common.primitives.Primitives;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.Server;
+import org.bukkit.inventory.ItemStack;
+
 import java.io.BufferedInputStream;
 import java.io.DataInput;
 import java.io.DataInputStream;
@@ -16,6 +31,7 @@ import java.util.AbstractList;
 import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -23,22 +39,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
-
-import org.bukkit.Bukkit;
-import org.bukkit.Material;
-import org.bukkit.Server;
-import org.bukkit.inventory.ItemStack;
-
-import com.google.common.base.Splitter;
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.MapMaker;
-import com.google.common.io.Closeables;
-import com.google.common.io.Files;
-import com.google.common.io.InputSupplier;
-import com.google.common.io.OutputSupplier;
-import com.google.common.primitives.Primitives;
 
 public class NbtFactory {
     // Convert between NBT id and the equivalent class in java
@@ -191,7 +191,7 @@ public class NbtFactory {
          * @return An existing map, a new map or NULL.
          */
         public NbtCompound getMap(final String key, final boolean createNew) {
-            return getMap(Arrays.asList(key), createNew);
+            return getMap(Collections.singletonList(key), createNew);
         }
         
         // Done

--- a/src/main/java/com/intellectualcrafters/plot/util/SchematicHandler.java
+++ b/src/main/java/com/intellectualcrafters/plot/util/SchematicHandler.java
@@ -1,5 +1,30 @@
 package com.intellectualcrafters.plot.util;
 
+import com.google.common.collect.Lists;
+import com.intellectualcrafters.jnbt.ByteArrayTag;
+import com.intellectualcrafters.jnbt.CompoundTag;
+import com.intellectualcrafters.jnbt.IntTag;
+import com.intellectualcrafters.jnbt.ListTag;
+import com.intellectualcrafters.jnbt.NBTInputStream;
+import com.intellectualcrafters.jnbt.NBTOutputStream;
+import com.intellectualcrafters.jnbt.ShortTag;
+import com.intellectualcrafters.jnbt.StringTag;
+import com.intellectualcrafters.jnbt.Tag;
+import com.intellectualcrafters.json.JSONArray;
+import com.intellectualcrafters.plot.PS;
+import com.intellectualcrafters.plot.config.Settings;
+import com.intellectualcrafters.plot.generator.ClassicPlotWorld;
+import com.intellectualcrafters.plot.object.ChunkLoc;
+import com.intellectualcrafters.plot.object.Location;
+import com.intellectualcrafters.plot.object.Plot;
+import com.intellectualcrafters.plot.object.PlotBlock;
+import com.intellectualcrafters.plot.object.PlotId;
+import com.intellectualcrafters.plot.object.PlotWorld;
+import com.intellectualcrafters.plot.object.RegionWrapper;
+import com.intellectualcrafters.plot.object.RunnableVal;
+import com.intellectualcrafters.plot.object.schematic.PlotItem;
+import com.plotsquared.object.schematic.StateWrapper;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -28,31 +53,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
-
-import com.google.common.collect.Lists;
-import com.intellectualcrafters.jnbt.ByteArrayTag;
-import com.intellectualcrafters.jnbt.CompoundTag;
-import com.intellectualcrafters.jnbt.IntTag;
-import com.intellectualcrafters.jnbt.ListTag;
-import com.intellectualcrafters.jnbt.NBTInputStream;
-import com.intellectualcrafters.jnbt.NBTOutputStream;
-import com.intellectualcrafters.jnbt.ShortTag;
-import com.intellectualcrafters.jnbt.StringTag;
-import com.intellectualcrafters.jnbt.Tag;
-import com.intellectualcrafters.json.JSONArray;
-import com.intellectualcrafters.plot.PS;
-import com.intellectualcrafters.plot.config.Settings;
-import com.intellectualcrafters.plot.generator.ClassicPlotWorld;
-import com.intellectualcrafters.plot.object.ChunkLoc;
-import com.intellectualcrafters.plot.object.Location;
-import com.intellectualcrafters.plot.object.Plot;
-import com.intellectualcrafters.plot.object.PlotBlock;
-import com.intellectualcrafters.plot.object.PlotId;
-import com.intellectualcrafters.plot.object.PlotWorld;
-import com.intellectualcrafters.plot.object.RegionWrapper;
-import com.intellectualcrafters.plot.object.RunnableVal;
-import com.intellectualcrafters.plot.object.schematic.PlotItem;
-import com.plotsquared.object.schematic.StateWrapper;
 
 public abstract class SchematicHandler {
     public static SchematicHandler manager;
@@ -85,9 +85,9 @@ public abstract class SchematicHandler {
                 }
                 final String name;
                 if (namingScheme == null) {
-                    name = plot.id.x + ";" + plot.id.y + "," + plot.world + "," + o;
+                    name = plot.getId().x + ";" + plot.getId().y + "," + plot.world + "," + o;
                 } else {
-                    name = namingScheme.replaceAll("%owner%", o).replaceAll("%id%", plot.id.toString()).replaceAll("%idx%", plot.id.x + "").replaceAll("%idy%", plot.id.y + "")
+                    name = namingScheme.replaceAll("%owner%", o).replaceAll("%id%", plot.getId().toString()).replaceAll("%idx%", plot.getId().x + "").replaceAll("%idy%", plot.getId().y + "")
                     .replaceAll("%world%", plot.world);
                 }
                 final String directory;
@@ -97,21 +97,21 @@ public abstract class SchematicHandler {
                     directory = outputDir.getPath();
                 }
                 final Runnable THIS = this;
-                SchematicHandler.manager.getCompoundTag(plot.world, plot.id, new RunnableVal<CompoundTag>() {
+                SchematicHandler.manager.getCompoundTag(plot.world, plot.getId(), new RunnableVal<CompoundTag>() {
                     @Override
                     public void run() {
                         if (value == null) {
-                            MainUtil.sendMessage(null, "&7 - Skipped plot &c" + plot.id);
+                            MainUtil.sendMessage(null, "&7 - Skipped plot &c" + plot.getId());
                         } else {
                             TaskManager.runTaskAsync(new Runnable() {
                                 @Override
                                 public void run() {
-                                    MainUtil.sendMessage(null, "&6ID: " + plot.id);
+                                    MainUtil.sendMessage(null, "&6ID: " + plot.getId());
                                     final boolean result = SchematicHandler.manager.save(value, directory + File.separator + name + ".schematic");
                                     if (!result) {
-                                        MainUtil.sendMessage(null, "&7 - Failed to save &c" + plot.id);
+                                        MainUtil.sendMessage(null, "&7 - Failed to save &c" + plot.getId());
                                     } else {
-                                        MainUtil.sendMessage(null, "&7 - &a  success: " + plot.id);
+                                        MainUtil.sendMessage(null, "&7 - &a  success: " + plot.getId());
                                     }
                                     TaskManager.runTask(new Runnable() {
                                         @Override
@@ -346,14 +346,12 @@ public abstract class SchematicHandler {
                                         }
                                     }
                                 });
-                                return;
                             }
                         }
                     });
                 } catch (final Exception e) {
                     e.printStackTrace();
                     TaskManager.runTask(whenDone);
-                    return;
                 }
             }
         });

--- a/src/main/java/com/intellectualcrafters/plot/uuid/UUIDFetcher.java
+++ b/src/main/java/com/intellectualcrafters/plot/uuid/UUIDFetcher.java
@@ -6,6 +6,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -97,6 +98,6 @@ public class UUIDFetcher implements Callable<Map<String, UUID>> {
     }
     
     public static UUID getUUIDOf(String name) throws Exception {
-        return new UUIDFetcher(Arrays.asList(name)).call().get(name);
+        return new UUIDFetcher(Collections.singletonList(name)).call().get(name);
     }
 }

--- a/src/main/java/com/plotsquared/bukkit/chat/FancyMessage.java
+++ b/src/main/java/com/plotsquared/bukkit/chat/FancyMessage.java
@@ -2,21 +2,13 @@ package com.plotsquared.bukkit.chat;
 
 import static com.plotsquared.bukkit.chat.TextualComponent.rawText;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
-
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.stream.JsonWriter;
+import com.intellectualcrafters.configuration.serialization.ConfigurationSerializable;
+import com.intellectualcrafters.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.Achievement;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -28,13 +20,21 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.stream.JsonWriter;
-import com.intellectualcrafters.configuration.serialization.ConfigurationSerializable;
-import com.intellectualcrafters.configuration.serialization.ConfigurationSerialization;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
 
 /**
  * Represents a formattable message. Such messages can use elements such as colors, formatting codes, hover and click data, and other features provided by the vanilla Minecraft <a href="http://minecraft.gamepedia.com/Tellraw#Raw_JSON_Text">JSON message formatter</a>.
@@ -61,7 +61,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
     @Override
     public FancyMessage clone() throws CloneNotSupportedException {
         final FancyMessage instance = (FancyMessage) super.clone();
-        instance.messageParts = new ArrayList<MessagePart>(messageParts.size());
+        instance.messageParts = new ArrayList<>(messageParts.size());
         for (int i = 0; i < messageParts.size(); i++) {
             instance.messageParts.add(i, messageParts.get(i).clone());
         }
@@ -79,7 +79,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
     }
     
     public FancyMessage(final TextualComponent firstPartText) {
-        messageParts = new ArrayList<MessagePart>();
+        messageParts = new ArrayList<>();
         messageParts.add(new MessagePart(firstPartText));
         jsonString = null;
         dirty = false;
@@ -503,9 +503,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
      * @return This builder instance.
      */
     public FancyMessage translationReplacements(final FancyMessage... replacements) {
-        for (final FancyMessage str : replacements) {
-            latest().translationReplacements.add(str);
-        }
+        Collections.addAll(latest().translationReplacements, replacements);
         
         dirty = true;
         
@@ -742,7 +740,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
     // Doc copied from interface
     @Override
     public Map<String, Object> serialize() {
-        final HashMap<String, Object> map = new HashMap<String, Object>();
+        final HashMap<String, Object> map = new HashMap<>();
         map.put("messageParts", messageParts);
         //		map.put("JSON", toJSONString());
         return map;
@@ -791,7 +789,7 @@ public class FancyMessage implements JsonRepresentedObject, Cloneable, Iterable<
                 // Deserialize text
                 if (TextualComponent.isTextKey(entry.getKey())) {
                     // The map mimics the YAML serialization, which has a "key" field and one or more "value" fields
-                    final Map<String, Object> serializedMapForm = new HashMap<String, Object>(); // Must be object due to Bukkit serializer API compliance
+                    final Map<String, Object> serializedMapForm = new HashMap<>(); // Must be object due to Bukkit serializer API compliance
                     serializedMapForm.put("key", entry.getKey());
                     if (entry.getValue().isJsonPrimitive()) {
                         // Assume string

--- a/src/main/java/com/plotsquared/bukkit/database/plotme/APlotMeConnector.java
+++ b/src/main/java/com/plotsquared/bukkit/database/plotme/APlotMeConnector.java
@@ -1,18 +1,17 @@
 package com.plotsquared.bukkit.database.plotme;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.HashMap;
-
-import org.bukkit.Bukkit;
-import org.bukkit.World;
-
 import com.intellectualcrafters.configuration.file.FileConfiguration;
 import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.object.Location;
 import com.intellectualcrafters.plot.object.Plot;
 import com.intellectualcrafters.plot.object.PlotId;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashMap;
 
 public abstract class APlotMeConnector {
     public abstract Connection getPlotMeConnection(final String plugin, final FileConfiguration plotConfig, final String dataFolder);
@@ -42,15 +41,12 @@ public abstract class APlotMeConnector {
         final String wallblock = plotConfig.getString("worlds." + world + ".WallBlockId"); //
         PS.get().config.set("worlds." + actualWorldName + ".wall.block", wallblock);
         final String floor = plotConfig.getString("worlds." + world + ".PlotFloorBlockId"); //
-        PS.get().config.set("worlds." + actualWorldName + ".plot.floor", Arrays.asList(floor));
+        PS.get().config.set("worlds." + actualWorldName + ".plot.floor", Collections.singletonList(floor));
         final String filling = plotConfig.getString("worlds." + world + ".PlotFillingBlockId"); //
-        PS.get().config.set("worlds." + actualWorldName + ".plot.filling", Arrays.asList(filling));
+        PS.get().config.set("worlds." + actualWorldName + ".plot.filling", Collections.singletonList(filling));
         final String road = plotConfig.getString("worlds." + world + ".RoadMainBlockId");
         PS.get().config.set("worlds." + actualWorldName + ".road.block", road);
         Integer height = plotConfig.getInt("worlds." + world + ".RoadHeight"); //
-        if (height == null) {
-            height = 64;
-        }
         PS.get().config.set("worlds." + actualWorldName + ".road.height", height);
     }
     

--- a/src/main/java/com/plotsquared/bukkit/database/plotme/ClassicPlotMeConnector.java
+++ b/src/main/java/com/plotsquared/bukkit/database/plotme/ClassicPlotMeConnector.java
@@ -123,9 +123,7 @@ public class ClassicPlotMeConnector extends APlotMeConnector {
                                     e.printStackTrace();
                                     owner = UUID.nameUUIDFromBytes(bytes);
                                 }
-                                if (owner != null) {
-                                    UUIDHandler.add(new StringWrapper(name), owner);
-                                }
+                                UUIDHandler.add(new StringWrapper(name), owner);
                             }
                         } catch (final Exception e) {
                             e.printStackTrace();
@@ -166,13 +164,13 @@ public class ClassicPlotMeConnector extends APlotMeConnector {
         
         r.close();
         stmt.close();
-        
+
         try {
-            
+
             PS.log(" - " + prefix + "Denied");
             stmt = connection.prepareStatement("SELECT * FROM `" + prefix + "Denied`");
             r = stmt.executeQuery();
-            
+
             while (r.next()) {
                 final PlotId id = new PlotId(r.getInt("idX"), r.getInt("idZ"));
                 final String name = r.getString("player");
@@ -195,9 +193,7 @@ public class ClassicPlotMeConnector extends APlotMeConnector {
                                         e.printStackTrace();
                                         denied = UUID.nameUUIDFromBytes(bytes);
                                     }
-                                    if (denied != null) {
-                                        UUIDHandler.add(new StringWrapper(name), denied);
-                                    }
+                                    UUIDHandler.add(new StringWrapper(name), denied);
                                 }
                             } catch (final Exception e) {
                                 e.printStackTrace();
@@ -213,10 +209,10 @@ public class ClassicPlotMeConnector extends APlotMeConnector {
                     plots.get(world).get(id).getDenied().add(denied);
                 }
             }
-            
+
             stmt = connection.prepareStatement("SELECT * FROM `" + plugin + "Allowed`");
             r = stmt.executeQuery();
-            
+
             while (r.next()) {
                 final PlotId id = new PlotId(r.getInt("idX"), r.getInt("idZ"));
                 final String name = r.getString("player");
@@ -239,9 +235,7 @@ public class ClassicPlotMeConnector extends APlotMeConnector {
                                         e.printStackTrace();
                                         helper = UUID.nameUUIDFromBytes(bytes);
                                     }
-                                    if (helper != null) {
-                                        UUIDHandler.add(new StringWrapper(name), helper);
-                                    }
+                                    UUIDHandler.add(new StringWrapper(name), helper);
                                 }
                             } catch (final Exception e) {
                                 e.printStackTrace();
@@ -257,11 +251,12 @@ public class ClassicPlotMeConnector extends APlotMeConnector {
                     plots.get(world).get(id).getTrusted().add(helper);
                 }
             }
-            
+
             r.close();
             stmt.close();
-            
-        } catch (final Exception e) {}
+
+        } catch (SQLException e) {
+        }
         return plots;
     }
     

--- a/src/main/java/com/plotsquared/bukkit/database/plotme/LikePlotMeConverter.java
+++ b/src/main/java/com/plotsquared/bukkit/database/plotme/LikePlotMeConverter.java
@@ -30,6 +30,7 @@ import java.nio.file.Paths;
 import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -51,7 +52,9 @@ import com.plotsquared.bukkit.generator.HybridGen;
 
 /**
  * Created 2014-08-17 for PlotSquared
- *
+ *
+
+
  */
 public class LikePlotMeConverter {
     private final String plugin;
@@ -128,7 +131,8 @@ public class LikePlotMeConverter {
             content = content.replaceAll("PlotMe-DefaultGenerator", "PlotSquared");
             content = content.replaceAll(plugin, "PlotSquared");
             Files.write(path, content.getBytes(charset));
-        } catch (final Exception e) {}
+        } catch (IOException e) {
+        }
     }
     
     public boolean run(final APlotMeConnector connector) {
@@ -210,7 +214,7 @@ public class LikePlotMeConverter {
                             pathwidth = 7;
                         }
                         PS.get().config.set("worlds." + world + ".road.width", pathwidth);
-                        
+
                         Integer pathheight = PLOTME_DG_YML.getInt("worlds." + plotMeWorldName + ".RoadHeight"); //
                         if ((pathheight == null) || (pathheight == 0)) {
                             pathheight = 64;
@@ -232,21 +236,21 @@ public class LikePlotMeConverter {
                         if (floor == null) {
                             floor = "2";
                         }
-                        PS.get().config.set("worlds." + world + ".plot.floor", Arrays.asList(floor));
+                        PS.get().config.set("worlds." + world + ".plot.floor", Collections.singletonList(floor));
                         String filling = PLOTME_DG_YML.getString("worlds." + plotMeWorldName + ".FillBlock"); //
                         if (filling == null) {
                             filling = "3";
                         }
-                        PS.get().config.set("worlds." + world + ".plot.filling", Arrays.asList(filling));
+                        PS.get().config.set("worlds." + world + ".plot.filling", Collections.singletonList(filling));
                         String road = PLOTME_DG_YML.getString("worlds." + plotMeWorldName + ".RoadMainBlock");
                         if (road == null) {
                             road = "5";
                         }
                         PS.get().config.set("worlds." + world + ".road.block", road);
                         Integer height = PLOTME_DG_YML.getInt("worlds." + plotMeWorldName + ".RoadHeight"); //
-                        if ((height == null) || (height == 0)) {
+                        if (height == 0) {
                             height = PLOTME_DG_YML.getInt("worlds." + plotMeWorldName + ".GroundHeight"); //
-                            if ((height == null) || (height == 0)) {
+                            if (height == 0) {
                                 height = 64;
                             }
                         }
@@ -255,12 +259,13 @@ public class LikePlotMeConverter {
                         PS.get().config.set("worlds." + actualWorldName + ".wall.height", height);
                         PS.get().config.save(PS.get().configFile);
                     }
-                } catch (final Exception e) {}
+                } catch (IOException e) {
+                }
             }
             for (final String world : plots.keySet()) {
                 int duplicate = 0;
                 for (final Plot plot : plots.get(world).values()) {
-                    if (PS.get().getPlot(world, plot.id) == null) {
+                    if (PS.get().getPlot(world, plot.getId()) == null) {
                         createdPlots.add(plot);
                     } else {
                         duplicate++;

--- a/src/main/java/com/plotsquared/bukkit/database/plotme/PlotMeConnector_017.java
+++ b/src/main/java/com/plotsquared/bukkit/database/plotme/PlotMeConnector_017.java
@@ -136,8 +136,8 @@ public class PlotMeConnector_017 extends APlotMeConnector {
             final Plot plot = entry.getValue();
             final HashMap<PlotId, boolean[]> mergeMap = merges.get(plot.world);
             if (mergeMap != null) {
-                if (mergeMap.containsKey(plot.id)) {
-                    plot.setMerged(mergeMap.get(plot.id));
+                if (mergeMap.containsKey(plot.getId())) {
+                    plot.setMerged(mergeMap.get(plot.getId()));
                 }
             }
         }
@@ -188,7 +188,7 @@ public class PlotMeConnector_017 extends APlotMeConnector {
                 map = new HashMap<>();
                 processed.put(plot.world, map);
             }
-            map.put(plot.id, plot);
+            map.put(plot.getId(), plot);
         }
         return processed;
     }

--- a/src/main/java/com/plotsquared/bukkit/generator/HybridGen.java
+++ b/src/main/java/com/plotsquared/bukkit/generator/HybridGen.java
@@ -20,15 +20,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.plotsquared.bukkit.generator;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map.Entry;
-
-import org.bukkit.Bukkit;
-import org.bukkit.World;
-import org.bukkit.block.Biome;
-
 import com.intellectualcrafters.plot.generator.HybridPlotManager;
 import com.intellectualcrafters.plot.generator.HybridPlotWorld;
 import com.intellectualcrafters.plot.object.PlotLoc;
@@ -36,12 +27,22 @@ import com.intellectualcrafters.plot.object.PlotManager;
 import com.intellectualcrafters.plot.object.PlotWorld;
 import com.intellectualcrafters.plot.object.PseudoRandom;
 import com.intellectualcrafters.plot.object.RegionWrapper;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.block.Biome;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map.Entry;
 
 /**
  * The default generator is very messy, as we have decided to try externalize all calculations from within the loop. -
  * You will see a lot of slower implementations have a single for loop. - This is perfectly fine to do, it will just
  * mean world generation may take somewhat longer
- *
+ *
+
+
  */
 public class HybridGen extends BukkitPlotGenerator {
     
@@ -120,7 +121,7 @@ public class HybridGen extends BukkitPlotGenerator {
         biome = Biome.valueOf(this.plotworld.PLOT_BIOME);
         try {
             maxY = Bukkit.getWorld(plotworld.worldname).getMaxHeight();
-        } catch (final NullPointerException e) {}
+        } catch (final NullPointerException ignored) {}
         if (maxY == 0) {
             maxY = 256;
         }
@@ -176,7 +177,7 @@ public class HybridGen extends BukkitPlotGenerator {
     public List<BukkitPlotPopulator> getPopulators(final String world) {
         // You can have as many populators as you would like, e.g. tree
         // populator, ore populator
-        return Arrays.asList((BukkitPlotPopulator) new HybridPop(plotworld));
+        return Collections.singletonList((BukkitPlotPopulator) new HybridPop(plotworld));
     }
     
     /**
@@ -292,6 +293,5 @@ public class HybridGen extends BukkitPlotGenerator {
                 }
             }
         }
-        return;
     }
 }

--- a/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -123,7 +123,9 @@ import com.plotsquared.bukkit.util.BukkitUtil;
 
 /**
  * Player Events involving plots
- *
+ *
+
+
  */
 @SuppressWarnings({ "deprecation", "unchecked" })
 public class PlayerEvents extends com.plotsquared.listener.PlotListener implements Listener {
@@ -593,7 +595,7 @@ public class PlayerEvents extends com.plotsquared.listener.PlotListener implemen
         final String message = event.getMessage();
         String format = C.PLOT_CHAT_FORMAT.s();
         final String sender = event.getPlayer().getDisplayName();
-        final PlotId id = plot.id;
+        final PlotId id = plot.getId();
         final Set<Player> recipients = event.getRecipients();
         recipients.clear();
         for (final Player p : Bukkit.getOnlinePlayers()) {

--- a/src/main/java/com/plotsquared/bukkit/listeners/worldedit/WEListener.java
+++ b/src/main/java/com/plotsquared/bukkit/listeners/worldedit/WEListener.java
@@ -1,6 +1,7 @@
 package com.plotsquared.bukkit.listeners.worldedit;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
@@ -35,16 +36,16 @@ public class WEListener implements Listener {
     public final HashSet<String> rad2 = new HashSet<>(Arrays.asList("fill", "fillr", "removenear", "remove"));
     public final HashSet<String> rad2_1 = new HashSet<>(Arrays.asList("hcyl", "cyl"));
     public final HashSet<String> rad2_2 = new HashSet<>(Arrays.asList("sphere", "pyramid"));
-    public final HashSet<String> rad2_3 = new HashSet<>(Arrays.asList("brush smooth"));
-    public final HashSet<String> rad3_1 = new HashSet<>(Arrays.asList("brush gravity"));
+    public final HashSet<String> rad2_3 = new HashSet<>(Collections.singletonList("brush smooth"));
+    public final HashSet<String> rad3_1 = new HashSet<>(Collections.singletonList("brush gravity"));
     public final HashSet<String> rad3_2 = new HashSet<>(Arrays.asList("brush sphere", "brush cylinder"));
     
     public final HashSet<String> region = new HashSet<>(Arrays.asList("move", "set", "replace", "overlay", "walls", "outline", "deform", "hollow", "smooth", "naturalize", "paste", "count", "distr",
     "regen", "copy", "cut", "green", "setbiome"));
-    public final HashSet<String> regionExtend = new HashSet<>(Arrays.asList("stack"));
+    public final HashSet<String> regionExtend = new HashSet<>(Collections.singletonList("stack"));
     public final HashSet<String> unregioned = new HashSet<>(Arrays.asList("paste", "redo", "undo", "rotate", "flip", "generate", "schematic", "schem"));
     public final HashSet<String> unsafe1 = new HashSet<>(Arrays.asList("cs", ".s", "restore", "snapshot", "delchunks", "listchunks"));
-    public final HashSet<String> restricted = new HashSet<>(Arrays.asList("up"));
+    public final HashSet<String> restricted = new HashSet<>(Collections.singletonList("up"));
     public final HashSet<String> other = new HashSet<>(Arrays.asList("undo", "redo"));
     
     public boolean checkCommand(final List<String> list, final String cmd) {
@@ -137,11 +138,9 @@ public class WEListener implements Listener {
         final long volume = Math.abs((pos1.getBlockX() - pos2.getBlockX()) * (pos1.getBlockY() - pos2.getBlockY()) * (pos1.getBlockZ() - pos2.getBlockZ())) * modifier;
         return checkVolume(pp, volume, max, e);
     }
-    
-    private final boolean set = false;
-    
+
     public boolean delay(final Player player, final String command, final boolean delayed) {
-        if (!Settings.QUEUE_COMMANDS || !Settings.EXPERIMENTAL_FAST_ASYNC_WORLDEDIT || set) {
+        if (!Settings.QUEUE_COMMANDS || !Settings.EXPERIMENTAL_FAST_ASYNC_WORLDEDIT) {
             return false;
         }
         final boolean free = SetBlockQueue.addNotify(null);

--- a/src/main/java/com/plotsquared/bukkit/util/BukkitChunkManager.java
+++ b/src/main/java/com/plotsquared/bukkit/util/BukkitChunkManager.java
@@ -1,13 +1,25 @@
 package com.plotsquared.bukkit.util;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
-
+import com.intellectualcrafters.plot.PS;
+import com.intellectualcrafters.plot.object.BlockLoc;
+import com.intellectualcrafters.plot.object.ChunkLoc;
+import com.intellectualcrafters.plot.object.Location;
+import com.intellectualcrafters.plot.object.Plot;
+import com.intellectualcrafters.plot.object.PlotBlock;
+import com.intellectualcrafters.plot.object.PlotId;
+import com.intellectualcrafters.plot.object.PlotLoc;
+import com.intellectualcrafters.plot.object.PlotPlayer;
+import com.intellectualcrafters.plot.object.PlotWorld;
+import com.intellectualcrafters.plot.object.RegionWrapper;
+import com.intellectualcrafters.plot.object.RunnableVal;
+import com.intellectualcrafters.plot.util.BlockUpdateUtil;
+import com.intellectualcrafters.plot.util.ChunkManager;
+import com.intellectualcrafters.plot.util.ClusterManager;
+import com.intellectualcrafters.plot.util.MainUtil;
+import com.intellectualcrafters.plot.util.SetBlockQueue.ChunkWrapper;
+import com.intellectualcrafters.plot.util.TaskManager;
+import com.plotsquared.bukkit.generator.AugmentedPopulator;
+import com.plotsquared.bukkit.object.entity.EntityWrapper;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.DyeColor;
@@ -43,26 +55,13 @@ import org.bukkit.generator.BlockPopulator;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 
-import com.intellectualcrafters.plot.PS;
-import com.intellectualcrafters.plot.object.BlockLoc;
-import com.intellectualcrafters.plot.object.ChunkLoc;
-import com.intellectualcrafters.plot.object.Location;
-import com.intellectualcrafters.plot.object.Plot;
-import com.intellectualcrafters.plot.object.PlotBlock;
-import com.intellectualcrafters.plot.object.PlotId;
-import com.intellectualcrafters.plot.object.PlotLoc;
-import com.intellectualcrafters.plot.object.PlotPlayer;
-import com.intellectualcrafters.plot.object.PlotWorld;
-import com.intellectualcrafters.plot.object.RegionWrapper;
-import com.intellectualcrafters.plot.object.RunnableVal;
-import com.intellectualcrafters.plot.util.BlockUpdateUtil;
-import com.intellectualcrafters.plot.util.ChunkManager;
-import com.intellectualcrafters.plot.util.ClusterManager;
-import com.intellectualcrafters.plot.util.MainUtil;
-import com.intellectualcrafters.plot.util.SetBlockQueue.ChunkWrapper;
-import com.intellectualcrafters.plot.util.TaskManager;
-import com.plotsquared.bukkit.generator.AugmentedPopulator;
-import com.plotsquared.bukkit.object.entity.EntityWrapper;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
 
 public class BukkitChunkManager extends ChunkManager {
     @Override
@@ -83,7 +82,7 @@ public class BukkitChunkManager extends ChunkManager {
         //        Chunk chunk = worldObj.getChunkAt(loc.x, loc.z);
         worldObj.regenerateChunk(loc.x, loc.z);
         if (BlockUpdateUtil.setBlockManager != null) {
-            BlockUpdateUtil.setBlockManager.update(world, Arrays.asList(loc));
+            BlockUpdateUtil.setBlockManager.update(world, Collections.singletonList(loc));
         }
         for (final Player player : worldObj.getPlayers()) {
             final org.bukkit.Location locObj = player.getLocation();
@@ -854,8 +853,7 @@ public class BukkitChunkManager extends ChunkManager {
     
     @Override
     public boolean loadChunk(final String world, final ChunkLoc loc, final boolean force) {
-        boolean result = BukkitUtil.getWorld(world).getChunkAt(loc.x, loc.z).load(force);
-        return result;
+        return BukkitUtil.getWorld(world).getChunkAt(loc.x, loc.z).load(force);
     }
     
     @Override
@@ -902,10 +900,8 @@ public class BukkitChunkManager extends ChunkManager {
                             BukkitSetBlockManager.setBlockManager.set(world2, xx, y, zz, 0, (byte) 0);
                         }
                     } else if (id2 == 0) {
-                        if (id1 != 0) {
-                            BukkitSetBlockManager.setBlockManager.set(world1, x, y, z, 0, (byte) 0);
-                            BukkitSetBlockManager.setBlockManager.set(world2, xx, y, zz, id1, data1);
-                        }
+                        BukkitSetBlockManager.setBlockManager.set(world1, x, y, z, 0, (byte) 0);
+                        BukkitSetBlockManager.setBlockManager.set(world2, xx, y, zz, id1, data1);
                     } else if (id1 == id2) {
                         if (data1 != data2) {
                             block1.setData(data2);
@@ -948,8 +944,8 @@ public class BukkitChunkManager extends ChunkManager {
         final int[] count = new int[6];
         final World world = BukkitUtil.getWorld(plot.world);
         
-        final Location bot = MainUtil.getPlotBottomLocAbs(plot.world, plot.id);
-        final Location top = MainUtil.getPlotTopLocAbs(plot.world, plot.id);
+        final Location bot = MainUtil.getPlotBottomLocAbs(plot.world, plot.getId());
+        final Location top = MainUtil.getPlotTopLocAbs(plot.world, plot.getId());
         final int bx = bot.getX() >> 4;
         final int bz = bot.getZ() >> 4;
         
@@ -985,7 +981,7 @@ public class BukkitChunkManager extends ChunkManager {
                         count(count, entity);
                     } else {
                         final PlotId id = MainUtil.getPlotId(BukkitUtil.getLocation(loc));
-                        if (plot.id.equals(id)) {
+                        if (plot.getId().equals(id)) {
                             count(count, entity);
                         }
                     }
@@ -999,7 +995,7 @@ public class BukkitChunkManager extends ChunkManager {
                 for (final Entity entity : ents) {
                     if ((X == bx) || (X == tx) || (Z == bz) || (Z == tz)) {
                         final PlotId id = MainUtil.getPlotId(BukkitUtil.getLocation(entity));
-                        if (plot.id.equals(id)) {
+                        if (plot.getId().equals(id)) {
                             count(count, entity);
                         }
                     } else {
@@ -1169,7 +1165,7 @@ public class BukkitChunkManager extends ChunkManager {
             restoreEntities(world, 0, 0);
         }
         MainUtil.update(world.getName(), chunkLoc);
-        BukkitSetBlockManager.setBlockManager.update(Arrays.asList(new Chunk[] { chunk }));
+        BukkitSetBlockManager.setBlockManager.update(Collections.singletonList(chunk));
         CURRENT_PLOT_CLEAR = null;
     }
     

--- a/src/main/java/com/plotsquared/bukkit/util/BukkitEconHandler.java
+++ b/src/main/java/com/plotsquared/bukkit/util/BukkitEconHandler.java
@@ -1,5 +1,6 @@
 package com.plotsquared.bukkit.util;
 
+import com.plotsquared.bukkit.object.BukkitPlayer;
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.permission.Permission;
 
@@ -54,19 +55,19 @@ public class BukkitEconHandler extends EconHandler {
     public double getMoney(final PlotPlayer player) {
         final double bal = super.getMoney(player);
         if (Double.isNaN(bal)) {
-            return econ.getBalance(player.getName());
+            return econ.getBalance(((BukkitPlayer)player).player);
         }
         return bal;
     }
     
     @Override
     public void withdrawMoney(final PlotPlayer player, final double amount) {
-        econ.withdrawPlayer(player.getName(), amount);
+        econ.withdrawPlayer(((BukkitPlayer)player).player, amount);
     }
     
     @Override
     public void depositMoney(final PlotPlayer player, final double amount) {
-        econ.depositPlayer(player.getName(), amount);
+        econ.depositPlayer(((BukkitPlayer)player).player, amount);
     }
     
     @Override

--- a/src/main/java/com/plotsquared/bukkit/util/BukkitTaskManager.java
+++ b/src/main/java/com/plotsquared/bukkit/util/BukkitTaskManager.java
@@ -11,7 +11,7 @@ public class BukkitTaskManager extends TaskManager {
         return BukkitMain.THIS.getServer().getScheduler().scheduleSyncRepeatingTask(BukkitMain.THIS, r, interval, interval);
     }
     
-    @Override
+    @SuppressWarnings("deprecation") @Override
     public int taskRepeatAsync(final Runnable r, final int interval) {
         return BukkitMain.THIS.getServer().getScheduler().scheduleAsyncRepeatingTask(BukkitMain.THIS, r, interval, interval);
     }

--- a/src/main/java/com/plotsquared/bukkit/uuid/LowerOfflineUUIDWrapper.java
+++ b/src/main/java/com/plotsquared/bukkit/uuid/LowerOfflineUUIDWrapper.java
@@ -24,10 +24,8 @@ public class LowerOfflineUUIDWrapper extends OfflineUUIDWrapper {
     
     public LowerOfflineUUIDWrapper() {
         try {
-            getOnline = Server.class.getMethod("getOnlinePlayers", new Class[0]);
-        } catch (final NoSuchMethodException e) {
-            e.printStackTrace();
-        } catch (final SecurityException e) {
+            getOnline = Server.class.getMethod("getOnlinePlayers");
+        } catch (final NoSuchMethodException | SecurityException e) {
             e.printStackTrace();
         }
     }
@@ -73,7 +71,8 @@ public class LowerOfflineUUIDWrapper extends OfflineUUIDWrapper {
     @Override
     public Player[] getOnlinePlayers() {
         if (getOnline == null) {
-            return Bukkit.getOnlinePlayers().toArray(new Player[0]);
+            Collection<? extends Player> onlinePlayers = Bukkit.getOnlinePlayers();
+            return onlinePlayers.toArray(new Player[onlinePlayers.size()]);
         }
         try {
             final Object players = getOnline.invoke(Bukkit.getServer(), arg);
@@ -82,12 +81,13 @@ public class LowerOfflineUUIDWrapper extends OfflineUUIDWrapper {
             } else {
                 @SuppressWarnings("unchecked")
                 final Collection<? extends Player> p = (Collection<? extends Player>) players;
-                return p.toArray(new Player[0]);
+                return p.toArray(new Player[p.size()]);
             }
         } catch (final Exception e) {
             PS.debug("Failed to resolve online players");
             getOnline = null;
-            return Bukkit.getOnlinePlayers().toArray(new Player[0]);
+            Collection<? extends Player> onlinePlayers = Bukkit.getOnlinePlayers();
+            return onlinePlayers.toArray(new Player[onlinePlayers.size()]);
         }
     }
     

--- a/src/main/java/com/plotsquared/bukkit/uuid/OfflineUUIDWrapper.java
+++ b/src/main/java/com/plotsquared/bukkit/uuid/OfflineUUIDWrapper.java
@@ -25,10 +25,8 @@ public class OfflineUUIDWrapper extends UUIDWrapper {
     
     public OfflineUUIDWrapper() {
         try {
-            getOnline = Server.class.getMethod("getOnlinePlayers", new Class[0]);
-        } catch (final NoSuchMethodException e) {
-            e.printStackTrace();
-        } catch (final SecurityException e) {
+            getOnline = Server.class.getMethod("getOnlinePlayers");
+        } catch (final NoSuchMethodException | SecurityException e) {
             e.printStackTrace();
         }
     }
@@ -72,7 +70,8 @@ public class OfflineUUIDWrapper extends UUIDWrapper {
     
     public Player[] getOnlinePlayers() {
         if (getOnline == null) {
-            return Bukkit.getOnlinePlayers().toArray(new Player[0]);
+            Collection<? extends Player> onlinePlayers = Bukkit.getOnlinePlayers();
+            return onlinePlayers.toArray(new Player[onlinePlayers.size()]);
         }
         try {
             final Object players = getOnline.invoke(Bukkit.getServer(), arg);
@@ -81,12 +80,13 @@ public class OfflineUUIDWrapper extends UUIDWrapper {
             } else {
                 @SuppressWarnings("unchecked")
                 final Collection<? extends Player> p = (Collection<? extends Player>) players;
-                return p.toArray(new Player[0]);
+                return p.toArray(new Player[p.size()]);
             }
         } catch (final Exception e) {
             PS.debug("Failed to resolve online players");
             getOnline = null;
-            return Bukkit.getOnlinePlayers().toArray(new Player[0]);
+            Collection<? extends Player> onlinePlayers = Bukkit.getOnlinePlayers();
+            return onlinePlayers.toArray(new Player[onlinePlayers.size()]);
         }
     }
     

--- a/src/main/java/com/plotsquared/bukkit/uuid/SQLUUIDHandler.java
+++ b/src/main/java/com/plotsquared/bukkit/uuid/SQLUUIDHandler.java
@@ -1,22 +1,5 @@
 package com.plotsquared.bukkit.uuid;
 
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.ArrayDeque;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.UUID;
-
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-
 import com.google.common.collect.HashBiMap;
 import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.C;
@@ -29,6 +12,22 @@ import com.intellectualcrafters.plot.util.TaskManager;
 import com.intellectualcrafters.plot.util.UUIDHandler;
 import com.intellectualcrafters.plot.util.UUIDHandlerImplementation;
 import com.intellectualcrafters.plot.uuid.UUIDWrapper;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.UUID;
 
 public class SQLUUIDHandler extends UUIDHandlerImplementation {
     
@@ -220,7 +219,7 @@ public class SQLUUIDHandler extends UUIDHandlerImplementation {
                     connection.setUseCaches(false);
                     connection.setDoInput(true);
                     connection.setDoOutput(true);
-                    String body = JSONArray.toJSONString(Arrays.asList(name));
+                    String body = JSONArray.toJSONString(Collections.singletonList(name));
                     OutputStream stream = connection.getOutputStream();
                     stream.write(body.getBytes());
                     stream.flush();

--- a/src/main/java/com/plotsquared/listener/PlotListener.java
+++ b/src/main/java/com/plotsquared/listener/PlotListener.java
@@ -46,7 +46,9 @@ import com.intellectualcrafters.plot.util.StringMan;
 import com.intellectualcrafters.plot.util.TaskManager;
 import com.intellectualcrafters.plot.util.UUIDHandler;
 
-/**
+/**
+
+
  */
 public class PlotListener {
     
@@ -55,7 +57,7 @@ public class PlotListener {
             return false;
         }
         final Plot last = (Plot) pp.getMeta("lastplot");
-        if ((last != null) && !last.id.equals(plot.id)) {
+        if ((last != null) && !last.getId().equals(plot.getId())) {
             plotExit(pp, last);
         }
         pp.setMeta("lastplot", MainUtil.getPlot(plot));
@@ -103,7 +105,7 @@ public class PlotListener {
                         if (!Permissions.hasPermission(pp, "plots.gamemode.bypass")) {
                             pp.setGamemode((PlotGamemode) gamemodeFlag.getValue());
                         } else {
-                            MainUtil.sendMessage(pp, StringMan.replaceAll(C.GAMEMODE_WAS_BYPASSED.s(), "{plot}", plot.id, "{gamemode}", gamemodeFlag.getValue()));
+                            MainUtil.sendMessage(pp, StringMan.replaceAll(C.GAMEMODE_WAS_BYPASSED.s(), "{plot}", plot.getId(), "{gamemode}", gamemodeFlag.getValue()));
                         }
                     }
                 }
@@ -163,10 +165,10 @@ public class PlotListener {
                         @Override
                         public void run() {
                             final Plot lastPlot = (Plot) pp.getMeta("lastplot");
-                            if ((lastPlot != null) && plot.id.equals(lastPlot.id)) {
+                            if ((lastPlot != null) && plot.getId().equals(lastPlot.getId())) {
                                 final Map<String, String> replacements = new HashMap<>();
-                                replacements.put("%x%", lastPlot.id.x + "");
-                                replacements.put("%z%", lastPlot.id.y + "");
+                                replacements.put("%x%", lastPlot.getId().x + "");
+                                replacements.put("%z%", lastPlot.getId().y + "");
                                 replacements.put("%world%", plot.world);
                                 replacements.put("%greeting%", greeting);
                                 replacements.put("%alias", plot.toString());

--- a/src/main/java/com/plotsquared/sponge/listener/MainListener.java
+++ b/src/main/java/com/plotsquared/sponge/listener/MainListener.java
@@ -399,7 +399,7 @@ public class MainListener {
         //  - Getting displayname currently causes NPE, so wait until sponge fixes that
         
         final String sender = player.getName();
-        final PlotId id = plot.id;
+        final PlotId id = plot.getId();
         final String newMessage = StringMan.replaceAll(C.PLOT_CHAT_FORMAT.s(), "%plot_id%", id.x + ";" + id.y, "%sender%", sender);
         final Text forcedMessage = event.getMessage();
         //        String forcedMessage = StringMan.replaceAll(C.PLOT_CHAT_FORCED.s(), "%plot_id%", id.x + ";" + id.y, "%sender%", sender);
@@ -811,7 +811,7 @@ public class MainListener {
                     }
                     return;
                 }
-            } else if ((lastPlot != null) && id.equals(lastPlot.id)) {
+            } else if ((lastPlot != null) && id.equals(lastPlot.getId())) {
                 return;
             } else {
                 final Plot plot = MainUtil.getPlot(worldname, id);
@@ -873,7 +873,7 @@ public class MainListener {
                     }
                     return;
                 }
-            } else if ((lastPlot != null) && id.equals(lastPlot.id)) {
+            } else if ((lastPlot != null) && id.equals(lastPlot.getId())) {
                 return;
             } else {
                 final Plot plot = MainUtil.getPlot(worldname, id);

--- a/src/main/java/com/plotsquared/sponge/util/SpongeCommand.java
+++ b/src/main/java/com/plotsquared/sponge/util/SpongeCommand.java
@@ -1,11 +1,9 @@
 package com.plotsquared.sponge.util;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
+import com.intellectualcrafters.plot.commands.MainCommand;
+import com.intellectualcrafters.plot.object.ConsolePlayer;
+import com.intellectualcrafters.plot.object.PlotPlayer;
+import com.plotsquared.sponge.SpongeMain;
 import org.spongepowered.api.command.CommandCallable;
 import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandResult;
@@ -14,10 +12,11 @@ import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
 
-import com.intellectualcrafters.plot.commands.MainCommand;
-import com.intellectualcrafters.plot.object.ConsolePlayer;
-import com.intellectualcrafters.plot.object.PlotPlayer;
-import com.plotsquared.sponge.SpongeMain;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public class SpongeCommand implements CommandCallable {
     
@@ -42,7 +41,7 @@ public class SpongeCommand implements CommandCallable {
     @Override
     public List<String> getSuggestions(final CommandSource cmd, final String string) throws CommandException {
         // TODO Auto-generated method stub
-        return new ArrayList<>(Arrays.asList("TEST"));
+        return new ArrayList<>(Collections.singletonList("TEST"));
     }
     
     @Override

--- a/src/main/java/com/plotsquared/sponge/uuid/SpongeLowerOfflineUUIDWrapper.java
+++ b/src/main/java/com/plotsquared/sponge/uuid/SpongeLowerOfflineUUIDWrapper.java
@@ -1,16 +1,16 @@
 package com.plotsquared.sponge.uuid;
 
-import java.util.UUID;
-
-import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.profile.GameProfile;
-
 import com.google.common.base.Charsets;
 import com.intellectualcrafters.plot.object.OfflinePlotPlayer;
 import com.intellectualcrafters.plot.object.PlotPlayer;
 import com.intellectualcrafters.plot.util.UUIDHandler;
 import com.intellectualcrafters.plot.uuid.UUIDWrapper;
 import com.plotsquared.sponge.SpongeMain;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.profile.GameProfile;
+
+import java.util.Collection;
+import java.util.UUID;
 
 public class SpongeLowerOfflineUUIDWrapper extends UUIDWrapper {
     
@@ -75,7 +75,8 @@ public class SpongeLowerOfflineUUIDWrapper extends UUIDWrapper {
     }
     
     public Player[] getOnlinePlayers() {
-        return SpongeMain.THIS.getServer().getOnlinePlayers().toArray(new Player[0]);
+        Collection<Player> onlinePlayers = SpongeMain.THIS.getServer().getOnlinePlayers();
+        return onlinePlayers.toArray(new Player[onlinePlayers.size()]);
     }
     
     @Override


### PR DESCRIPTION
Optimizations and Cleanup of code
Reduced the amount of deprecated code being used to not just reduce IDE warnings but to also better organize and clean the code later on.
Used Collections.singletonList() where possible instead which improves performance compared to when Arrays.asList() was used.