### PR TITLE
Fixed plot owner UUIDs getting unnecessarily randomized.

### DIFF
--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/database/plotme/ClassicPlotMeConnector.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/database/plotme/ClassicPlotMeConnector.java
@@ -116,10 +116,10 @@ public class ClassicPlotMeConnector extends APlotMeConnector {
                         PlotSquared.log(
                             "&cCould not identify owner for plot: " + id + " -> '" + name + "'");
                         missing++;
+                        owner = UUID.nameUUIDFromBytes(
+                            ("OfflinePlayer:" + name.toLowerCase()).getBytes(Charsets.UTF_8));
                         continue;
                     }
-                    owner = UUID.nameUUIDFromBytes(
-                        ("OfflinePlayer:" + name.toLowerCase()).getBytes(Charsets.UTF_8));
                 }
             } else {
                 UUIDHandler.add(new StringWrapper(name), owner);


### PR DESCRIPTION
While migrating our server from PlotMe to PlotSquared during our 1.12 to 1.13 transition, we had a major issue where many people were losing ownership of a single plot after the database migration. Any affected plot would simply list "Unknown" as the owner.

We looked in the database and compared owner UUIDs between the original PlotMe database and the migrated PlotSquared database and observed that any affected plot would have a random UUID set as the owner.

I dug into the source and came across what I am pretty sure caused the issue. During database migration, it appears that for every plot it encounters, it consults its local UUID dictionary to see if it already knows what UUID corresponds to the owner's name. If it doesn't find one, it extracts it from PlotMe's database and saves it. The issue is that even though it has extracted and saved the UUID and now it knows the UUID for the owner for the plot, it then generates a new UUID because it still thinks it never found a UUID for the player name. The reason only a single plot for each person is affected by this is because when it comes across another plot owned by the same person, PlotSquared now has their UUID in the dictionary so it skips the problematic regeneration.

We managed to fix this for us by moving the random UUID generator inside the block that declares the plot missing. We have used this patch in our production environment and it has fixed everyone's plot ownership after the database was remigrated.