### PR TITLE
Implement PlotComponentSetEvent

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,6 +7,6 @@
 
 Make sure you've completed the following steps (put an X between of brackets):
 - [] Include `/plot debugpaste`
-- [] Made sure there aren't duplicates of this report [(Use Search)](https://github.com/IntellectualSites/PlotSquared/issues)
+- [] Made sure there aren't duplicates of this report [(Use Search)](https://github.com/IntellectualSites/PlotSquared/issues?utf8=%E2%9C%93&q=is%3Aissue)
 - [] Made sure you're using an updated version of PlotSquared
 - [] Made sure the bug/error isn't caused by any other plugin

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/events/PlotComponentSetEvent.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/events/PlotComponentSetEvent.java
@@ -1,0 +1,56 @@
+package com.plotsquared.bukkit.events;
+
+import com.intellectualcrafters.plot.object.Plot;
+import com.intellectualcrafters.plot.object.PlotId;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Called when a plot component is set
+ *
+ */
+public class PlotComponentSetEvent extends PlotEvent {
+
+    private static final HandlerList handlers = new HandlerList();
+    private final String component;
+
+    public PlotComponentSetEvent(Plot plot, String component) {
+        super(plot);
+        this.component = component;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    /**
+     * Get the PlotId
+     *
+     * @return PlotId
+     */
+    public PlotId getPlotId() {
+        return getPlot().getId();
+    }
+
+    /**
+     * Get the world name
+     *
+     * @return String
+     */
+    public String getWorld() {
+        return getPlot().getArea().worldname;
+    }
+
+    /**
+     * Get the component which was set
+     *
+     * @return Component name
+     */
+    public String getComponent() {
+        return this.component;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+}

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -109,7 +109,6 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.projectiles.BlockProjectileSource;
 import org.bukkit.projectiles.ProjectileSource;
 import org.bukkit.util.Vector;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitEventUtil.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitEventUtil.java
@@ -18,6 +18,7 @@ import com.plotsquared.bukkit.events.PlayerPlotHelperEvent;
 import com.plotsquared.bukkit.events.PlayerPlotTrustedEvent;
 import com.plotsquared.bukkit.events.PlayerTeleportToPlotEvent;
 import com.plotsquared.bukkit.events.PlotClearEvent;
+import com.plotsquared.bukkit.events.PlotComponentSetEvent;
 import com.plotsquared.bukkit.events.PlotDeleteEvent;
 import com.plotsquared.bukkit.events.PlotFlagAddEvent;
 import com.plotsquared.bukkit.events.PlotFlagRemoveEvent;
@@ -55,6 +56,11 @@ public class BukkitEventUtil extends EventUtil {
     @Override
     public boolean callTeleport(PlotPlayer player, Location from, Plot plot) {
         return callEvent(new PlayerTeleportToPlotEvent(getPlayer(player), from, plot));
+    }
+
+    @Override
+    public boolean callComponentSet(Plot plot, String component) {
+        return callEvent(new PlotComponentSetEvent(plot, component));
     }
 
     @Override

--- a/Core/src/main/java/com/intellectualcrafters/plot/generator/ClassicPlotManager.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/generator/ClassicPlotManager.java
@@ -7,9 +7,9 @@ import com.intellectualcrafters.plot.object.PlotBlock;
 import com.intellectualcrafters.plot.object.PlotId;
 import com.intellectualcrafters.plot.object.PseudoRandom;
 import com.intellectualcrafters.plot.object.RegionWrapper;
+import com.intellectualcrafters.plot.util.EventUtil;
 import com.intellectualcrafters.plot.util.MainUtil;
 import com.intellectualcrafters.plot.util.SetQueue;
-
 import java.util.ArrayList;
 
 /**
@@ -22,27 +22,35 @@ public class ClassicPlotManager extends SquarePlotManager {
         switch (component) {
             case "floor":
                 setFloor(plotworld, plotid, blocks);
+                EventUtil.manager.callComponentSet(plotworld.getPlot(plotid), component);
                 return true;
             case "wall":
                 setWallFilling(plotworld, plotid, blocks);
+                EventUtil.manager.callComponentSet(plotworld.getPlot(plotid), component);
                 return true;
             case "all":
                 setAll(plotworld, plotid, blocks);
+                EventUtil.manager.callComponentSet(plotworld.getPlot(plotid), component);
                 return true;
             case "air":
                 setAir(plotworld, plotid, blocks);
+                EventUtil.manager.callComponentSet(plotworld.getPlot(plotid), component);
                 return true;
             case "main":
                 setMain(plotworld, plotid, blocks);
+                EventUtil.manager.callComponentSet(plotworld.getPlot(plotid), component);
                 return true;
             case "middle":
                 setMiddle(plotworld, plotid, blocks);
+                EventUtil.manager.callComponentSet(plotworld.getPlot(plotid), component);
                 return true;
             case "outline":
                 setOutline(plotworld, plotid, blocks);
+                EventUtil.manager.callComponentSet(plotworld.getPlot(plotid), component);
                 return true;
             case "border":
                 setWall(plotworld, plotid, blocks);
+                EventUtil.manager.callComponentSet(plotworld.getPlot(plotid), component);
                 return true;
         }
         return false;

--- a/Core/src/main/java/com/intellectualcrafters/plot/util/EventUtil.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/util/EventUtil.java
@@ -31,6 +31,8 @@ public abstract class EventUtil {
 
     public abstract boolean callTeleport(PlotPlayer player, Location from, Plot plot);
 
+    public abstract boolean callComponentSet(Plot plot, String component);
+
     public abstract boolean callClear(Plot plot);
 
     public abstract void callDelete(Plot plot);

--- a/Core/src/test/java/com/intellectualcrafters/plot/util/EventUtilTest.java
+++ b/Core/src/test/java/com/intellectualcrafters/plot/util/EventUtilTest.java
@@ -26,6 +26,8 @@ public class EventUtilTest extends EventUtil {
         return false;
     }
 
+    @Override public  boolean callComponentSet(Plot plot, String component) { return false; }
+
     @Override public boolean callClear(Plot plot) {
         return false;
     }

--- a/Sponge/src/main/java/com/plotsquared/sponge/events/PlotComponentSetEvent.java
+++ b/Sponge/src/main/java/com/plotsquared/sponge/events/PlotComponentSetEvent.java
@@ -1,0 +1,54 @@
+package com.plotsquared.sponge.events;
+
+import com.intellectualcrafters.plot.object.Plot;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.impl.AbstractEvent;
+
+import com.intellectualcrafters.plot.object.PlotId;
+
+public class PlotComponentSetEvent extends AbstractEvent {
+    private final Plot plot;
+    private final String component;
+
+    /**
+     * PlotDeleteEvent: Called when a plot is deleted
+     *
+     * @param plot    The plot that was deleted
+     */
+    public PlotComponentSetEvent(Plot plot, String component) {
+        this.plot = plot;
+        this.component = component;
+    }
+
+    /**
+     * Get the PlotId
+     *
+     * @return PlotId
+     */
+    public PlotId getPlotId() {
+        return this.plot.getId();
+    }
+
+    /**
+     * Get the world name
+     *
+     * @return String
+     */
+    public String getWorld() {
+        return this.plot.getArea().worldname;
+    }
+
+    /**
+     * Get the component which was set
+     *
+     * @return Component name
+     */
+    public String getComponent() {
+        return this.component;
+    }
+
+    @Override
+    public Cause getCause() {
+        return null;
+    }
+}

--- a/Sponge/src/main/java/com/plotsquared/sponge/events/PlotComponentSetEvent.java
+++ b/Sponge/src/main/java/com/plotsquared/sponge/events/PlotComponentSetEvent.java
@@ -11,9 +11,10 @@ public class PlotComponentSetEvent extends AbstractEvent {
     private final String component;
 
     /**
-     * PlotDeleteEvent: Called when a plot is deleted
+     * PlotComponentSetEvent: Called when a plot component is set
      *
-     * @param plot    The plot that was deleted
+     * @param plot        The plot
+     * @param component   The component which was set
      */
     public PlotComponentSetEvent(Plot plot, String component) {
         this.plot = plot;

--- a/Sponge/src/main/java/com/plotsquared/sponge/util/SpongeEventUtil.java
+++ b/Sponge/src/main/java/com/plotsquared/sponge/util/SpongeEventUtil.java
@@ -19,6 +19,7 @@ import com.plotsquared.sponge.events.PlayerPlotHelperEvent;
 import com.plotsquared.sponge.events.PlayerPlotTrustedEvent;
 import com.plotsquared.sponge.events.PlayerTeleportToPlotEvent;
 import com.plotsquared.sponge.events.PlotClearEvent;
+import com.plotsquared.sponge.events.PlotComponentSetEvent;
 import com.plotsquared.sponge.events.PlotDeleteEvent;
 import com.plotsquared.sponge.events.PlotFlagAddEvent;
 import com.plotsquared.sponge.events.PlotFlagRemoveEvent;
@@ -51,6 +52,11 @@ public class SpongeEventUtil extends EventUtil {
     @Override
     public boolean callTeleport(PlotPlayer player, Location from, Plot plot) {
         return callEvent(new PlayerTeleportToPlotEvent(SpongeUtil.getPlayer(player), from, plot));
+    }
+
+    @Override
+    public boolean callComponentSet(Plot plot, String component) {
+        return callEvent(new PlotComponentSetEvent(plot, component));
     }
     
     @Override


### PR DESCRIPTION
Changes proposed in this pull request:

- Implement a `PlotComponentSetEvent` for both Bukkit & Sponge. This event fires when a component was set, either by a third plugin or via /plot set floor stone and similar

This was first raised [here](https://github.com/IntellectualSites/PlotSquared/issues/735#issuecomment-197919513).