### PR TITLE
Fix tree growing not working in merged plots

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -1072,7 +1072,14 @@ public class PlayerEvents extends PlotListener implements Listener {
         for (int i = blocks.size() - 1; i >= 0; i--) {
             location = BukkitUtil.getLocation(blocks.get(i).getLocation());
             Plot plot = area.getOwnedPlot(location);
-            if (!Objects.equals(plot, origin)) {
+            /*
+             * plot -> the base plot of the merged area
+             * origin -> the plot where the event gets called
+             */
+
+            // Are plot and origin not the same AND are both plots merged
+            if (!Objects.equals(plot, origin) && (!plot.isMerged() && !origin.isMerged())) {
+                System.out.println("Removing all blocks (last)");
                 event.getBlocks().remove(i);
             }
         }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -1079,7 +1079,6 @@ public class PlayerEvents extends PlotListener implements Listener {
 
             // Are plot and origin not the same AND are both plots merged
             if (!Objects.equals(plot, origin) && (!plot.isMerged() && !origin.isMerged())) {
-                System.out.println("Removing all blocks (last)");
                 event.getBlocks().remove(i);
             }
         }


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix #1085 

Only deny tree/mushroom growth when the base plot and the plot where the event gets fired differ and both are __not__ merged. Else it can be assumed that they are in one merged area together and it's fine to grow trees/mushroom

I have tested the pull request
- Trees/Mushroom still don't grow over plot borders
- Trees/Mushroom grow on all plots of the merged area, also on roads
- Tested with multiple accounts having multiple plots merged adjacent to each other
- Still works after multiple unlinks and re-merges