### PR TITLE
Fix NPE produced by Stacktrace below - I suspect this might have been…

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitMain.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitMain.java
@@ -49,6 +49,8 @@ import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 
+import javax.annotation.Nonnull;
+
 import static com.intellectualcrafters.plot.util.ReflectionUtils.getRefClass;
 
 public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain {
@@ -316,6 +318,7 @@ public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain 
                             Iterator<Entity> iterator = entities.iterator();
                             while (iterator.hasNext()) {
                                 Entity entity = iterator.next();
+                                if(entity == null)continue;
                                 switch (entity.getType()) {
                                     case EGG:
                                     case COMPLEX_PART:
@@ -446,23 +449,18 @@ public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain 
                                                 if (entity instanceof LivingEntity) {
                                                     LivingEntity livingEntity = (LivingEntity) entity;
                                                     if (!livingEntity.isLeashed() || !entity.hasMetadata("keep")) {
-                                                        Entity passenger = entity.getPassenger();
-                                                        if (!(passenger instanceof Player) && entity.getMetadata("keep").isEmpty()) {
-                                                            iterator.remove();
-                                                            entity.remove();
-                                                            entity = null;
-                                                        }
+                                                        List<Entity> passengers = entity.getPassengers();
+                                                        removeEntityVehicles(entity, passengers);
                                                     }
                                                 } else {
-                                                    Entity passenger = entity.getPassenger();
-                                                    if (!(passenger instanceof Player) && entity.getMetadata("keep").isEmpty()) {
-                                                        iterator.remove();
-                                                        entity.remove();
-                                                        entity = null;
-                                                    }
+                                                    List<Entity> passengers = entity.getPassengers();
+                                                    removeEntityVehicles(entity, passengers);
+
                                                 }
+                                                if(entity == null)continue;
                                             }
                                         }
+                                        break;
                                     }
                                     case SHULKER: {
                                         if (Settings.Enabled_Components.KILL_ROAD_MOBS) {
@@ -494,6 +492,16 @@ public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain 
                 });
             }
         }, 20);
+    }
+
+    private void removeEntityVehicles(Entity entity, List<Entity> passengers) {
+        for(Entity passenger:passengers) {
+            if(entity == null)return;
+            if (!(passenger instanceof Player) && entity.getMetadata("keep").isEmpty()) {
+                entity.remove();
+                entity = null;
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
… cause by the fact the switch could set an entity to null and then fall through to the shulker code

java.lang.NullPointerException2018-03-10 04:40:18 [Server thread/WARN]:at com.plotsquared.bukkit.BukkitMain$4$1.run(BukkitMain.java:473)
2018-03-10 04:40:18 [Server thread/WARN]:at com.plotsquared.bukkit.BukkitMain$4$1.run(BukkitMain.java:307)
2018-03-10 04:40:18 [Server thread/WARN]:at com.intellectualcrafters.plot.PS.foreachPlotArea(PS.java:1801)
2018-03-10 04:40:18 [Server thread/WARN]:at com.plotsquared.bukkit.BukkitMain$4.run(BukkitMain.java:307)
2018-03-10 04:40:18 [Server thread/WARN]:at org.bukkit.craftbukkit.v1_12_R1.scheduler.CraftTask.run(CraftTask.java:71)
2018-03-10 04:40:18 [Server thread/WARN]:at org.bukkit.craftbukkit.v1_12_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:353)
2018-03-10 04:40:18 [Server thread/WARN]:at net.minecraft.server.v1_12_R1.MinecraftServer.D(MinecraftServer.java:739)
2018-03-10 04:40:18 [Server thread/WARN]:at net.minecraft.server.v1_12_R1.DedicatedServer.D(DedicatedServer.java:406)
2018-03-10 04:40:18 [Server thread/WARN]:at net.minecraft.server.v1_12_R1.MinecraftServer.C(MinecraftServer.java:679)
2018-03-10 04:40:18 [Server thread/WARN]:at net.minecraft.server.v1_12_R1.MinecraftServer.run(MinecraftServer.java:577)
2018-03-10 04:40:18 [Server thread/WARN]:at java.lang.Thread.run(Thread.java:748)