### PR TITLE
improvements: Message for visit Command to a players without plots

### DIFF
--- a/Core/src/main/java/com/intellectualcrafters/plot/commands/Visit.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/commands/Visit.java
@@ -88,14 +88,23 @@ public class Visit extends Command {
         			C.COMMAND_SYNTAX.send(player, getUsage());
         			return;
         		}
-        		
-        		// we found nothing we now check for a combined command arg
-        		if((args[0].contains(";") || args[0].contains(",")) && (unsorted == null || unsorted.isEmpty())) {
-        			Plot plot = MainUtil.getPlotFromString(player, args[0], true);
-        			if (plot != null) {
-                        unsorted = Collections.singletonList(plot.getBasePlot(false));
-                    }
-        		}
+        				
+        		if(unsorted == null || unsorted.isEmpty()) {        			
+        			// we now check for a combined command arg
+        			if(args[0].contains(";") || args[0].contains(",")) {
+        				Plot plot = MainUtil.getPlotFromString(player, args[0], true);
+            			if (plot != null) {
+                            unsorted = Collections.singletonList(plot.getBasePlot(false));
+                        }
+        			} else { // its not a combined command check for player search without result
+        				UUID user = UUIDHandler.getUUIDFromString(args[0]);
+        				if(user != null) {            					
+        					// we know safe its a player (we can provide a specific message that we searched for player plots without result)
+        					MainUtil.sendMessage(player, C.FOUND_NO_PLOTS_FOR_PLAYER, UUIDHandler.getName(user));
+        					return;
+        				}
+        			}
+        		}        		
         		
         		break;
         	case 0:
@@ -224,7 +233,6 @@ public class Visit extends Command {
     		}
     	} catch (Exception ignored) {
     		page = PAGE_OUT_OF_RANGE;
-    		C.NOT_VALID_NUMBER.send(player, "(1, ∞)");
     	}
     	
     	return page;

--- a/Core/src/main/java/com/intellectualcrafters/plot/config/C.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/config/C.java
@@ -541,6 +541,7 @@ public enum C {
     NO_SUCH_PLOT("$2There is no such plot", "Invalid"),
     PLAYER_HAS_NOT_BEEN_ON("$2That player hasn't been in the plotworld", "Invalid"),
     FOUND_NO_PLOTS("$2Found no plots with your search query", "Invalid"),
+    FOUND_NO_PLOTS_FOR_PLAYER("$2No plots found for player: %s", "Invalid"),
     /*
      * Camera
      */


### PR DESCRIPTION
We provide now a clear message if we are sure that the Visit command means a player but we dont found any claimed plots for this player.

This is helpful if we try teleport to  a numeric named player

See this related tickets: #1691, #1778

Teststeps_A:
Try teleport to a known player without a claimed plot
/p h [playerName]
-> should gives you a message no plots found for player

Teststeps_B:
Try teleport to a unknown player without a claimed plot
/p h [playerName]
-> should gives you the general message no plots found