### PR TITLE
Switch Vault repository to the real one

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     </repository>
     <repository>
       <id>vault</id>
-      <url>http://maven.elmakers.com/repository/</url>
+      <url>http://nexus.hc.to/content/repositories/pub_releases/</url>
     </repository>
     <repository>
       <id>empcraft-repo</id>


### PR DESCRIPTION
#1326 migrated the Vault repository from the old location to an improper new location, while https://github.com/IntellectualSites/PlotSquared/commit/a2d87ac0647a9abb212c012e222d218b41af1772 migrated to the proper new location without changing the Maven `pom.xml`.