### PR TITLE
Fixed plot merge keep road without permission

### DIFF
--- a/Core/src/main/java/com/intellectualcrafters/plot/commands/Merge.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/commands/Merge.java
@@ -102,10 +102,15 @@ public class Merge extends SubCommand {
             }
         } else {
             if ("all".equalsIgnoreCase(args[0]) || "auto".equalsIgnoreCase(args[0])) {
-                boolean terrain = true;
-                if (args.length == 2) {
-                    terrain = "true".equalsIgnoreCase(args[1]);
+                boolean terrain = args.length == 2
+                        ? Boolean.valueOf(args[1])
+                        : true;
+
+                if(!terrain && !Permissions.hasPermission(player, C.PERMISSION_MERGE_TERRAIN)) {
+                    MainUtil.sendMessage(player, C.NO_PERMISSION, C.PERMISSION_MERGE_TERRAIN.s());
+                    return true;
                 }
+
                 if (plot.autoMerge(-1, maxSize, uuid, terrain)) {
                     if (EconHandler.manager != null && plotArea.USE_ECONOMY && price > 0d) {
                         EconHandler.manager.withdrawMoney(player, price);
@@ -130,12 +135,16 @@ public class Merge extends SubCommand {
             MainUtil.sendMessage(player, C.DIRECTION.s().replaceAll("%dir%", direction(loc.getYaw())));
             return false;
         }
-        final boolean terrain;
-        if (args.length == 2) {
-            terrain = "true".equalsIgnoreCase(args[1]);
-        } else {
-            terrain = true;
+
+        final boolean terrain = args.length == 2
+                ? Boolean.valueOf(args[1])
+                : true;
+
+        if(!terrain && !Permissions.hasPermission(player, C.PERMISSION_MERGE_TERRAIN)) {
+            MainUtil.sendMessage(player, C.NO_PERMISSION, C.PERMISSION_MERGE_TERRAIN.s());
+            return true;
         }
+
         if (plot.autoMerge(direction, maxSize - size, uuid, terrain)) {
             if (EconHandler.manager != null && plotArea.USE_ECONOMY && price > 0d) {
                 EconHandler.manager.withdrawMoney(player, price);

--- a/Core/src/main/java/com/intellectualcrafters/plot/commands/Merge.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/commands/Merge.java
@@ -106,8 +106,8 @@ public class Merge extends SubCommand {
                         ? Boolean.valueOf(args[1])
                         : true;
 
-                if(!terrain && !Permissions.hasPermission(player, C.PERMISSION_MERGE_TERRAIN)) {
-                    MainUtil.sendMessage(player, C.NO_PERMISSION, C.PERMISSION_MERGE_TERRAIN.s());
+                if(!terrain && !Permissions.hasPermission(player, C.PERMISSION_MERGE_KEEPROAD)) {
+                    MainUtil.sendMessage(player, C.NO_PERMISSION, C.PERMISSION_MERGE_KEEPROAD.s());
                     return true;
                 }
 
@@ -140,8 +140,8 @@ public class Merge extends SubCommand {
                 ? Boolean.valueOf(args[1])
                 : true;
 
-        if(!terrain && !Permissions.hasPermission(player, C.PERMISSION_MERGE_TERRAIN)) {
-            MainUtil.sendMessage(player, C.NO_PERMISSION, C.PERMISSION_MERGE_TERRAIN.s());
+        if(!terrain && !Permissions.hasPermission(player, C.PERMISSION_MERGE_KEEPROAD)) {
+            MainUtil.sendMessage(player, C.NO_PERMISSION, C.PERMISSION_MERGE_KEEPROAD.s());
             return true;
         }
 

--- a/Core/src/main/java/com/intellectualcrafters/plot/config/C.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/config/C.java
@@ -59,6 +59,7 @@ public enum C {
     PERMISSION_ADMIN_ENTRY_FORCEFIELD("plots.admin.entry.forcefield", "static.permissions"),
     PERMISSION_COMMANDS_CHAT("plots.admin.command.chat", "static.permissions"),
     PERMISSION_MERGE_OTHER("plots.merge.other", "static.permissions"),
+    PERMISSION_MERGE_TERRAIN("plots.merge.terrain", "static.permissions"),
     PERMISSION_ADMIN_DESTROY_UNOWNED("plots.admin.destroy.unowned", "static.permissions"),
     PERMISSION_ADMIN_DESTROY_GROUNDLEVEL("plots.admin.destroy.groundlevel", "static.permissions"),
     PERMISSION_ADMIN_DESTROY_OTHER("plots.admin.destroy.other", "static.permissions"),

--- a/Core/src/main/java/com/intellectualcrafters/plot/config/C.java
+++ b/Core/src/main/java/com/intellectualcrafters/plot/config/C.java
@@ -59,7 +59,7 @@ public enum C {
     PERMISSION_ADMIN_ENTRY_FORCEFIELD("plots.admin.entry.forcefield", "static.permissions"),
     PERMISSION_COMMANDS_CHAT("plots.admin.command.chat", "static.permissions"),
     PERMISSION_MERGE_OTHER("plots.merge.other", "static.permissions"),
-    PERMISSION_MERGE_TERRAIN("plots.merge.terrain", "static.permissions"),
+    PERMISSION_MERGE_KEEPROAD("plots.merge.keeproad", "static.permissions"),
     PERMISSION_ADMIN_DESTROY_UNOWNED("plots.admin.destroy.unowned", "static.permissions"),
     PERMISSION_ADMIN_DESTROY_GROUNDLEVEL("plots.admin.destroy.groundlevel", "static.permissions"),
     PERMISSION_ADMIN_DESTROY_OTHER("plots.admin.destroy.other", "static.permissions"),


### PR DESCRIPTION
Fixes the problem that you do not need an explicit permission to merge two plots without removing the road. This allows you to break down the road and keep the resources.