### PR TITLE
Players are able to bypass border

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -537,7 +537,6 @@ public class PlayerEvents extends PlotListener implements Listener {
                     plotEntry(pp, plot);
                 }
             }
-            return;
         }
         playerMove(event);
     }
@@ -667,7 +666,6 @@ public class PlayerEvents extends PlotListener implements Listener {
                 }
             } else if (now.equals(lastPlot)) {
                 ForceFieldListener.handleForcefield(player, pp, now);
-                return;
             } else if (!plotEntry(pp, now) && this.tmpTeleport) {
                 MainUtil.sendMessage(pp, C.NO_PERMISSION_EVENT, C.PERMISSION_ADMIN_ENTRY_DENIED);
                 this.tmpTeleport = false;
@@ -685,7 +683,6 @@ public class PlayerEvents extends PlotListener implements Listener {
                 player.teleport(event.getTo());
                 this.tmpTeleport = true;
                 MainUtil.sendMessage(pp, C.BORDER);
-                return;
             }
             if (x2 < -border && this.tmpTeleport) {
                 to.setX(-border + 1);
@@ -693,9 +690,7 @@ public class PlayerEvents extends PlotListener implements Listener {
                 player.teleport(event.getTo());
                 this.tmpTeleport = true;
                 MainUtil.sendMessage(pp, C.BORDER);
-                return;
             }
-            return;
         }
         int z2;
         if (MathMan.roundInt(from.getZ()) != (z2 = MathMan.roundInt(to.getZ()))) {
@@ -728,7 +723,6 @@ public class PlayerEvents extends PlotListener implements Listener {
                 }
             } else if (now.equals(lastPlot)) {
                 ForceFieldListener.handleForcefield(player, pp, now);
-                return;
             } else if (!plotEntry(pp, now) && this.tmpTeleport) {
                 MainUtil.sendMessage(pp, C.NO_PERMISSION_EVENT, C.PERMISSION_ADMIN_ENTRY_DENIED);
                 this.tmpTeleport = false;

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -680,7 +680,7 @@ public class PlayerEvents extends PlotListener implements Listener {
             }
             Integer border = area.getBorder();
             if (x2 > border && this.tmpTeleport) {
-                to.setX(x2 - 1);
+                to.setX(border - 1);
                 this.tmpTeleport = false;
                 player.teleport(event.getTo());
                 this.tmpTeleport = true;
@@ -688,7 +688,7 @@ public class PlayerEvents extends PlotListener implements Listener {
                 return;
             }
             if (x2 < -border && this.tmpTeleport) {
-                to.setX(x2 + 1);
+                to.setX(-border + 1);
                 this.tmpTeleport = false;
                 player.teleport(event.getTo());
                 this.tmpTeleport = true;
@@ -742,13 +742,13 @@ public class PlayerEvents extends PlotListener implements Listener {
             }
             Integer border = area.getBorder();
             if (z2 > border && this.tmpTeleport) {
-                to.setZ(z2 - 1);
+                to.setZ(border - 1);
                 this.tmpTeleport = false;
                 player.teleport(event.getTo());
                 this.tmpTeleport = true;
                 MainUtil.sendMessage(pp, C.BORDER);
             } else if (z2 < -border && this.tmpTeleport) {
-                to.setZ(z2 + 1);
+                to.setZ(-border + 1);
                 this.tmpTeleport = false;
                 player.teleport(event.getTo());
                 this.tmpTeleport = true;


### PR DESCRIPTION
Currently players are able to bypass the worldborder as described in #2249 
This can be done by  using sprint flight agains the border while flying at a specific angle. It is also possible to bypass the border at the edges. Another way is to use enderpearls.

This PR forces players back inside the border instead of just teleporting them a block back. (first commit)

The second commit is needed so that enderpearl teleports are properly detected. A few returns stopped the processing before the border would be checked, or stopped the processing before the z axis would be checked.

With these changes I was no longer able to bypass the border using creative flight, enderpearls and the minecraft tp command.