### PR TITLE
Fix Spigot artifact in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,9 +80,9 @@
   </repositories>
   <dependencies>
     <dependency>
-      <groupId>org.bukkit</groupId>
-      <artifactId>Spigot</artifactId>
-      <version>1.10</version>
+      <groupId>org.spigotmc</groupId>
+      <artifactId>spigot</artifactId>
+      <version>1.10.2-R0.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.sk89q</groupId>


### PR DESCRIPTION
Use the correct groupId, artifactId and version of Spigot dependency installed by BuildTools