### PR TITLE
Improvement: Code refactoring (FLAG:misc-interact, frame-interact) (EVENT:interact-misc)

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -51,6 +51,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.Ageable;
 import org.bukkit.entity.Animals;
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Creature;
 import org.bukkit.entity.EnderDragon;
@@ -2200,7 +2201,10 @@ public class PlayerEvents extends PlotListener implements Listener {
             if (entity instanceof Villager && plot.getFlag(Flags.VILLAGER_INTERACT, false)) {
                 return;
             }
-            if (entity instanceof ItemFrame && plot.getFlag(Flags.MISC_INTERACT, false)) {
+            if (entity instanceof ItemFrame && plot.getFlag(Flags.FRAME_INTERACT, false)) {
+                return;
+            }
+            if (entity instanceof ArmorStand && plot.getFlag(Flags.MISC_INTERACT, false)) {
                 return;
             }
             if (!Permissions.hasPermission(pp, C.PERMISSION_ADMIN_INTERACT_OTHER)) {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents_1_8.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents_1_8.java
@@ -132,41 +132,4 @@ public class PlayerEvents_1_8 extends PlotListener implements Listener {
             event.setCursor(new ItemStack(newItem.getType(), newItem.getAmount(), newItem.getDurability()));
         }
     }
-    
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onInteract(PlayerInteractAtEntityEvent e) {
-        Entity entity = e.getRightClicked();
-        if (!(entity instanceof ArmorStand)) {
-            return;
-        }
-        Location l = BukkitUtil.getLocation(e.getRightClicked().getLocation());
-        PlotArea area = l.getPlotArea();
-        if (area == null) {
-            return;
-        }
-        Plot plot = area.getPlotAbs(l);
-        PlotPlayer pp = BukkitUtil.getPlayer(e.getPlayer());
-        if (plot == null) {
-            if (!Permissions.hasPermission(pp, "plots.admin.interact.road")) {
-                MainUtil.sendMessage(pp, C.NO_PERMISSION_EVENT, "plots.admin.interact.road");
-                e.setCancelled(true);
-            }
-        } else if (!plot.hasOwner()) {
-            if (!Permissions.hasPermission(pp, "plots.admin.interact.unowned")) {
-                MainUtil.sendMessage(pp, C.NO_PERMISSION_EVENT, "plots.admin.interact.unowned");
-                e.setCancelled(true);
-            }
-        } else {
-            UUID uuid = pp.getUUID();
-            if (!plot.isAdded(uuid)) {
-                if (Flags.MISC_INTERACT.isTrue(plot)) {
-                    return;
-                }
-                if (!Permissions.hasPermission(pp, "plots.admin.interact.other")) {
-                    MainUtil.sendMessage(pp, C.NO_PERMISSION_EVENT, "plots.admin.interact.other");
-                    e.setCancelled(true);
-                }
-            }
-        }
-    }
 }

--- a/Core/src/main/java/com/intellectualcrafters/plot/flag/Flags.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/flag/Flags.java
@@ -71,6 +71,7 @@ public final class Flags {
     public static final BooleanFlag MISC_PLACE = new BooleanFlag("misc-place");
     public static final BooleanFlag MISC_BREAK = new BooleanFlag("misc-break");
     public static final BooleanFlag MISC_INTERACT = new BooleanFlag("misc-interact");
+    public static final BooleanFlag FRAME_INTERACT = new BooleanFlag("frame-interact");
     public static final BooleanFlag VILLAGER_INTERACT = new BooleanFlag("villager-interact");
     public static final BooleanFlag PLAYER_INTERACT = new BooleanFlag("player-interact");
     public static final BooleanFlag TAMED_ATTACK = new BooleanFlag("tamed-attack");

--- a/Core/src/main/java/com/intellectualcrafters/plot/util/EventUtil.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/util/EventUtil.java
@@ -270,31 +270,6 @@ public abstract class EventUtil {
                 }
                 return true;
             }
-            case INTERACT_MISC: {
-                if (plot == null) {
-                    return Permissions.hasPermission(player, C.PERMISSION_ADMIN_INTERACT_ROAD.s(), notifyPerms);
-                }
-                if (!plot.hasOwner()) {
-                    return Permissions.hasPermission(player, C.PERMISSION_ADMIN_INTERACT_UNOWNED.s(), notifyPerms);
-                }
-                if (plot.getFlag(Flags.MISC_INTERACT).or(false)) {
-                    return true;
-                }
-                Optional<HashSet<PlotBlock>> flag = plot.getFlag(Flags.USE);
-                HashSet<PlotBlock> value;
-                if (flag.isPresent()) {
-                    value = flag.get();
-                } else {
-                    value = null;
-                }
-                if (value == null || !value.contains(PlotBlock.EVERYTHING) && !value.contains(block.getPlotBlock())) {
-                    if (Permissions.hasPermission(player, C.PERMISSION_ADMIN_INTERACT_OTHER.s(), false)) {
-                        return true;
-                    }
-                    return !(!notifyPerms || MainUtil.sendMessage(player, C.FLAG_TUTORIAL_USAGE, C.FLAG_USE.s() + '/' + C.FLAG_MISC_INTERACT.s()));
-                }
-                return true;
-            }
             case INTERACT_VEHICLE: {
                 if (plot == null) {
                     return Permissions.hasPermission(player, C.PERMISSION_ADMIN_INTERACT_ROAD.s(), notifyPerms);

--- a/Core/src/main/java/com/plotsquared/listener/PlayerBlockEventType.java
+++ b/Core/src/main/java/com/plotsquared/listener/PlayerBlockEventType.java
@@ -28,8 +28,6 @@ public enum PlayerBlockEventType {
     BREAK_HANGING,
     BREAK_VEHICLE,
     
-    // armor stands
-    INTERACT_MISC,
     // blocks
     INTERACT_BLOCK,
     // vehicle


### PR DESCRIPTION
Final goal make the code more readable and clear. #1798

The improvement is located here PlayerEvents_1_8.onInteract(PlayerInteractAtEntityEvent e)
Added in commit: 93c4854

Step 1:
Suggestion remove the special handling for AmorStand from the PlayerEvents_1_8.class and move it to the PlayerEvent.class

Step 2:
Refactoring the misc-interact flag and the interact-misc event.
After understanding the current code i came to the point. That the moving the handling for AmorStand to PlayerEvents makes most of the code obsolete since PlayerEvents.class handles all that stuff.

Step 3:
Remove unused code
The case INTERACT_MISC in EventUtil is unused -> no one set at any time the EventType for that
Remove the EventType INTERACT_MISC itself -> not used anymore

Step 4:
Add a new flag frame-interact for item frame this is for player that want seperate the interact between
ItemFrame and AmorStand