### PR TITLE
Fix errors with tab completion on Sponge.

### DIFF
--- a/Sponge/src/main/java/com/plotsquared/sponge/util/SpongeCommand.java
+++ b/Sponge/src/main/java/com/plotsquared/sponge/util/SpongeCommand.java
@@ -1,5 +1,6 @@
 package com.plotsquared.sponge.util;
 
+import com.google.common.collect.ImmutableList;
 import com.intellectualcrafters.plot.commands.MainCommand;
 import com.intellectualcrafters.plot.object.ConsolePlayer;
 import com.intellectualcrafters.plot.object.PlotPlayer;
@@ -47,7 +48,7 @@ public class SpongeCommand implements CommandCallable {
     public List<String> getSuggestions(CommandSource source, String arguments, Location<World> targetPosition)
             throws CommandException {
         if (!(source instanceof Player)) {
-            return null;
+            return ImmutableList.of();
         }
         PlotPlayer player = SpongeUtil.getPlayer((Player) source);
         String[] args = arguments.split(" ");
@@ -56,13 +57,13 @@ public class SpongeCommand implements CommandCallable {
         }
         Collection objects = MainCommand.getInstance().tab(player, args, arguments.endsWith(" "));
         if (objects == null) {
-            return null;
+            return ImmutableList.of();
         }
         List<String> result = new ArrayList<>();
         for (Object o : objects) {
             result.add(o.toString());
         }
-        return result.isEmpty() ? null : result;
+        return result;
     }
 
     @Override


### PR DESCRIPTION
In Sponge, `CommandCallable#getSuggestions` is [marked as `Nonnull` at a package level](https://github.com/SpongePowered/SpongeAPI/blob/bleeding/src/main/java/org/spongepowered/api/command/package-info.java). As a result, our implementation of Sponge assumes that `getSuggestions` returns a list, even if it is empty, and processes tab completions based on that.

In PlotSquared, you're currently using `null` to indicate no choices, which is causing tab completion errors as shown in #1768 because we use the return value to create our own list. PlotSquared's Sponge commands should be returning an empty list instead - which is what this PR does.