### PR TITLE
fix: shulker-teleport in a other plot

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitMain.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitMain.java
@@ -99,8 +99,10 @@ import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Shulker;
 import org.bukkit.event.Listener;
 import org.bukkit.generator.ChunkGenerator;
+import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
@@ -469,6 +471,7 @@ public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain 
                                                         if (!(passenger instanceof Player) && entity.getMetadata("keep").isEmpty()) {
                                                             iterator.remove();
                                                             entity.remove();
+                                                            entity = null;
                                                         }
                                                     }
                                                 } else {
@@ -476,10 +479,32 @@ public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain 
                                                     if (!(passenger instanceof Player) && entity.getMetadata("keep").isEmpty()) {
                                                         iterator.remove();
                                                         entity.remove();
+                                                        entity = null;
                                                     }
                                                 }
                                             }
                                         }
+                                        
+                                        if (entity != null && BukkitUtil.getLocation(entity.getLocation()).isPlotArea()) {
+                                        	if (entity instanceof Shulker) {
+                                        		LivingEntity livingEntity = (LivingEntity) entity;
+                                        		if (entity.hasMetadata("ownerplot")) {
+                                        			if(!livingEntity.isLeashed() || !entity.hasMetadata("keep")) {
+                                        				PlotId originalPlotId = (PlotId) (!entity.getMetadata("ownerplot").isEmpty() ? entity.getMetadata("ownerplot").get(0).value() : null);
+                                        				PlotId currentPlotId = BukkitUtil.getLocation(entity.getLocation()).getPlot().getId();
+                                        				if(!originalPlotId.equals(currentPlotId)) {
+                                        					iterator.remove();
+                                        					entity.remove();
+                                        				}
+                                        				
+                                        			}
+                                        		}
+                                        		else {
+                                        			//This is to apply the metadata to already spawned shulkers (see EntitySpawnListener.java)
+                                        			entity.setMetadata("ownerplot", new FixedMetadataValue((Plugin) PS.get().IMP, BukkitUtil.getLocation(entity.getLocation()).getPlot().getId()));
+                                        		}
+    										}
+    									}
                                 }
                             }
                         } catch (Throwable e) {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitMain.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitMain.java
@@ -492,7 +492,7 @@ public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain 
                                         			if(!livingEntity.isLeashed() || !entity.hasMetadata("keep")) {
                                         				PlotId originalPlotId = (PlotId) (!entity.getMetadata("ownerplot").isEmpty() ? entity.getMetadata("ownerplot").get(0).value() : null);
                                         				PlotId currentPlotId = BukkitUtil.getLocation(entity.getLocation()).getPlot().getId();
-                                        				if(!originalPlotId.equals(currentPlotId)) {
+                                        				if(!currentPlotId.equals(originalPlotId)) {
                                         					iterator.remove();
                                         					entity.remove();
                                         				}
@@ -500,8 +500,10 @@ public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain 
                                         			}
                                         		}
                                         		else {
-                                        			//This is to apply the metadata to already spawned shulkers (see EntitySpawnListener.java)
-                                        			entity.setMetadata("ownerplot", new FixedMetadataValue((Plugin) PS.get().IMP, BukkitUtil.getLocation(entity.getLocation()).getPlot().getId()));
+                                                    if(!entity.hasMetadata("ownerplot")) {
+                                        				//This is to apply the metadata to already spawned shulkers (see EntitySpawnListener.java)
+                                            			entity.setMetadata("ownerplot", new FixedMetadataValue((Plugin) PS.get().IMP, BukkitUtil.getLocation(entity.getLocation()).getPlot().getId()));                                        				
+                                        			}
                                         		}
     										}
     									}

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/EntitySpawnListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/EntitySpawnListener.java
@@ -42,7 +42,9 @@ public class EntitySpawnListener implements Listener {
                     event.setCancelled(true);
                 }
             case SHULKER:
-            	entity.setMetadata("ownerplot", new FixedMetadataValue((Plugin) PS.get().IMP, plot.getId()));
+            	if(!entity.hasMetadata("ownerplot")) {
+            		entity.setMetadata("ownerplot", new FixedMetadataValue((Plugin) PS.get().IMP, plot.getId()));
+            	}
         }
     }
 }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/EntitySpawnListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/EntitySpawnListener.java
@@ -1,5 +1,6 @@
 package com.plotsquared.bukkit.listeners;
 
+import com.intellectualcrafters.plot.PS;
 import com.intellectualcrafters.plot.config.Settings;
 import com.intellectualcrafters.plot.flag.Flags;
 import com.intellectualcrafters.plot.object.Location;
@@ -11,6 +12,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntitySpawnEvent;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.plugin.Plugin;
 
 public class EntitySpawnListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -38,6 +41,8 @@ public class EntitySpawnListener implements Listener {
                 if (PlayerEvents.checkEntity(entity, plot)) {
                     event.setCancelled(true);
                 }
+            case SHULKER:
+            	entity.setMetadata("ownerplot", new FixedMetadataValue((Plugin) PS.get().IMP, plot.getId()));
         }
     }
 }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -1263,7 +1263,8 @@ public class PlayerEvents extends PlotListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBlockDispense(BlockDispenseEvent event) {
         Material type = event.getItem().getType();
-        if (type != Material.WATER_BUCKET && type != Material.LAVA_BUCKET) {
+        Material dispenserType = event.getBlock().getType();
+        if (dispenserType == Material.DROPPER || (type != Material.WATER_BUCKET && type != Material.LAVA_BUCKET)) {
             return;
         }
         Location location = BukkitUtil.getLocation(event.getVelocity().toLocation(event.getBlock().getWorld()));


### PR DESCRIPTION
shulker-teleport in a other plot #1762 

As we dont have an shulker teleport event. This is a workaround.

We assign to each shulker a new metadata (ownerplot) with the plotid of the shulker stays on

in the runEntityTask we check the shulker if it sill is on the original plot as it was spawnd. if not we delete it
