### PR TITLE
fix: numeric Playernames thows NumberFormatException on Teleport

### DIFF
--- a/Core/src/main/java/com/intellectualcrafters/plot/PS.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/PS.java
@@ -1968,17 +1968,14 @@ public class PS{
      * @param alias to search plots
      * @param worldname to filter alias to a specific world [optional] null means all worlds
      *
-     * @return Set<{@link Plot}> null if nothing found
+     * @return Set<{@link Plot}> empty if nothing found
      */
     public Set<Plot> getPlotsByAlias(String alias, String worldname) {
-    	Set<Plot> result = null;
+    	Set<Plot> result = new HashSet<>();
     	
     	if (alias != null) {
     		for (Plot plot : getPlots()) {
-    			if (alias.equals(plot.getAlias()) && (worldname == null || worldname.equals(plot.getWorldName()))) {
-    				if (result == null) {
-    					result = new HashSet<>();
-    				}
+    			if (alias.equals(plot.getAlias()) && (worldname == null || worldname.equals(plot.getWorldName()))) {    				
     				result.add(plot);    				
     			}
     		}

--- a/Core/src/main/java/com/intellectualcrafters/plot/PS.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/PS.java
@@ -1961,6 +1961,31 @@ public class PS{
             return null;
         }
     }
+    
+    /**
+     * Get Plots based on alias
+     *
+     * @param alias to search plots
+     * @param worldname to filter alias to a specific world [optional] null means all worlds
+     *
+     * @return Set<{@link Plot}> null if nothing found
+     */
+    public Set<Plot> getPlotsByAlias(String alias, String worldname) {
+    	Set<Plot> result = null;
+    	
+    	if (alias != null) {
+    		for (Plot plot : getPlots()) {
+    			if (alias.equals(plot.getAlias()) && (worldname == null || worldname.equals(plot.getWorldName()))) {
+    				if (result == null) {
+    					result = new HashSet<>();
+    				}
+    				result.add(plot);    				
+    			}
+    		}
+    	}
+    	
+    	return result;
+    }
 
     public Set<PlotArea> getPlotAreas(String world, RegionWrapper region) {
         PlotArea[] areas = manager.getPlotAreas(world, region);

--- a/Core/src/main/java/com/intellectualcrafters/plot/commands/Visit.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/commands/Visit.java
@@ -5,6 +5,7 @@ import com.intellectualcrafters.plot.config.C;
 import com.intellectualcrafters.plot.config.Settings;
 import com.intellectualcrafters.plot.object.Plot;
 import com.intellectualcrafters.plot.object.PlotArea;
+import com.intellectualcrafters.plot.object.PlotId;
 import com.intellectualcrafters.plot.object.PlotPlayer;
 import com.intellectualcrafters.plot.object.RunnableVal2;
 import com.intellectualcrafters.plot.object.RunnableVal3;
@@ -31,6 +32,9 @@ import java.util.UUID;
         category = CommandCategory.TELEPORT)
 public class Visit extends Command {
 
+	private final int PageOutOfRange = -998899; // this is to flag Page argument is to long. Can occur if someone enters a large number (some player uses numeric names)
+	private final int MaxPageRange = 100;
+	
     public Visit() {
         super(MainCommand.getInstance(), true);
     }
@@ -50,54 +54,48 @@ public class Visit extends Command {
         PlotArea sortByArea = player.getApplicablePlotArea();
         boolean shouldSortByArea = Settings.Teleport.PER_WORLD_VISIT;
         switch (args.length) {
-            case 3:
-                if (!MathMan.isInteger(args[1])) {
-                    C.NOT_VALID_NUMBER.send(player, "(1, ∞)");
-                    C.COMMAND_SYNTAX.send(player, getUsage());
-                    return;
-                }
-                page = Integer.parseInt(args[2]);
-            case 2:
-                if (!MathMan.isInteger(args[1])) {
-                    sortByArea = PS.get().getPlotAreaByString(args[1]);
-                    if (sortByArea == null) {
-                        C.NOT_VALID_NUMBER.send(player, "(1, ∞)");
-                        C.COMMAND_SYNTAX.send(player, getUsage());
-                        return;
-                    }
-                    UUID user = UUIDHandler.getUUIDFromString(args[0]);
-                    if (user == null) {
-                        C.COMMAND_SYNTAX.send(player, getUsage());
-                        return;
-                    }
-                    unsorted = PS.get().getBasePlots(user);
-                    shouldSortByArea = true;
-                    break;
-                }
-                page = Integer.parseInt(args[1]);
-            case 1:
-                UUID user = (args.length == 2 || !MathMan.isInteger(args[0])) ? UUIDHandler.getUUIDFromString(args[0]) : null;
-                if (page == Integer.MIN_VALUE && user == null && MathMan.isInteger(args[0])) {
-                    page = Integer.parseInt(args[0]);
-                    unsorted = PS.get().getBasePlots(player);
-                    break;
-                }
-                if (user != null) {
-                    unsorted = PS.get().getBasePlots(user);
-                } else {
-                    Plot plot = MainUtil.getPlotFromString(player, args[0], true);
-                    if (plot != null) {
-                        unsorted = Collections.singletonList(plot.getBasePlot(false));
-                    }
-                }
-                break;
-            case 0:
-                page = 1;
-                unsorted = PS.get().getPlots(player);
-                break;
-            default:
-
+        	case 2:
+        		if (MathMan.isInteger(args[1])) {
+        			page = tryReadPageIdFromArg(player, args[1]);
+        		} else {        			
+        			C.COMMAND_SYNTAX.send(player, getUsage());
+        			return;
+        		}
+        		// don't add break here. we handle the first argument in case 1
+        	case 1:
+        		boolean isCorrectSyntaxWithoutResults = false;
+        		Collection<Plot> plots = null;
+        		if (args[0] != null) {
+        			plots = getPlotsFromSingleArgument(args[0], sortByArea);
+            		if (plots != null) {
+            			unsorted = plots;        			
+            		} else {
+            			if (MathMan.isInteger(args[0])) {
+            				page = tryReadPageIdFromArg(player, args[0]);
+            				
+            				if (page != PageOutOfRange && page != Integer.MIN_VALUE) {
+            					unsorted = PS.get().getPlots(player);
+            				}
+            			} else {
+            				// we know now syntax is correct but no results.
+            				isCorrectSyntaxWithoutResults = true;
+            			}            				
+            		}
+        		}
+        		
+        		if (!isCorrectSyntaxWithoutResults && plots == null && page == Integer.MIN_VALUE) {        			
+        			C.COMMAND_SYNTAX.send(player, getUsage());
+        			return;
+        		}
+        		break;
+        	case 0:
+        		unsorted = PS.get().getPlots(player);
+        		break;
+        	default:
+        		C.COMMAND_SYNTAX.send(player, getUsage());
+    			return;        		
         }
+
         if (page == Integer.MIN_VALUE) {
             page = 1;
         }
@@ -112,7 +110,7 @@ public class Visit extends Command {
             }
         }
         if (page < 1 || page > unsorted.size()) {
-            C.NOT_VALID_NUMBER.send(player, "(1, " + unsorted.size() + ")");
+            C.NOT_VALID_NUMBER.send(player, "(1 - " + unsorted.size() + ")");
             return;
         }
         List<Plot> plots;
@@ -160,4 +158,62 @@ public class Visit extends Command {
         });
     }
 
+    /**
+     * Get Plots based on an unknown argument type
+     * Check order: Player, Alias, World, PlotId
+     * @param argument to search plots
+     * <pre>
+     * Samples:
+     * p h xPlotPlayerGuy	= Player [numeric] [alphanumeric] [UUID]
+     * p h MyPlantage		= Alias  [numeric] [alphanumeric] [Set<Plot>]
+     * p h PlotworldLarge	= World  [numeric] [alphanumeric] [PlotArea]
+     * p h 1:1		= plotId [numeric] (1,1|1;2)      [PlotId]
+     * </pre>
+     * @param applicablePlotArea the area from the player invoked the command
+     * @return Collection<{@link Plot}> null if nothing found
+     */
+    private Collection<Plot> getPlotsFromSingleArgument(String argument, PlotArea applicablePlotArea) {    	
+    	
+    	Collection<Plot> result = null;    	
+		UUID user = UUIDHandler.getUUIDFromString(argument);
+		if (user != null) {
+			result = PS.get().getBasePlots(user);
+		} else {
+			result = PS.get().getPlotsByAlias(argument, applicablePlotArea.worldname);
+		}
+		
+		if (result == null) {
+			PlotArea plotArea = PS.get().getPlotArea(argument, "0,0");
+			if (plotArea != null) {
+				result = plotArea.getBasePlots();
+			}
+		}
+		
+		if (result == null) {
+			PlotId plotId = PlotId.fromString(argument);
+			if (plotId != null) {
+				result = Collections.singletonList(applicablePlotArea.getPlot(plotId));				
+			}			
+		}
+				
+		return result != null && result.size() > 0 ? result : null;
+    }
+    
+    private int tryReadPageIdFromArg(PlotPlayer player, String arg) {
+    	int page = Integer.MIN_VALUE;    	
+    	
+    	try {
+    		if (MathMan.isInteger(arg)) {
+    			page = Integer.parseInt(arg);
+    			if (page > MaxPageRange) {
+    				page = PageOutOfRange;
+    			}
+    		}
+    	} catch (Exception ignored) {
+    		page = PageOutOfRange;
+    		C.NOT_VALID_NUMBER.send(player, "(1, ∞)");
+    	}
+    	
+    	return page;
+    }
 }


### PR DESCRIPTION
fix for #1691 

Refactoring of the Teleport Handling

Supports now:
     * p h xPlotPlayerGuy [PAGE] = Player  [numeric] [alphanumeric]
     * p h MyPlantage      [PAGE] = Alias    [numeric] [alphanumeric]
     * p h PlotworldLarge [PAGE] = World  [numeric] [alphanumeric]
     * p h 1:1		       [PAGE] = plotId  [numeric (1,1|1;2) ]
     * p h 4		                   = 4 th Plot of the Player if available  [numeric (1,1|1;2) ]
Check order: Player, Alias, World, PlotId, Page [PAGE]
[PAGE] is optional