### PR TITLE
Remove unused API Location that got printed on startup

### DIFF
--- a/Core/src/main/java/com/intellectualcrafters/plot/PS.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/PS.java
@@ -2182,7 +2182,6 @@ public class PS {
             settings.put("Auto Clear Enabled", "" + Settings.AUTO_CLEAR);
             settings.put("Auto Clear Days", "" + Settings.AUTO_CLEAR_DAYS);
             settings.put("Schematics Save Path", "" + Settings.SCHEMATIC_SAVE_PATH);
-            settings.put("API Location", "" + Settings.API_URL);
             for (Entry<String, String> setting : settings.entrySet()) {
                 PS.log(C.PREFIX + String.format("&cKey: &6%s&c, Value: &6%s", setting.getKey(), setting.getValue()));
             }

--- a/Core/src/main/java/com/intellectualcrafters/plot/config/Settings.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/config/Settings.java
@@ -138,10 +138,6 @@ public class Settings {
     public static int CLEAR_THRESHOLD = 1;
     public static int CLEAR_INTERVAL = 120;
     /**
-     * API Location
-     */
-    public static String API_URL = "http://www.intellectualsites.com/minecraft.php";
-    /**
      * Use the custom API
      */
     public static boolean CUSTOM_API = true;


### PR DESCRIPTION
Changes proposed in this pull request:

- Removed unused API_URL which got printed on every startup and was not required anymore