### PR TITLE
[Core] Fix listener to actually use guest gamemode flag

### DIFF
--- a/Core/src/main/java/com/plotsquared/listener/PlotListener.java
+++ b/Core/src/main/java/com/plotsquared/listener/PlotListener.java
@@ -99,13 +99,13 @@ public class PlotListener {
                     }
                 }
                 Optional<PlotGameMode> guestGamemodeFlag = plot.getFlag(Flags.GUEST_GAMEMODE);
-                if (gamemodeFlag.isPresent()) {
-                    if (player.getGameMode() != gamemodeFlag.get() && !plot.isAdded(player.getUUID())) {
+                if (guestGamemodeFlag.isPresent()) {
+                    if (player.getGameMode() != guestGamemodeFlag.get() && !plot.isAdded(player.getUUID())) {
                         if (!Permissions.hasPermission(player, "plots.gamemode.bypass")) {
-                            player.setGameMode(gamemodeFlag.get());
+                            player.setGameMode(guestGamemodeFlag.get());
                         } else {
                             MainUtil.sendMessage(player,
-                                    StringMan.replaceAll(C.GAMEMODE_WAS_BYPASSED.s(), "{plot}", plot.getId(), "{gamemode}", gamemodeFlag.get()));
+                                    StringMan.replaceAll(C.GAMEMODE_WAS_BYPASSED.s(), "{plot}", plot.getId(), "{gamemode}", guestGamemodeFlag.get()));
                         }
                     }
                 }

--- a/Core/src/main/java/com/plotsquared/listener/PlotListener.java
+++ b/Core/src/main/java/com/plotsquared/listener/PlotListener.java
@@ -87,20 +87,10 @@ public class PlotListener {
                         player.setFlight(flyFlag.get());
                     }
                 }
-                Optional<PlotGameMode> gamemodeFlag = plot.getFlag(Flags.GAMEMODE);
-                if (gamemodeFlag.isPresent()) {
-                    if (player.getGameMode() != gamemodeFlag.get()) {
-                        if (!Permissions.hasPermission(player, "plots.gamemode.bypass")) {
-                            player.setGameMode(gamemodeFlag.get());
-                        } else {
-                            MainUtil.sendMessage(player,
-                                    StringMan.replaceAll(C.GAMEMODE_WAS_BYPASSED.s(), "{plot}", plot.getId(), "{gamemode}", gamemodeFlag.get()));
-                        }
-                    }
-                }
+
                 Optional<PlotGameMode> guestGamemodeFlag = plot.getFlag(Flags.GUEST_GAMEMODE);
-                if (guestGamemodeFlag.isPresent()) {
-                    if (player.getGameMode() != guestGamemodeFlag.get() && !plot.isAdded(player.getUUID())) {
+                if (guestGamemodeFlag.isPresent() && !plot.isAdded(player.getUUID())) {
+                    if (player.getGameMode() != guestGamemodeFlag.get()) {
                         if (!Permissions.hasPermission(player, "plots.gamemode.bypass")) {
                             player.setGameMode(guestGamemodeFlag.get());
                         } else {
@@ -108,7 +98,20 @@ public class PlotListener {
                                     StringMan.replaceAll(C.GAMEMODE_WAS_BYPASSED.s(), "{plot}", plot.getId(), "{gamemode}", guestGamemodeFlag.get()));
                         }
                     }
+                } else {
+                    Optional<PlotGameMode> gamemodeFlag = plot.getFlag(Flags.GAMEMODE);
+                    if (gamemodeFlag.isPresent()) {
+                        if (player.getGameMode() != gamemodeFlag.get()) {
+                            if (!Permissions.hasPermission(player, "plots.gamemode.bypass")) {
+                                player.setGameMode(gamemodeFlag.get());
+                            } else {
+                                MainUtil.sendMessage(player,
+                                        StringMan.replaceAll(C.GAMEMODE_WAS_BYPASSED.s(), "{plot}", plot.getId(), "{gamemode}", gamemodeFlag.get()));
+                            }
+                        }
+                    }
                 }
+
                 Optional<Long> timeFlag = plot.getFlag(Flags.TIME);
                 if (timeFlag.isPresent()) {
                     try {


### PR DESCRIPTION
I noticed a mistake where the guest gamemode flag wasn't used when it looks as though it was intended to be. I fixed that and removed a redundant check for the regular gamemode flag when the guest gamemode flag applies. That means the gamemode flag is used for guests if it's present and the guest gamemode flag isn't.
