### PR TITLE
Allow SSL to be enabled or disabled in storage.yml

### DIFF
--- a/Core/src/main/java/com/intellectualcrafters/plot/config/Storage.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/config/Storage.java
@@ -25,6 +25,7 @@ public class Storage extends Config {
         public static String DATABASE = "plot_db";
         @Comment("Only enable this if your MySQL Database has SSL set up. If its not set up on your MySQL server, leave it as false.")
         public static String SSL = "false";
+        public static String verifySSL = "false";
     }
 
     @Comment("SQLite section")

--- a/Core/src/main/java/com/intellectualcrafters/plot/config/Storage.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/config/Storage.java
@@ -21,6 +21,7 @@ public class Storage extends Config {
         public static String HOST = "localhost";
         public static String PORT = "3306";
         public static String USER = "root";
+        public static String SSL = "false";
         public static String PASSWORD = "password";
         public static String DATABASE = "plot_db";
     }

--- a/Core/src/main/java/com/intellectualcrafters/plot/config/Storage.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/config/Storage.java
@@ -21,9 +21,10 @@ public class Storage extends Config {
         public static String HOST = "localhost";
         public static String PORT = "3306";
         public static String USER = "root";
-        public static String SSL = "false";
         public static String PASSWORD = "password";
         public static String DATABASE = "plot_db";
+        @Comment("Only enable this if your MySQL Database has SSL set up. If its not set up on your MySQL server, leave it as false.")
+        public static String SSL = "false";
     }
 
     @Comment("SQLite section")

--- a/Core/src/main/java/com/intellectualcrafters/plot/database/MySQL.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/database/MySQL.java
@@ -21,25 +21,29 @@ public class MySQL extends Database {
     private final String password;
     private final String port;
     private final String hostname;
+    private final String ssl;
+    private final String verifyssl;
     private Connection connection;
 
     /**
      * Creates a new MySQL instance.
      *
-     * @param hostname Name of the host
-     * @param port     Port number
-     * @param database Database name
-     * @param username Username
-     * @param password Password
-     * @param ssl      SSL
+     * @param hostname  Name of the host
+     * @param port      Port number
+     * @param database  Database name
+     * @param username  Username
+     * @param password  Password
+     * @param ssl       SSL
+     * @param verifyssl verifySSL
      */
-    public MySQL(String hostname, String port, String database, String username, String password, String ssl) {
+    public MySQL(String hostname, String port, String database, String username, String password, String ssl, String verifyssl) {
         this.hostname = hostname;
         this.port = port;
         this.database = database;
         this.user = username;
         this.password = password;
         this.ssl = ssl;
+        this.verifyssl = verifyssl;
         this.connection = null;
     }
 
@@ -47,7 +51,7 @@ public class MySQL extends Database {
     public Connection forceConnection() throws SQLException, ClassNotFoundException {
         Class.forName("com.mysql.jdbc.Driver");
         this.connection =
-                DriverManager.getConnection("jdbc:mysql://" + this.hostname + ':' + this.port + '/' + this.database + "?useSSL=" + this.ssl, this.user, this.password);
+                DriverManager.getConnection("jdbc:mysql://" + this.hostname + ':' + this.port + '/' + this.database + "?useSSL=" + this.ssl + "&verifyServerCertificate=" + this.verifyssl, this.user, this.password);
         return this.connection;
     }
 
@@ -57,9 +61,9 @@ public class MySQL extends Database {
             return this.connection;
         }
         Class.forName("com.mysql.jdbc.Driver");
-        PS.debug("jdbc:mysql://" + this.hostname + ':' + this.port + '/' + this.database + "?useSSL=" + this.ssl);
+        PS.debug("jdbc:mysql://" + this.hostname + ':' + this.port + '/' + this.database + "?useSSL=" + this.ssl + "&verifyServerCertificate=" + this.verifyssl);
         this.connection =
-                DriverManager.getConnection("jdbc:mysql://" + this.hostname + ':' + this.port + '/' + this.database + "?useSSL=" + this.ssl, this.user, this.password);
+                DriverManager.getConnection("jdbc:mysql://" + this.hostname + ':' + this.port + '/' + this.database + "?useSSL=" + this.ssl + "&verifyServerCertificate=" + this.verifyssl, this.user, this.password);
         return this.connection;
     }
 

--- a/Core/src/main/java/com/intellectualcrafters/plot/database/MySQL.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/database/MySQL.java
@@ -31,13 +31,15 @@ public class MySQL extends Database {
      * @param database Database name
      * @param username Username
      * @param password Password
+     * @param ssl      SSL
      */
-    public MySQL(String hostname, String port, String database, String username, String password) {
+    public MySQL(String hostname, String port, String database, String username, String password, String ssl) {
         this.hostname = hostname;
         this.port = port;
         this.database = database;
         this.user = username;
         this.password = password;
+        this.ssl = ssl;
         this.connection = null;
     }
 
@@ -45,7 +47,7 @@ public class MySQL extends Database {
     public Connection forceConnection() throws SQLException, ClassNotFoundException {
         Class.forName("com.mysql.jdbc.Driver");
         this.connection =
-                DriverManager.getConnection("jdbc:mysql://" + this.hostname + ':' + this.port + '/' + this.database + "?useSSL=false", this.user, this.password);
+                DriverManager.getConnection("jdbc:mysql://" + this.hostname + ':' + this.port + '/' + this.database + "?useSSL=" + this.ssl, this.user, this.password);
         return this.connection;
     }
 
@@ -55,9 +57,9 @@ public class MySQL extends Database {
             return this.connection;
         }
         Class.forName("com.mysql.jdbc.Driver");
-        PS.debug("jdbc:mysql://" + this.hostname + ':' + this.port + '/' + this.database + "?useSSL=false");
+        PS.debug("jdbc:mysql://" + this.hostname + ':' + this.port + '/' + this.database + "?useSSL=" + this.ssl);
         this.connection =
-                DriverManager.getConnection("jdbc:mysql://" + this.hostname + ':' + this.port + '/' + this.database + "?useSSL=false", this.user, this.password);
+                DriverManager.getConnection("jdbc:mysql://" + this.hostname + ':' + this.port + '/' + this.database + "?useSSL=" + this.ssl, this.user, this.password);
         return this.connection;
     }
 


### PR DESCRIPTION
Some people may have ssl set up on their MySQL Databases, so I don't see the problem allowing people to enable it IMO.

By default, it will be set to false and has a message for people not to enable it if they didn't set it up on their servers.