### PR TITLE
Make WorldEvents method non-static

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/WorldEvents.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/WorldEvents.java
@@ -14,7 +14,7 @@ import com.plotsquared.bukkit.generator.BukkitPlotGenerator;
 public class WorldEvents implements Listener {
     
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public static void onWorldInit(final WorldInitEvent event) {
+    public void onWorldInit(final WorldInitEvent event) {
         final World world = event.getWorld();
         final String name = world.getName();
         final ChunkGenerator gen = world.getGenerator();


### PR DESCRIPTION
PlotSquared doesnt work on PaperSpigot anymore since [this patch](https://github.com/PaperMC/Paper/commit/386693ee50f3096c207c03adef4dd6df7d126b76#diff-c8358d413de543013e1aca754cbc09f0R295) forces all event methods to be non-static.

Error while starting the server.
```
java.lang.IllegalArgumentException: Static method onWorldInit
at com.google.common.base.Preconditions.checkArgument(Preconditions.java:148)
at org.bukkit.plugin.EventExecutor.create(EventExecutor.java:28)
at org.bukkit.plugin.java.JavaPluginLoader.createRegisteredListeners(JavaPluginLoader.java:294)
at org.bukkit.plugin.SimplePluginManager.registerEvents(SimplePluginManager.java:548)
at com.plotsquared.bukkit.BukkitMain.registerWorldEvents(BukkitMain.java:509)
```