### PR TITLE
fix dispensers

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -1322,12 +1322,13 @@ public class PlayerEvents extends PlotListener implements Listener {
             case WATER_BUCKET:
             case LAVA_BUCKET: {
                 if (event.getBlock().getType() == Material.DROPPER) return;
+                BlockFace targetFace = ((org.bukkit.material.Dispenser) event.getBlock().getState().getData()).getFacing();
+                Location location = BukkitUtil.getLocation(event.getBlock().getRelative(targetFace).getLocation());
+                if (location.isPlotRoad()) {
+                    event.setCancelled(true);
+                }
             }
-        }
-        Location location = BukkitUtil.getLocation(event.getVelocity().toLocation(event.getBlock().getWorld()));
-        if (location.isPlotRoad()) {
-            event.setCancelled(true);
-        }
+        } 
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)


### PR DESCRIPTION
previously dispensers were not working at all, this change blocks lava and water and allows dispensers to function normally again on servers with plotsquared. if you were trying to block dispensers launching items into the road however that still is not blocked by this