### PR TITLE
Plot schematic fix

### DIFF
--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/util/block/BukkitLocalQueue.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/util/block/BukkitLocalQueue.java
@@ -70,11 +70,7 @@ public class BukkitLocalQueue<T> extends BasicLocalBlockQueue<T> {
     }
 
     @Override public final void setComponents(LocalChunk<T> lc) {
-        if (isBaseBlocks()) {
-            setBaseBlocks(lc);
-        } else {
-            setBlocks(lc);
-        }
+        setBaseBlocks(lc);
     }
 
     public World getBukkitWorld() {
@@ -83,30 +79,6 @@ public class BukkitLocalQueue<T> extends BasicLocalBlockQueue<T> {
 
     public Chunk getChunk(int x, int z) {
         return getBukkitWorld().getChunkAt(x, z);
-    }
-
-    public void setBlocks(LocalChunk<T> lc) {
-        World worldObj = Bukkit.getWorld(getWorld());
-        Chunk chunk = worldObj.getChunkAt(lc.getX(), lc.getZ());
-        chunk.load(true);
-        for (int layer = 0; layer < lc.blocks.length; layer++) {
-            PlotBlock[] blocksLayer = (PlotBlock[]) lc.blocks[layer];
-            if (blocksLayer != null) {
-                for (int j = 0; j < blocksLayer.length; j++) {
-                    if (blocksLayer[j] != null) {
-                        PlotBlock block = blocksLayer[j];
-                        int x = MainUtil.x_loc[layer][j];
-                        int y = MainUtil.y_loc[layer][j];
-                        int z = MainUtil.z_loc[layer][j];
-                        Block existing = chunk.getBlock(x, y, z);
-                        if (equals(block, existing)) {
-                            continue;
-                        }
-                        setMaterial(block, existing);
-                    }
-                }
-            }
-        }
     }
 
     public void setBaseBlocks(LocalChunk<T> lc) {

--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/util/block/BukkitLocalQueue.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/util/block/BukkitLocalQueue.java
@@ -21,14 +21,14 @@ import org.bukkit.block.data.BlockData;
 
 import java.util.Locale;
 
-public class BukkitLocalQueue<T> extends BasicLocalBlockQueue<T> {
+public class BukkitLocalQueue extends BasicLocalBlockQueue {
 
     public BukkitLocalQueue(String world) {
         super(world);
     }
 
-    @Override public LocalChunk<T> getLocalChunk(int x, int z) {
-        return (LocalChunk<T>) new BasicLocalChunk(this, x, z) {
+    @Override public LocalChunk getLocalChunk(int x, int z) {
+        return new BasicLocalChunk(this, x, z) {
             // Custom stuff?
         };
     }
@@ -69,7 +69,7 @@ public class BukkitLocalQueue<T> extends BasicLocalBlockQueue<T> {
         }
     }
 
-    @Override public final void setComponents(LocalChunk<T> lc) {
+    @Override public final void setComponents(LocalChunk lc) {
         setBaseBlocks(lc);
     }
 
@@ -81,7 +81,7 @@ public class BukkitLocalQueue<T> extends BasicLocalBlockQueue<T> {
         return getBukkitWorld().getChunkAt(x, z);
     }
 
-    public void setBaseBlocks(LocalChunk<T> lc) {
+    public void setBaseBlocks(LocalChunk lc) {
         World worldObj = Bukkit.getWorld(getWorld());
         Chunk chunk = worldObj.getChunkAt(lc.getX(), lc.getZ());
         chunk.load(true);
@@ -152,7 +152,7 @@ public class BukkitLocalQueue<T> extends BasicLocalBlockQueue<T> {
             legacyPlotBlock.id == 0 || legacyPlotBlock.data == block.getData());
     }
 
-    public void setBiomes(LocalChunk<T> lc) {
+    public void setBiomes(LocalChunk lc) {
         if (lc.biomes != null) {
             World worldObj = Bukkit.getWorld(getWorld());
             int bx = lc.getX() << 4;

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridPlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridPlotManager.java
@@ -81,6 +81,7 @@ public class HybridPlotManager extends ClassicPlotManager {
         } else {
             minY = 1;
         }
+        BaseBlock airBlock = BlockTypes.AIR.getDefaultState().toBaseBlock();
         for (int x = pos1.getX(); x <= pos2.getX(); x++) {
             short absX = (short) ((x - hpw.ROAD_OFFSET_X) % size);
             if (absX < 0) {
@@ -98,7 +99,7 @@ public class HybridPlotManager extends ClassicPlotManager {
                             queue.setBlock(x, minY + y, z, blocks[y]);
                         } else {
                             // This is necessary, otherwise any blocks not specified in the schematic will remain after a clear
-                            queue.setBlock(x, minY + y, z, BlockTypes.AIR.getDefaultState().toBaseBlock());
+                            queue.setBlock(x, minY + y, z, airBlock);
                         }
                     }
                 }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridPlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridPlotManager.java
@@ -11,7 +11,7 @@ import com.github.intellectualsites.plotsquared.plot.util.block.GlobalBlockQueue
 import com.github.intellectualsites.plotsquared.plot.util.block.LocalBlockQueue;
 import com.google.common.collect.Sets;
 import com.sk89q.worldedit.world.block.BaseBlock;
-
+import com.sk89q.worldedit.world.block.BlockTypes;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -96,6 +96,9 @@ public class HybridPlotManager extends ClassicPlotManager {
                     for (int y = 0; y < blocks.length; y++) {
                         if (blocks[y] != null) {
                             queue.setBlock(x, minY + y, z, blocks[y]);
+                        } else {
+                            // This is necessary, otherwise any blocks not specified in the schematic will remain after a clear
+                            queue.setBlock(x, minY + y, z, BlockTypes.AIR.getDefaultState().toBaseBlock());
                         }
                     }
                 }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/LegacyPlotBlock.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/LegacyPlotBlock.java
@@ -1,6 +1,10 @@
 package com.github.intellectualsites.plotsquared.plot.object;
 
+import com.sk89q.worldedit.world.block.BaseBlock;
+import com.sk89q.worldedit.world.block.BlockTypes;
+import com.sk89q.worldedit.world.registry.LegacyMapper;
 import lombok.Getter;
+import lombok.Setter;
 
 public class LegacyPlotBlock extends PlotBlock {
 
@@ -15,6 +19,7 @@ public class LegacyPlotBlock extends PlotBlock {
         }
     }
 
+    @Setter private BaseBlock baseBlock = null;
     @Getter public final short id;
     @Getter public final byte data;
 
@@ -25,6 +30,13 @@ public class LegacyPlotBlock extends PlotBlock {
 
     @Override public Object getRawId() {
         return this.id;
+    }
+
+    @Override public BaseBlock getBaseBlock() {
+        if (baseBlock == null) {
+            baseBlock = LegacyMapper.getInstance().getBlockFromLegacy(id, data).toBaseBlock();
+        }
+        return baseBlock;
     }
 
     @Override public boolean isAir() {

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotBlock.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotBlock.java
@@ -133,4 +133,6 @@ public abstract class PlotBlock implements ConfigurationSerializable {
 
     public abstract Object getRawId();
 
+    public abstract BaseBlock getBaseBlock();
+
 }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/StringPlotBlock.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/StringPlotBlock.java
@@ -1,6 +1,7 @@
 package com.github.intellectualsites.plotsquared.plot.object;
 
 import com.sk89q.worldedit.world.block.BaseBlock;
+import com.sk89q.worldedit.world.block.BlockTypes;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -15,7 +16,7 @@ public class StringPlotBlock extends PlotBlock {
     private static final Map<String, StringPlotBlock> STRING_PLOT_BLOCK_CACHE = new HashMap<>();
     @Getter private final String nameSpace;
     @Getter private final String itemId;
-    @Getter @Setter private BaseBlock baseBlock = null;
+    @Setter private BaseBlock baseBlock = null;
     private boolean isForeign = false;
 
     public StringPlotBlock(@NonNull final String nameSpace, @NonNull final String itemId) {
@@ -77,6 +78,13 @@ public class StringPlotBlock extends PlotBlock {
 
     @Override public Object getRawId() {
         return this.getItemId();
+    }
+
+    @Override public BaseBlock getBaseBlock() {
+        if (baseBlock == null) {
+            baseBlock = BlockTypes.get(itemId).getDefaultState().toBaseBlock();
+        }
+        return baseBlock;
     }
 
     @Override public boolean equals(Object obj) {

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/util/block/BasicLocalBlockQueue.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/util/block/BasicLocalBlockQueue.java
@@ -15,7 +15,7 @@ import lombok.Getter;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
-public abstract class BasicLocalBlockQueue<T> extends LocalBlockQueue {
+public abstract class BasicLocalBlockQueue extends LocalBlockQueue {
 
     private final String world;
     private final ConcurrentHashMap<Long, LocalChunk> blockChunks = new ConcurrentHashMap<>();
@@ -35,7 +35,7 @@ public abstract class BasicLocalBlockQueue<T> extends LocalBlockQueue {
 
     @Override public abstract PlotBlock getBlock(int x, int y, int z);
 
-    public abstract void setComponents(LocalChunk<T> lc);
+    public abstract void setComponents(LocalChunk lc);
 
     @Override public final String getWorld() {
         return world;
@@ -62,7 +62,7 @@ public abstract class BasicLocalBlockQueue<T> extends LocalBlockQueue {
         return false;
     }
 
-    public final boolean execute(final LocalChunk<T> lc) {
+    public final boolean execute(final LocalChunk lc) {
         if (lc == null) {
             return false;
         }
@@ -149,7 +149,7 @@ public abstract class BasicLocalBlockQueue<T> extends LocalBlockQueue {
         return true;
     }
 
-    public final void setChunk(LocalChunk<T> chunk) {
+    public final void setChunk(LocalChunk chunk) {
         LocalChunk previous = this.blockChunks.put(chunk.longHash(), chunk);
         if (previous != null) {
             chunks.remove(previous);
@@ -169,7 +169,7 @@ public abstract class BasicLocalBlockQueue<T> extends LocalBlockQueue {
     }
 
 
-    public abstract class LocalChunk<B> {
+    public abstract class LocalChunk {
         public final BasicLocalBlockQueue parent;
         public final int z;
         public final int x;
@@ -177,7 +177,7 @@ public abstract class BasicLocalBlockQueue<T> extends LocalBlockQueue {
         public BaseBlock[][] baseblocks;
         public String[][] biomes;
 
-        public LocalChunk(BasicLocalBlockQueue<B> parent, int x, int z) {
+        public LocalChunk(BasicLocalBlockQueue parent, int x, int z) {
             this.parent = parent;
             this.x = x;
             this.z = z;
@@ -223,7 +223,7 @@ public abstract class BasicLocalBlockQueue<T> extends LocalBlockQueue {
     }
 
 
-    public class BasicLocalChunk extends LocalChunk<PlotBlock[]> {
+    public class BasicLocalChunk extends LocalChunk {
         public BasicLocalChunk(BasicLocalBlockQueue parent, int x, int z) {
             super(parent, x, z);
             baseblocks = new BaseBlock[16][];

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/util/block/BasicLocalBlockQueue.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/util/block/BasicLocalBlockQueue.java
@@ -121,15 +121,7 @@ public abstract class BasicLocalBlockQueue extends LocalBlockQueue {
         // Trying to mix PlotBlock and BaseBlock leads to all kinds of issues.
         // Since BaseBlock has more features than PlotBlock, simply convert
         // all PlotBlocks to BaseBlocks
-        if (id instanceof StringPlotBlock) {
-            StringPlotBlock stringPlotBlock = (StringPlotBlock) id;
-            return setBlock(x, y, z, BlockTypes.get(stringPlotBlock.getItemId()).getDefaultState().toBaseBlock());
-        } else if (id instanceof LegacyPlotBlock) {
-            LegacyPlotBlock legacyPlotBlock = (LegacyPlotBlock) id;
-            return setBlock(x, y, z, LegacyMapper.getInstance().getBlockFromLegacy(legacyPlotBlock.getId(), legacyPlotBlock.getData()).toBaseBlock());
-        } else {
-            throw new RuntimeException("Unknown PlotBock class: " + id.getClass().getName());
-        }
+        return setBlock(x, y, z, id.getBaseBlock());
     }
 
     @Override public final boolean setBiome(int x, int z, String biome) {


### PR DESCRIPTION
These changes fixes various issues with using plot schematics and `paste-on-top` together, although it may also fix other bugs with a related cause. These issues were discovered while working on fixing other things mentioned in #2375, but aren't really shown or mentioned therein.

* Due to a conflict between using `BaseBlock` and `PlotBlock` at the same time in the same `BukkitLocalQueue`: https://github.com/IntellectualSites/PlotSquared/blob/ac5cdfae648ce3f76ed3d036a7444a1ec5ea6fef/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/util/block/BukkitLocalQueue.java#L70-L76 when using a schematic (which uses `BaseBlock`), all other block operations (which use `PlotBlock`) would be silently ignored. I solved this by converting `PlotBlock`s to `BaseBlock`s, since the latter has more features/is a superset of the former.
* Blocks above `WALL_HEIGHT` that were air in the schematic would not be removed/replaced when clearing a plot. This meant that any blocks in the schematic that were air, would remain whatever they were,  which is not great for a clear operation. Whatever blocks were not specified in the schematic are now turned into air: https://github.com/IntellectualSites/PlotSquared/blob/fbc80fe6931a464cb276268e3f869987f80cf78f/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridPlotManager.java#L105-L110