### PR TITLE
Add bypass permission for breaking blocks at y0

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -616,7 +616,6 @@ public class PlayerEvents extends PlotListener implements Listener {
         Plot plot = area.getPlotAbs(loc);
         if (plot != null) {
             PlotPlayer pp = BukkitUtil.getPlayer(player);
-            // TODO test
             if (event.getBlock().getY() == 0) {
                 if (!Permissions.hasPermission(pp, C.PERMISSION_ADMIN_DESTROY_GROUNDLEVEL)) {
                     MainUtil.sendMessage(pp, C.NO_PERMISSION_EVENT, C.PERMISSION_ADMIN_DESTROY_GROUNDLEVEL);

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -28,16 +28,6 @@ import com.plotsquared.bukkit.object.BukkitPlayer;
 import com.plotsquared.bukkit.util.BukkitUtil;
 import com.plotsquared.listener.PlayerBlockEventType;
 import com.plotsquared.listener.PlotListener;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
-import java.util.regex.Pattern;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -118,6 +108,16 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.projectiles.BlockProjectileSource;
 import org.bukkit.projectiles.ProjectileSource;
 import org.bukkit.util.Vector;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
 
 /**
  * Player Events involving plots.
@@ -615,11 +615,15 @@ public class PlayerEvents extends PlotListener implements Listener {
         }
         Plot plot = area.getPlotAbs(loc);
         if (plot != null) {
-            if (event.getBlock().getY() == 0) {
-                event.setCancelled(true);
-                return;
-            }
             PlotPlayer pp = BukkitUtil.getPlayer(player);
+            // TODO test
+            if (event.getBlock().getY() == 0) {
+                if (!Permissions.hasPermission(pp, C.PERMISSION_ADMIN_DESTROY_GROUNDLEVEL)) {
+                    MainUtil.sendMessage(pp, C.NO_PERMISSION_EVENT, C.PERMISSION_ADMIN_DESTROY_GROUNDLEVEL);
+                    event.setCancelled(true);
+                    return;
+                }
+            }
             if (!plot.hasOwner()) {
                 if (Permissions.hasPermission(pp, C.PERMISSION_ADMIN_DESTROY_UNOWNED)) {
                     return;

--- a/Core/src/main/java/com/intellectualcrafters/plot/config/C.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/config/C.java
@@ -6,7 +6,6 @@ import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.object.ConsolePlayer;
 import com.intellectualcrafters.plot.util.StringMan;
 import com.plotsquared.general.commands.CommandCaller;
-
 import java.io.File;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -59,6 +58,7 @@ public enum C {
     PERMISSION_COMMANDS_CHAT("plots.admin.command.chat", "static.permissions"),
     PERMISSION_MERGE_OTHER("plots.merge.other", "static.permissions"),
     PERMISSION_ADMIN_DESTROY_UNOWNED("plots.admin.destroy.unowned", "static.permissions"),
+    PERMISSION_ADMIN_DESTROY_GROUNDLEVEL("plots.admin.destroy.groundlevel", "static.permissions"),
     PERMISSION_ADMIN_DESTROY_OTHER("plots.admin.destroy.other", "static.permissions"),
     PERMISSION_ADMIN_DESTROY_ROAD("plots.admin.destroy.road", "static.permissions"),
     PERMISSION_ADMIN_BUILD_ROAD("plots.admin.build.road", "static.permissions"),


### PR DESCRIPTION
Changes proposed in this pull request:
- Added a `plots.admin.destroy.groundlevel` which allows players granted that permission to destroy the blocks that are located at y=0, which in most cases is bedrock

I'm open for name suggestions for the permission name :+1: 