### PR TITLE
Add additional alias for /p middle

### DIFF
--- a/Core/src/main/java/com/intellectualcrafters/plot/commands/Middle.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/commands/Middle.java
@@ -11,7 +11,7 @@ import com.plotsquared.general.commands.CommandDeclaration;
  */
 @CommandDeclaration(
         command = "middle",
-        aliases = {"center"},
+        aliases = {"center", "centre"},
         description = "Teleports you to the center of the plot",
         usage = "/plot middle",
         category = CommandCategory.TELEPORT,


### PR DESCRIPTION
Changes proposed in this pull request:

- Add additional alias for `/plot middle`

| `/plot middle` |
|----------------|
| `/plot center` |
| `/plot centre` |

http://grammarist.com/spelling/center-centre/