### PR TITLE
PlotManager + PlotArea cleanup

### DIFF
--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/generator/DelegatePlotGenerator.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/generator/DelegatePlotGenerator.java
@@ -30,8 +30,8 @@ import java.util.Random;
     @Override public void initialize(PlotArea area) {
     }
 
-    @Override public PlotManager getNewPlotManager() {
-        return PlotSquared.get().IMP.getDefaultGenerator().getNewPlotManager();
+    @Override public PlotManager getNewPlotManager(PlotArea plotArea) {
+        return PlotSquared.get().IMP.getDefaultGenerator().getNewPlotManager(plotArea);
     }
 
     @Override public String getName() {

--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/generator/DelegatePlotGenerator.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/generator/DelegatePlotGenerator.java
@@ -30,10 +30,6 @@ import java.util.Random;
     @Override public void initialize(PlotArea area) {
     }
 
-    @Override public PlotManager getNewPlotManager(PlotArea plotArea) {
-        return PlotSquared.get().IMP.getDefaultGenerator().getNewPlotManager(plotArea);
-    }
-
     @Override public String getName() {
         return this.chunkGenerator.getClass().getName();
     }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/PlotSquared.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/PlotSquared.java
@@ -1086,7 +1086,7 @@ import java.util.zip.ZipInputStream;
             }
             // Conventional plot generator
             PlotArea plotArea = plotGenerator.getNewPlotArea(world, null, null, null);
-            PlotManager plotManager = plotGenerator.getNewPlotManager(plotArea);
+            PlotManager plotManager = plotArea.getPlotManager();
             PlotSquared.log(Captions.PREFIX + "&aDetected world load for '" + world + "'");
             PlotSquared
                 .log(Captions.PREFIX + "&3 - generator: &7" + baseGenerator + ">" + plotGenerator);

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/PlotSquared.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/PlotSquared.java
@@ -1086,7 +1086,7 @@ import java.util.zip.ZipInputStream;
             }
             // Conventional plot generator
             PlotArea plotArea = plotGenerator.getNewPlotArea(world, null, null, null);
-            PlotManager plotManager = plotGenerator.getNewPlotManager();
+            PlotManager plotManager = plotGenerator.getNewPlotManager(plotArea);
             PlotSquared.log(Captions.PREFIX + "&aDetected world load for '" + world + "'");
             PlotSquared
                 .log(Captions.PREFIX + "&3 - generator: &7" + baseGenerator + ">" + plotGenerator);

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/DebugClaimTest.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/DebugClaimTest.java
@@ -55,7 +55,7 @@ public class DebugClaimTest extends SubCommand {
                 MainUtil.sendMessage(player, " - &cDB Already contains: " + plot.getId());
                 continue;
             }
-            Location loc = manager.getSignLoc(area, plot);
+            Location loc = manager.getSignLoc(plot);
             ChunkLoc chunk = new ChunkLoc(loc.getX() >> 4, loc.getZ() >> 4);
             boolean result = ChunkManager.manager.loadChunk(area.worldname, chunk, false);
             if (!result) {

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/DebugRoadRegen.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/DebugRoadRegen.java
@@ -2,11 +2,9 @@ package com.github.intellectualsites.plotsquared.plot.commands;
 
 import com.github.intellectualsites.plotsquared.commands.CommandDeclaration;
 import com.github.intellectualsites.plotsquared.plot.config.Captions;
-import com.github.intellectualsites.plotsquared.plot.generator.HybridPlotManager;
-import com.github.intellectualsites.plotsquared.plot.generator.HybridPlotWorld;
 import com.github.intellectualsites.plotsquared.plot.object.Location;
 import com.github.intellectualsites.plotsquared.plot.object.Plot;
-import com.github.intellectualsites.plotsquared.plot.object.PlotArea;
+import com.github.intellectualsites.plotsquared.plot.object.PlotManager;
 import com.github.intellectualsites.plotsquared.plot.object.PlotPlayer;
 import com.github.intellectualsites.plotsquared.plot.util.MainUtil;
 
@@ -18,20 +16,16 @@ public class DebugRoadRegen extends SubCommand {
 
     @Override public boolean onCommand(PlotPlayer player, String[] args) {
         Location loc = player.getLocation();
-        PlotArea plotArea = loc.getPlotArea();
-        if (!(plotArea instanceof HybridPlotWorld)) {
-            return sendMessage(player, Captions.NOT_IN_PLOT_WORLD);
-        }
+        PlotManager manager = loc.getPlotArea().getPlotManager();
         Plot plot = player.getCurrentPlot();
         if (plot == null) {
             Captions.NOT_IN_PLOT.send(player);
         } else if (plot.isMerged()) {
             Captions.REQUIRES_UNMERGED.send(player);
         } else {
-            HybridPlotManager manager = (HybridPlotManager) plotArea.getPlotManager();
-            manager.createRoadEast(plotArea, plot);
-            manager.createRoadSouth(plotArea, plot);
-            manager.createRoadSouthEast(plotArea, plot);
+            manager.createRoadEast(plot);
+            manager.createRoadSouth(plot);
+            manager.createRoadSouthEast(plot);
             MainUtil.sendMessage(player, "&6Regenerating plot south/east roads: " + plot.getId()
                 + "\n&6 - Result: &aSuccess");
             MainUtil.sendMessage(player, "&cTo regenerate all roads: /plot regenallroads");

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/DebugRoadRegen.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/DebugRoadRegen.java
@@ -4,6 +4,7 @@ import com.github.intellectualsites.plotsquared.commands.CommandDeclaration;
 import com.github.intellectualsites.plotsquared.plot.config.Captions;
 import com.github.intellectualsites.plotsquared.plot.object.Location;
 import com.github.intellectualsites.plotsquared.plot.object.Plot;
+import com.github.intellectualsites.plotsquared.plot.object.PlotArea;
 import com.github.intellectualsites.plotsquared.plot.object.PlotManager;
 import com.github.intellectualsites.plotsquared.plot.object.PlotPlayer;
 import com.github.intellectualsites.plotsquared.plot.util.MainUtil;
@@ -16,13 +17,17 @@ public class DebugRoadRegen extends SubCommand {
 
     @Override public boolean onCommand(PlotPlayer player, String[] args) {
         Location loc = player.getLocation();
-        PlotManager manager = loc.getPlotArea().getPlotManager();
+        PlotArea area = loc.getPlotArea();
+        if (area == null) {
+            return sendMessage(player, Captions.NOT_IN_PLOT_WORLD);
+        }
         Plot plot = player.getCurrentPlot();
         if (plot == null) {
             Captions.NOT_IN_PLOT.send(player);
         } else if (plot.isMerged()) {
             Captions.REQUIRES_UNMERGED.send(player);
         } else {
+            PlotManager manager = area.getPlotManager();
             manager.createRoadEast(plot);
             manager.createRoadSouth(plot);
             manager.createRoadSouthEast(plot);

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Set.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Set.java
@@ -47,7 +47,7 @@ import java.util.stream.IntStream;
             @Override public boolean set(PlotPlayer player, final Plot plot, String value) {
                 PlotArea plotArea = player.getLocation().getPlotArea();
                 PlotManager manager = player.getLocation().getPlotManager();
-                String[] components = manager.getPlotComponents(plotArea, plot.getId());
+                String[] components = manager.getPlotComponents(plot.getId());
                 boolean allowUnsafe = DebugAllowUnsafe.unsafeAllowed.contains(player.getUUID());
 
                 String[] args = value.split(" ");
@@ -124,7 +124,7 @@ import java.util.stream.IntStream;
         Plot plot = player.getCurrentPlot();
         if (plot != null) {
             newValues.addAll(
-                Arrays.asList(plot.getManager().getPlotComponents(plot.getArea(), plot.getId())));
+                Arrays.asList(plot.getManager().getPlotComponents(plot.getId())));
         }
         MainUtil.sendMessage(player, Captions.SUBCOMMAND_SET_OPTIONS_HEADER.s() + StringMan
             .join(newValues, Captions.BLOCK_LIST_SEPARATER.formatted()));
@@ -151,7 +151,7 @@ import java.util.stream.IntStream;
         }
         // components
         HashSet<String> components = new HashSet<>(
-            Arrays.asList(plot.getManager().getPlotComponents(plot.getArea(), plot.getId())));
+            Arrays.asList(plot.getManager().getPlotComponents(plot.getId())));
         if (components.contains(args[0].toLowerCase())) {
             return this.component.onCommand(player, Arrays.copyOfRange(args, 0, args.length));
         }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Template.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Template.java
@@ -179,7 +179,7 @@ import java.util.zip.ZipOutputStream;
                 final PlotManager manager = area.getPlotManager();
                 TaskManager.runTaskAsync(() -> {
                     try {
-                        manager.exportTemplate(area);
+                        manager.exportTemplate();
                     } catch (Exception e) { // Must recover from any exception thrown a third party template manager
                         e.printStackTrace();
                         MainUtil.sendMessage(player, "Failed: " + e.getMessage());

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/AugmentedUtils.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/AugmentedUtils.java
@@ -96,7 +96,7 @@ public class AugmentedUtils {
                     for (int z = bzz; z <= tzz; z++) {
                         int rx = x + blockX;
                         int rz = z + blockZ;
-                        boolean can = manager.getPlotId(area, rx, 0, rz) == null;
+                        boolean can = manager.getPlotId(rx, 0, rz) == null;
                         if (can) {
                             for (int y = 1; y < 128; y++) {
                                 queue.setBlock(rx, y, rz, air);

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/ClassicPlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/ClassicPlotManager.java
@@ -13,8 +13,19 @@ import java.util.List;
  */
 public class ClassicPlotManager extends SquarePlotManager {
 
+    private final ClassicPlotWorld classicPlotWorld;
+
+    public ClassicPlotManager(PlotArea plotArea) {
+        super(plotArea);
+        if (plotArea instanceof ClassicPlotWorld){
+            classicPlotWorld = (ClassicPlotWorld)plotArea;
+        } else {
+            throw new RuntimeException("ClassicPlotManager requires plotArea to be an instance of ClassicPlotWorld");
+        }
+    }
+
     @Override public boolean setComponent(PlotArea plotArea, PlotId plotId, String component,
-        BlockBucket blocks) {
+                                          BlockBucket blocks) {
         switch (component) {
             case "floor":
                 setFloor(plotArea, plotId, blocks);

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/ClassicPlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/ClassicPlotManager.java
@@ -24,55 +24,53 @@ public class ClassicPlotManager extends SquarePlotManager {
         }
     }
 
-    @Override public boolean setComponent(PlotArea plotArea, PlotId plotId, String component,
+    @Override public boolean setComponent(PlotId plotId, String component,
                                           BlockBucket blocks) {
         switch (component) {
             case "floor":
-                setFloor(plotArea, plotId, blocks);
+                setFloor(plotId, blocks);
                 return true;
             case "wall":
-                setWallFilling(plotArea, plotId, blocks);
+                setWallFilling(plotId, blocks);
                 return true;
             case "all":
-                setAll(plotArea, plotId, blocks);
+                setAll(plotId, blocks);
                 return true;
             case "air":
-                setAir(plotArea, plotId, blocks);
+                setAir(plotId, blocks);
                 return true;
             case "main":
-                setMain(plotArea, plotId, blocks);
+                setMain(plotId, blocks);
                 return true;
             case "middle":
-                setMiddle(plotArea, plotId, blocks);
+                setMiddle(plotId, blocks);
                 return true;
             case "outline":
-                setOutline(plotArea, plotId, blocks);
+                setOutline(plotId, blocks);
                 return true;
             case "border":
-                setWall(plotArea, plotId, blocks);
+                setWall(plotId, blocks);
                 return true;
         }
         return false;
     }
 
-    @Override public boolean unClaimPlot(PlotArea plotArea, Plot plot, Runnable whenDone) {
-        ClassicPlotWorld dpw = (ClassicPlotWorld) plotArea;
-        setWallFilling(dpw, plot.getId(), dpw.WALL_FILLING);
-        setWall(dpw, plot.getId(), dpw.WALL_BLOCK);
+    @Override public boolean unClaimPlot(Plot plot, Runnable whenDone) {
+        setWallFilling(plot.getId(), classicPlotWorld.WALL_FILLING);
+        setWall(plot.getId(), classicPlotWorld.WALL_BLOCK);
         GlobalBlockQueue.IMP.addTask(whenDone);
         return true;
     }
 
-    public boolean setFloor(PlotArea plotArea, PlotId plotId, BlockBucket blocks) {
-        Plot plot = plotArea.getPlotAbs(plotId);
-        LocalBlockQueue queue = plotArea.getQueue(false);
+    public boolean setFloor(PlotId plotId, BlockBucket blocks) {
+        Plot plot = classicPlotWorld.getPlotAbs(plotId);
+        LocalBlockQueue queue = classicPlotWorld.getQueue(false);
         if (plot.isBasePlot()) {
-            ClassicPlotWorld dpw = (ClassicPlotWorld) plotArea;
             for (RegionWrapper region : plot.getRegions()) {
                 Location pos1 =
-                    new Location(plotArea.worldname, region.minX, dpw.PLOT_HEIGHT, region.minZ);
+                    new Location(classicPlotWorld.worldname, region.minX, classicPlotWorld.PLOT_HEIGHT, region.minZ);
                 Location pos2 =
-                    new Location(plotArea.worldname, region.maxX, dpw.PLOT_HEIGHT, region.maxZ);
+                    new Location(classicPlotWorld.worldname, region.maxX, classicPlotWorld.PLOT_HEIGHT, region.maxZ);
                 queue.setCuboid(pos1, pos2, blocks);
             }
         }
@@ -80,87 +78,83 @@ public class ClassicPlotManager extends SquarePlotManager {
         return true;
     }
 
-    public boolean setAll(PlotArea plotArea, PlotId plotId, BlockBucket blocks) {
-        Plot plot = plotArea.getPlotAbs(plotId);
+    public boolean setAll(PlotId plotId, BlockBucket blocks) {
+        Plot plot = classicPlotWorld.getPlotAbs(plotId);
         if (!plot.isBasePlot()) {
             return false;
         }
-        LocalBlockQueue queue = plotArea.getQueue(false);
-        int maxY = plotArea.getPlotManager().getWorldHeight();
+        LocalBlockQueue queue = classicPlotWorld.getQueue(false);
+        int maxY = getWorldHeight();
         for (RegionWrapper region : plot.getRegions()) {
-            Location pos1 = new Location(plotArea.worldname, region.minX, 1, region.minZ);
-            Location pos2 = new Location(plotArea.worldname, region.maxX, maxY, region.maxZ);
+            Location pos1 = new Location(classicPlotWorld.worldname, region.minX, 1, region.minZ);
+            Location pos2 = new Location(classicPlotWorld.worldname, region.maxX, maxY, region.maxZ);
             queue.setCuboid(pos1, pos2, blocks);
         }
         queue.enqueue();
         return true;
     }
 
-    public boolean setAir(PlotArea plotArea, PlotId plotId, BlockBucket blocks) {
-        Plot plot = plotArea.getPlotAbs(plotId);
+    public boolean setAir(PlotId plotId, BlockBucket blocks) {
+        Plot plot = classicPlotWorld.getPlotAbs(plotId);
         if (!plot.isBasePlot()) {
             return false;
         }
-        ClassicPlotWorld dpw = (ClassicPlotWorld) plotArea;
-        LocalBlockQueue queue = plotArea.getQueue(false);
-        int maxY = plotArea.getPlotManager().getWorldHeight();
+        LocalBlockQueue queue = classicPlotWorld.getQueue(false);
+        int maxY = getWorldHeight();
         for (RegionWrapper region : plot.getRegions()) {
             Location pos1 =
-                new Location(plotArea.worldname, region.minX, dpw.PLOT_HEIGHT + 1, region.minZ);
-            Location pos2 = new Location(plotArea.worldname, region.maxX, maxY, region.maxZ);
+                new Location(classicPlotWorld.worldname, region.minX, classicPlotWorld.PLOT_HEIGHT + 1, region.minZ);
+            Location pos2 = new Location(classicPlotWorld.worldname, region.maxX, maxY, region.maxZ);
             queue.setCuboid(pos1, pos2, blocks);
         }
         queue.enqueue();
         return true;
     }
 
-    public boolean setMain(PlotArea plotArea, PlotId plotId, BlockBucket blocks) {
-        Plot plot = plotArea.getPlotAbs(plotId);
+    public boolean setMain(PlotId plotId, BlockBucket blocks) {
+        Plot plot = classicPlotWorld.getPlotAbs(plotId);
         if (!plot.isBasePlot()) {
             return false;
         }
-        ClassicPlotWorld dpw = (ClassicPlotWorld) plotArea;
-        LocalBlockQueue queue = plotArea.getQueue(false);
+        LocalBlockQueue queue = classicPlotWorld.getQueue(false);
         for (RegionWrapper region : plot.getRegions()) {
-            Location pos1 = new Location(plotArea.worldname, region.minX, 1, region.minZ);
+            Location pos1 = new Location(classicPlotWorld.worldname, region.minX, 1, region.minZ);
             Location pos2 =
-                new Location(plotArea.worldname, region.maxX, dpw.PLOT_HEIGHT - 1, region.maxZ);
+                new Location(classicPlotWorld.worldname, region.maxX, classicPlotWorld.PLOT_HEIGHT - 1, region.maxZ);
             queue.setCuboid(pos1, pos2, blocks);
         }
         queue.enqueue();
         return true;
     }
 
-    public boolean setMiddle(PlotArea plotArea, PlotId plotId, BlockBucket blocks) {
-        Plot plot = plotArea.getPlotAbs(plotId);
+    public boolean setMiddle(PlotId plotId, BlockBucket blocks) {
+        Plot plot = classicPlotWorld.getPlotAbs(plotId);
         if (!plot.isBasePlot()) {
             return false;
         }
         Location[] corners = plot.getCorners();
-        ClassicPlotWorld dpw = (ClassicPlotWorld) plotArea;
-        LocalBlockQueue queue = plotArea.getQueue(false);
+        LocalBlockQueue queue = classicPlotWorld.getQueue(false);
 
         int x = MathMan.average(corners[0].getX(), corners[1].getX());
         int z = MathMan.average(corners[0].getZ(), corners[1].getZ());
-        queue.setBlock(x, dpw.PLOT_HEIGHT, z, blocks.getBlock());
+        queue.setBlock(x, classicPlotWorld.PLOT_HEIGHT, z, blocks.getBlock());
         queue.enqueue();
         return true;
     }
 
-    public boolean setOutline(PlotArea plotArea, PlotId plotId, BlockBucket blocks) {
-        ClassicPlotWorld dpw = (ClassicPlotWorld) plotArea;
-        if (dpw.ROAD_WIDTH == 0) {
+    public boolean setOutline(PlotId plotId, BlockBucket blocks) {
+        if (classicPlotWorld.ROAD_WIDTH == 0) {
             return false;
         }
-        Plot plot = plotArea.getPlotAbs(plotId);
+        Plot plot = classicPlotWorld.getPlotAbs(plotId);
         Location bottom = plot.getBottomAbs();
         Location top = plot.getExtendedTopAbs();
-        LocalBlockQueue queue = plotArea.getQueue(false);
-        int maxY = plotArea.getPlotManager().getWorldHeight();
+        LocalBlockQueue queue = classicPlotWorld.getQueue(false);
+        int maxY = classicPlotWorld.getPlotManager().getWorldHeight();
         if (!plot.getMerged(Direction.NORTH)) {
             int z = bottom.getZ();
             for (int x = bottom.getX(); x <= top.getX(); x++) {
-                for (int y = dpw.PLOT_HEIGHT; y <= maxY; y++) {
+                for (int y = classicPlotWorld.PLOT_HEIGHT; y <= maxY; y++) {
                     queue.setBlock(x, y, z, blocks.getBlock());
                 }
             }
@@ -168,7 +162,7 @@ public class ClassicPlotManager extends SquarePlotManager {
         if (!plot.getMerged(Direction.WEST)) {
             int x = bottom.getX();
             for (int z = bottom.getZ(); z <= top.getZ(); z++) {
-                for (int y = dpw.PLOT_HEIGHT; y <= maxY; y++) {
+                for (int y = classicPlotWorld.PLOT_HEIGHT; y <= maxY; y++) {
                     queue.setBlock(x, y, z, blocks.getBlock());
                 }
             }
@@ -177,7 +171,7 @@ public class ClassicPlotManager extends SquarePlotManager {
         if (!plot.getMerged(Direction.SOUTH)) {
             int z = top.getZ();
             for (int x = bottom.getX(); x <= top.getX(); x++) {
-                for (int y = dpw.PLOT_HEIGHT; y <= maxY; y++) {
+                for (int y = classicPlotWorld.PLOT_HEIGHT; y <= maxY; y++) {
                     queue.setBlock(x, y, z, blocks.getBlock());
                 }
             }
@@ -185,15 +179,15 @@ public class ClassicPlotManager extends SquarePlotManager {
         if (!plot.getMerged(Direction.EAST)) {
             int x = top.getX();
             for (int z = bottom.getZ(); z <= top.getZ(); z++) {
-                for (int y = dpw.PLOT_HEIGHT; y <= maxY; y++) {
+                for (int y = classicPlotWorld.PLOT_HEIGHT; y <= maxY; y++) {
                     queue.setBlock(x, y, z, blocks.getBlock());
                 }
             }
         }
         if (plot.isBasePlot()) {
             for (RegionWrapper region : plot.getRegions()) {
-                Location pos1 = new Location(plotArea.worldname, region.minX, maxY, region.minZ);
-                Location pos2 = new Location(plotArea.worldname, region.maxX, maxY, region.maxZ);
+                Location pos1 = new Location(classicPlotWorld.worldname, region.minX, maxY, region.minZ);
+                Location pos2 = new Location(classicPlotWorld.worldname, region.maxX, maxY, region.maxZ);
                 queue.setCuboid(pos1, pos2, blocks);
             }
         }
@@ -201,21 +195,20 @@ public class ClassicPlotManager extends SquarePlotManager {
         return true;
     }
 
-    public boolean setWallFilling(PlotArea plotArea, PlotId plotId, BlockBucket blocks) {
-        ClassicPlotWorld dpw = (ClassicPlotWorld) plotArea;
-        if (dpw.ROAD_WIDTH == 0) {
+    public boolean setWallFilling(PlotId plotId, BlockBucket blocks) {
+        if (classicPlotWorld.ROAD_WIDTH == 0) {
             return false;
         }
-        Plot plot = plotArea.getPlotAbs(plotId);
+        Plot plot = classicPlotWorld.getPlotAbs(plotId);
         Location bot = plot.getExtendedBottomAbs()
             .subtract(plot.getMerged(Direction.WEST) ? 0 : 1, 0,
                 plot.getMerged(Direction.NORTH) ? 0 : 1);
         Location top = plot.getExtendedTopAbs().add(1, 0, 1);
-        LocalBlockQueue queue = plotArea.getQueue(false);
+        LocalBlockQueue queue = classicPlotWorld.getQueue(false);
         if (!plot.getMerged(Direction.NORTH)) {
             int z = bot.getZ();
             for (int x = bot.getX(); x < top.getX(); x++) {
-                for (int y = 1; y <= dpw.WALL_HEIGHT; y++) {
+                for (int y = 1; y <= classicPlotWorld.WALL_HEIGHT; y++) {
                     queue.setBlock(x, y, z, blocks.getBlock());
                 }
             }
@@ -223,7 +216,7 @@ public class ClassicPlotManager extends SquarePlotManager {
         if (!plot.getMerged(Direction.WEST)) {
             int x = bot.getX();
             for (int z = bot.getZ(); z < top.getZ(); z++) {
-                for (int y = 1; y <= dpw.WALL_HEIGHT; y++) {
+                for (int y = 1; y <= classicPlotWorld.WALL_HEIGHT; y++) {
                     queue.setBlock(x, y, z, blocks.getBlock());
                 }
             }
@@ -232,7 +225,7 @@ public class ClassicPlotManager extends SquarePlotManager {
             int z = top.getZ();
             for (int x = bot.getX();
                  x < top.getX() + (plot.getMerged(Direction.EAST) ? 0 : 1); x++) {
-                for (int y = 1; y <= dpw.WALL_HEIGHT; y++) {
+                for (int y = 1; y <= classicPlotWorld.WALL_HEIGHT; y++) {
                     queue.setBlock(x, y, z, blocks.getBlock());
                 }
             }
@@ -241,7 +234,7 @@ public class ClassicPlotManager extends SquarePlotManager {
             int x = top.getX();
             for (int z = bot.getZ();
                  z < top.getZ() + (plot.getMerged(Direction.SOUTH) ? 0 : 1); z++) {
-                for (int y = 1; y <= dpw.WALL_HEIGHT; y++) {
+                for (int y = 1; y <= classicPlotWorld.WALL_HEIGHT; y++) {
                     queue.setBlock(x, y, z, blocks.getBlock());
                 }
             }
@@ -250,18 +243,17 @@ public class ClassicPlotManager extends SquarePlotManager {
         return true;
     }
 
-    public boolean setWall(PlotArea plotArea, PlotId plotId, BlockBucket blocks) {
-        ClassicPlotWorld dpw = (ClassicPlotWorld) plotArea;
-        if (dpw.ROAD_WIDTH == 0) {
+    public boolean setWall(PlotId plotId, BlockBucket blocks) {
+        if (classicPlotWorld.ROAD_WIDTH == 0) {
             return false;
         }
-        Plot plot = plotArea.getPlotAbs(plotId);
+        Plot plot = classicPlotWorld.getPlotAbs(plotId);
         Location bot = plot.getExtendedBottomAbs()
             .subtract(plot.getMerged(Direction.WEST) ? 0 : 1, 0,
                 plot.getMerged(Direction.NORTH) ? 0 : 1);
         Location top = plot.getExtendedTopAbs().add(1, 0, 1);
-        LocalBlockQueue queue = plotArea.getQueue(false);
-        int y = dpw.WALL_HEIGHT + 1;
+        LocalBlockQueue queue = classicPlotWorld.getQueue(false);
+        int y = classicPlotWorld.WALL_HEIGHT + 1;
         if (!plot.getMerged(Direction.NORTH)) {
             int z = bot.getZ();
             for (int x = bot.getX(); x < top.getX(); x++) {
@@ -295,145 +287,139 @@ public class ClassicPlotManager extends SquarePlotManager {
     /**
      * PLOT MERGING.
      */
-    @Override public boolean createRoadEast(PlotArea plotArea, Plot plot) {
-        ClassicPlotWorld dpw = (ClassicPlotWorld) plotArea;
-        Location pos1 = getPlotBottomLocAbs(plotArea, plot.getId());
-        Location pos2 = getPlotTopLocAbs(plotArea, plot.getId());
+    @Override public boolean createRoadEast(Plot plot) {
+        Location pos1 = getPlotBottomLocAbs(plot.getId());
+        Location pos2 = getPlotTopLocAbs(plot.getId());
         int sx = pos2.getX() + 1;
-        int ex = sx + dpw.ROAD_WIDTH - 1;
+        int ex = sx + classicPlotWorld.ROAD_WIDTH - 1;
         int sz = pos1.getZ() - 2;
         int ez = pos2.getZ() + 2;
-        LocalBlockQueue queue = plotArea.getQueue(false);
-        int maxY = plotArea.getPlotManager().getWorldHeight();
+        LocalBlockQueue queue = classicPlotWorld.getQueue(false);
+        int maxY = getWorldHeight();
         queue.setCuboid(
-            new Location(plotArea.worldname, sx, Math.min(dpw.WALL_HEIGHT, dpw.ROAD_HEIGHT) + 1,
-                sz + 1), new Location(plotArea.worldname, ex, maxY, ez - 1),
+            new Location(classicPlotWorld.worldname, sx, Math.min(classicPlotWorld.WALL_HEIGHT, classicPlotWorld.ROAD_HEIGHT) + 1,
+                sz + 1), new Location(classicPlotWorld.worldname, ex, maxY, ez - 1),
             PlotBlock.get((short) 0, (byte) 0));
-        queue.setCuboid(new Location(plotArea.worldname, sx, 0, sz + 1),
-            new Location(plotArea.worldname, ex, 0, ez - 1), PlotBlock.get((short) 7, (byte) 0));
-        queue.setCuboid(new Location(plotArea.worldname, sx, 1, sz + 1),
-            new Location(plotArea.worldname, sx, dpw.WALL_HEIGHT, ez - 1), dpw.WALL_FILLING);
-        queue.setCuboid(new Location(plotArea.worldname, sx, dpw.WALL_HEIGHT + 1, sz + 1),
-            new Location(plotArea.worldname, sx, dpw.WALL_HEIGHT + 1, ez - 1), dpw.WALL_BLOCK);
-        queue.setCuboid(new Location(plotArea.worldname, ex, 1, sz + 1),
-            new Location(plotArea.worldname, ex, dpw.WALL_HEIGHT, ez - 1), dpw.WALL_FILLING);
-        queue.setCuboid(new Location(plotArea.worldname, ex, dpw.WALL_HEIGHT + 1, sz + 1),
-            new Location(plotArea.worldname, ex, dpw.WALL_HEIGHT + 1, ez - 1), dpw.WALL_BLOCK);
-        queue.setCuboid(new Location(plotArea.worldname, sx + 1, 1, sz + 1),
-            new Location(plotArea.worldname, ex - 1, dpw.ROAD_HEIGHT, ez - 1), dpw.ROAD_BLOCK);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx, 0, sz + 1),
+            new Location(classicPlotWorld.worldname, ex, 0, ez - 1), PlotBlock.get((short) 7, (byte) 0));
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx, 1, sz + 1),
+            new Location(classicPlotWorld.worldname, sx, classicPlotWorld.WALL_HEIGHT, ez - 1), classicPlotWorld.WALL_FILLING);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx, classicPlotWorld.WALL_HEIGHT + 1, sz + 1),
+            new Location(classicPlotWorld.worldname, sx, classicPlotWorld.WALL_HEIGHT + 1, ez - 1), classicPlotWorld.WALL_BLOCK);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, ex, 1, sz + 1),
+            new Location(classicPlotWorld.worldname, ex, classicPlotWorld.WALL_HEIGHT, ez - 1), classicPlotWorld.WALL_FILLING);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, ex, classicPlotWorld.WALL_HEIGHT + 1, sz + 1),
+            new Location(classicPlotWorld.worldname, ex, classicPlotWorld.WALL_HEIGHT + 1, ez - 1), classicPlotWorld.WALL_BLOCK);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx + 1, 1, sz + 1),
+            new Location(classicPlotWorld.worldname, ex - 1, classicPlotWorld.ROAD_HEIGHT, ez - 1), classicPlotWorld.ROAD_BLOCK);
         queue.enqueue();
         return true;
     }
 
-    @Override public boolean createRoadSouth(PlotArea plotArea, Plot plot) {
-        ClassicPlotWorld dpw = (ClassicPlotWorld) plotArea;
-        Location pos1 = getPlotBottomLocAbs(plotArea, plot.getId());
-        Location pos2 = getPlotTopLocAbs(plotArea, plot.getId());
+    @Override public boolean createRoadSouth(Plot plot) {
+        Location pos1 = getPlotBottomLocAbs(plot.getId());
+        Location pos2 = getPlotTopLocAbs(plot.getId());
         int sz = pos2.getZ() + 1;
-        int ez = sz + dpw.ROAD_WIDTH - 1;
+        int ez = sz + classicPlotWorld.ROAD_WIDTH - 1;
         int sx = pos1.getX() - 2;
         int ex = pos2.getX() + 2;
-        LocalBlockQueue queue = plotArea.getQueue(false);
+        LocalBlockQueue queue = classicPlotWorld.getQueue(false);
         queue.setCuboid(
-            new Location(plotArea.worldname, sx + 1, Math.min(dpw.WALL_HEIGHT, dpw.ROAD_HEIGHT) + 1,
+            new Location(classicPlotWorld.worldname, sx + 1, Math.min(classicPlotWorld.WALL_HEIGHT, classicPlotWorld.ROAD_HEIGHT) + 1,
                 sz),
-            new Location(plotArea.worldname, ex - 1, plotArea.getPlotManager().getWorldHeight(),
+            new Location(classicPlotWorld.worldname, ex - 1, classicPlotWorld.getPlotManager().getWorldHeight(),
                 ez), PlotBlock.get((short) 0, (byte) 0));
-        queue.setCuboid(new Location(plotArea.worldname, sx + 1, 0, sz),
-            new Location(plotArea.worldname, ex - 1, 0, ez), PlotBlock.get((short) 7, (byte) 0));
-        queue.setCuboid(new Location(plotArea.worldname, sx + 1, 1, sz),
-            new Location(plotArea.worldname, ex - 1, dpw.WALL_HEIGHT, sz), dpw.WALL_FILLING);
-        queue.setCuboid(new Location(plotArea.worldname, sx + 1, dpw.WALL_HEIGHT + 1, sz),
-            new Location(plotArea.worldname, ex - 1, dpw.WALL_HEIGHT + 1, sz), dpw.WALL_BLOCK);
-        queue.setCuboid(new Location(plotArea.worldname, sx + 1, 1, ez),
-            new Location(plotArea.worldname, ex - 1, dpw.WALL_HEIGHT, ez), dpw.WALL_FILLING);
-        queue.setCuboid(new Location(plotArea.worldname, sx + 1, dpw.WALL_HEIGHT + 1, ez),
-            new Location(plotArea.worldname, ex - 1, dpw.WALL_HEIGHT + 1, ez), dpw.WALL_BLOCK);
-        queue.setCuboid(new Location(plotArea.worldname, sx + 1, 1, sz + 1),
-            new Location(plotArea.worldname, ex - 1, dpw.ROAD_HEIGHT, ez - 1), dpw.ROAD_BLOCK);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx + 1, 0, sz),
+            new Location(classicPlotWorld.worldname, ex - 1, 0, ez), PlotBlock.get((short) 7, (byte) 0));
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx + 1, 1, sz),
+            new Location(classicPlotWorld.worldname, ex - 1, classicPlotWorld.WALL_HEIGHT, sz), classicPlotWorld.WALL_FILLING);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx + 1, classicPlotWorld.WALL_HEIGHT + 1, sz),
+            new Location(classicPlotWorld.worldname, ex - 1, classicPlotWorld.WALL_HEIGHT + 1, sz), classicPlotWorld.WALL_BLOCK);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx + 1, 1, ez),
+            new Location(classicPlotWorld.worldname, ex - 1, classicPlotWorld.WALL_HEIGHT, ez), classicPlotWorld.WALL_FILLING);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx + 1, classicPlotWorld.WALL_HEIGHT + 1, ez),
+            new Location(classicPlotWorld.worldname, ex - 1, classicPlotWorld.WALL_HEIGHT + 1, ez), classicPlotWorld.WALL_BLOCK);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx + 1, 1, sz + 1),
+            new Location(classicPlotWorld.worldname, ex - 1, classicPlotWorld.ROAD_HEIGHT, ez - 1), classicPlotWorld.ROAD_BLOCK);
         queue.enqueue();
         return true;
     }
 
-    @Override public boolean createRoadSouthEast(PlotArea plotArea, Plot plot) {
-        ClassicPlotWorld dpw = (ClassicPlotWorld) plotArea;
-        Location pos2 = getPlotTopLocAbs(plotArea, plot.getId());
+    @Override public boolean createRoadSouthEast(Plot plot) {
+        Location pos2 = getPlotTopLocAbs(plot.getId());
         int sx = pos2.getX() + 1;
-        int ex = sx + dpw.ROAD_WIDTH - 1;
+        int ex = sx + classicPlotWorld.ROAD_WIDTH - 1;
         int sz = pos2.getZ() + 1;
-        int ez = sz + dpw.ROAD_WIDTH - 1;
-        LocalBlockQueue queue = plotArea.getQueue(false);
-        queue.setCuboid(new Location(plotArea.worldname, sx + 1, dpw.ROAD_HEIGHT + 1, sz + 1),
-            new Location(plotArea.worldname, ex - 1, dpw.getPlotManager().getWorldHeight(), ez - 1),
+        int ez = sz + classicPlotWorld.ROAD_WIDTH - 1;
+        LocalBlockQueue queue = classicPlotWorld.getQueue(false);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx + 1, classicPlotWorld.ROAD_HEIGHT + 1, sz + 1),
+            new Location(classicPlotWorld.worldname, ex - 1, classicPlotWorld.getPlotManager().getWorldHeight(), ez - 1),
             PlotBlock.get((short) 0, (byte) 0));
-        queue.setCuboid(new Location(plotArea.worldname, sx + 1, 0, sz + 1),
-            new Location(plotArea.worldname, ex - 1, 0, ez - 1),
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx + 1, 0, sz + 1),
+            new Location(classicPlotWorld.worldname, ex - 1, 0, ez - 1),
             PlotBlock.get((short) 7, (byte) 0));
-        queue.setCuboid(new Location(plotArea.worldname, sx + 1, 1, sz + 1),
-            new Location(plotArea.worldname, ex - 1, dpw.ROAD_HEIGHT, ez - 1), dpw.ROAD_BLOCK);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx + 1, 1, sz + 1),
+            new Location(classicPlotWorld.worldname, ex - 1, classicPlotWorld.ROAD_HEIGHT, ez - 1), classicPlotWorld.ROAD_BLOCK);
         queue.enqueue();
         return true;
     }
 
-    @Override public boolean removeRoadEast(PlotArea plotArea, Plot plot) {
-        ClassicPlotWorld dpw = (ClassicPlotWorld) plotArea;
-        Location pos1 = getPlotBottomLocAbs(plotArea, plot.getId());
-        Location pos2 = getPlotTopLocAbs(plotArea, plot.getId());
+    @Override public boolean removeRoadEast(Plot plot) {
+        Location pos1 = getPlotBottomLocAbs(plot.getId());
+        Location pos2 = getPlotTopLocAbs(plot.getId());
         int sx = pos2.getX() + 1;
-        int ex = sx + dpw.ROAD_WIDTH - 1;
+        int ex = sx + classicPlotWorld.ROAD_WIDTH - 1;
         int sz = pos1.getZ() - 1;
         int ez = pos2.getZ() + 1;
-        LocalBlockQueue queue = plotArea.getQueue(false);
+        LocalBlockQueue queue = classicPlotWorld.getQueue(false);
         queue.setCuboid(
-            new Location(plotArea.worldname, sx, Math.min(dpw.PLOT_HEIGHT, dpw.ROAD_HEIGHT) + 1,
+            new Location(classicPlotWorld.worldname, sx, Math.min(classicPlotWorld.PLOT_HEIGHT, classicPlotWorld.ROAD_HEIGHT) + 1,
                 sz),
-            new Location(plotArea.worldname, ex, plotArea.getPlotManager().getWorldHeight(), ez),
+            new Location(classicPlotWorld.worldname, ex, classicPlotWorld.getPlotManager().getWorldHeight(), ez),
             PlotBlock.get((short) 0, (byte) 0));
-        queue.setCuboid(new Location(plotArea.worldname, sx, 1, sz + 1),
-            new Location(plotArea.worldname, ex, dpw.PLOT_HEIGHT - 1, ez - 1), dpw.MAIN_BLOCK);
-        queue.setCuboid(new Location(plotArea.worldname, sx, dpw.PLOT_HEIGHT, sz + 1),
-            new Location(plotArea.worldname, ex, dpw.PLOT_HEIGHT, ez - 1), dpw.TOP_BLOCK);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx, 1, sz + 1),
+            new Location(classicPlotWorld.worldname, ex, classicPlotWorld.PLOT_HEIGHT - 1, ez - 1), classicPlotWorld.MAIN_BLOCK);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx, classicPlotWorld.PLOT_HEIGHT, sz + 1),
+            new Location(classicPlotWorld.worldname, ex, classicPlotWorld.PLOT_HEIGHT, ez - 1), classicPlotWorld.TOP_BLOCK);
         queue.enqueue();
         return true;
     }
 
-    @Override public boolean removeRoadSouth(PlotArea plotArea, Plot plot) {
-        ClassicPlotWorld dpw = (ClassicPlotWorld) plotArea;
-        Location pos1 = getPlotBottomLocAbs(plotArea, plot.getId());
-        Location pos2 = getPlotTopLocAbs(plotArea, plot.getId());
+    @Override public boolean removeRoadSouth(Plot plot) {
+        Location pos1 = getPlotBottomLocAbs(plot.getId());
+        Location pos2 = getPlotTopLocAbs(plot.getId());
         int sz = pos2.getZ() + 1;
-        int ez = sz + dpw.ROAD_WIDTH - 1;
+        int ez = sz + classicPlotWorld.ROAD_WIDTH - 1;
         int sx = pos1.getX() - 1;
         int ex = pos2.getX() + 1;
-        LocalBlockQueue queue = plotArea.getQueue(false);
+        LocalBlockQueue queue = classicPlotWorld.getQueue(false);
         queue.setCuboid(
-            new Location(plotArea.worldname, sx, Math.min(dpw.PLOT_HEIGHT, dpw.ROAD_HEIGHT) + 1,
+            new Location(classicPlotWorld.worldname, sx, Math.min(classicPlotWorld.PLOT_HEIGHT, classicPlotWorld.ROAD_HEIGHT) + 1,
                 sz),
-            new Location(plotArea.worldname, ex, plotArea.getPlotManager().getWorldHeight(), ez),
+            new Location(classicPlotWorld.worldname, ex, classicPlotWorld.getPlotManager().getWorldHeight(), ez),
             PlotBlock.get((short) 0, (byte) 0));
-        queue.setCuboid(new Location(plotArea.worldname, sx + 1, 1, sz),
-            new Location(plotArea.worldname, ex - 1, dpw.PLOT_HEIGHT - 1, ez), dpw.MAIN_BLOCK);
-        queue.setCuboid(new Location(plotArea.worldname, sx + 1, dpw.PLOT_HEIGHT, sz),
-            new Location(plotArea.worldname, ex - 1, dpw.PLOT_HEIGHT, ez), dpw.TOP_BLOCK);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx + 1, 1, sz),
+            new Location(classicPlotWorld.worldname, ex - 1, classicPlotWorld.PLOT_HEIGHT - 1, ez), classicPlotWorld.MAIN_BLOCK);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx + 1, classicPlotWorld.PLOT_HEIGHT, sz),
+            new Location(classicPlotWorld.worldname, ex - 1, classicPlotWorld.PLOT_HEIGHT, ez), classicPlotWorld.TOP_BLOCK);
         queue.enqueue();
         return true;
     }
 
-    @Override public boolean removeRoadSouthEast(PlotArea plotArea, Plot plot) {
-        ClassicPlotWorld dpw = (ClassicPlotWorld) plotArea;
-        Location location = getPlotTopLocAbs(dpw, plot.getId());
+    @Override public boolean removeRoadSouthEast(Plot plot) {
+        Location location = getPlotTopLocAbs(plot.getId());
         int sx = location.getX() + 1;
-        int ex = sx + dpw.ROAD_WIDTH - 1;
+        int ex = sx + classicPlotWorld.ROAD_WIDTH - 1;
         int sz = location.getZ() + 1;
-        int ez = sz + dpw.ROAD_WIDTH - 1;
-        LocalBlockQueue queue = plotArea.getQueue(false);
-        queue.setCuboid(new Location(plotArea.worldname, sx, dpw.ROAD_HEIGHT + 1, sz),
-            new Location(plotArea.worldname, ex, plotArea.getPlotManager().getWorldHeight(), ez),
+        int ez = sz + classicPlotWorld.ROAD_WIDTH - 1;
+        LocalBlockQueue queue = classicPlotWorld.getQueue(false);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx, classicPlotWorld.ROAD_HEIGHT + 1, sz),
+            new Location(classicPlotWorld.worldname, ex, classicPlotWorld.getPlotManager().getWorldHeight(), ez),
             PlotBlock.get((short) 0, (byte) 0));
-        queue.setCuboid(new Location(plotArea.worldname, sx, 1, sz),
-            new Location(plotArea.worldname, ex, dpw.ROAD_HEIGHT - 1, ez), dpw.MAIN_BLOCK);
-        queue.setCuboid(new Location(plotArea.worldname, sx, dpw.ROAD_HEIGHT, sz),
-            new Location(plotArea.worldname, ex, dpw.ROAD_HEIGHT, ez), dpw.TOP_BLOCK);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx, 1, sz),
+            new Location(classicPlotWorld.worldname, ex, classicPlotWorld.ROAD_HEIGHT - 1, ez), classicPlotWorld.MAIN_BLOCK);
+        queue.setCuboid(new Location(classicPlotWorld.worldname, sx, classicPlotWorld.ROAD_HEIGHT, sz),
+            new Location(classicPlotWorld.worldname, ex, classicPlotWorld.ROAD_HEIGHT, ez), classicPlotWorld.TOP_BLOCK);
         queue.enqueue();
         return true;
     }
@@ -441,48 +427,47 @@ public class ClassicPlotManager extends SquarePlotManager {
     /**
      * Finishing off plot merging by adding in the walls surrounding the plot (OPTIONAL)(UNFINISHED).
      */
-    @Override public boolean finishPlotMerge(PlotArea plotArea, List<PlotId> plotIds) {
-        final BlockBucket block = ((ClassicPlotWorld) plotArea).CLAIMED_WALL_BLOCK;
-        plotIds.forEach(id -> setWall(plotArea, id, block));
+    @Override public boolean finishPlotMerge(List<PlotId> plotIds) {
+        final BlockBucket block = classicPlotWorld.CLAIMED_WALL_BLOCK;
+        plotIds.forEach(id -> setWall(id, block));
         if (Settings.General.MERGE_REPLACE_WALL) {
-            final BlockBucket wallBlock = ((ClassicPlotWorld) plotArea).WALL_FILLING;
-            plotIds.forEach(id -> setWallFilling(plotArea, id, wallBlock));
+            final BlockBucket wallBlock = classicPlotWorld.WALL_FILLING;
+            plotIds.forEach(id -> setWallFilling(id, wallBlock));
         }
         return true;
     }
 
-    @Override public boolean finishPlotUnlink(PlotArea plotArea, List<PlotId> plotIds) {
-        final BlockBucket block = ((ClassicPlotWorld) plotArea).CLAIMED_WALL_BLOCK;
-        plotIds.forEach(id -> setWall(plotArea, id, block));
+    @Override public boolean finishPlotUnlink(List<PlotId> plotIds) {
+        final BlockBucket block = classicPlotWorld.CLAIMED_WALL_BLOCK;
+        plotIds.forEach(id -> setWall(id, block));
         return true;
     }
 
-    @Override public boolean startPlotMerge(PlotArea plotArea, List<PlotId> plotIds) {
+    @Override public boolean startPlotMerge(List<PlotId> plotIds) {
         return true;
     }
 
-    @Override public boolean startPlotUnlink(PlotArea plotArea, List<PlotId> plotIds) {
+    @Override public boolean startPlotUnlink(List<PlotId> plotIds) {
         return true;
     }
 
-    @Override public boolean claimPlot(PlotArea plotArea, Plot plot) {
-        final BlockBucket claim = ((ClassicPlotWorld) plotArea).CLAIMED_WALL_BLOCK;
-        setWall(plotArea, plot.getId(), claim);
+    @Override public boolean claimPlot(Plot plot) {
+        final BlockBucket claim = classicPlotWorld.CLAIMED_WALL_BLOCK;
+        setWall(plot.getId(), claim);
         return true;
     }
 
-    @Override public String[] getPlotComponents(PlotArea plotArea, PlotId plotId) {
+    @Override public String[] getPlotComponents(PlotId plotId) {
         return new String[] {"main", "floor", "air", "all", "border", "wall", "outline", "middle"};
     }
 
     /**
      * Remove sign for a plot.
      */
-    @Override public Location getSignLoc(PlotArea plotArea, Plot plot) {
-        ClassicPlotWorld dpw = (ClassicPlotWorld) plotArea;
+    @Override public Location getSignLoc(Plot plot) {
         plot = plot.getBasePlot(false);
         Location bot = plot.getBottomAbs();
-        return new Location(plotArea.worldname, bot.getX() - 1, dpw.ROAD_HEIGHT + 1,
+        return new Location(classicPlotWorld.worldname, bot.getX() - 1, classicPlotWorld.ROAD_HEIGHT + 1,
             bot.getZ() - 2);
     }
 }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/ClassicPlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/ClassicPlotManager.java
@@ -15,13 +15,9 @@ public class ClassicPlotManager extends SquarePlotManager {
 
     private final ClassicPlotWorld classicPlotWorld;
 
-    public ClassicPlotManager(PlotArea plotArea) {
-        super(plotArea);
-        if (plotArea instanceof ClassicPlotWorld){
-            classicPlotWorld = (ClassicPlotWorld)plotArea;
-        } else {
-            throw new RuntimeException("ClassicPlotManager requires plotArea to be an instance of ClassicPlotWorld");
-        }
+    public ClassicPlotManager(ClassicPlotWorld classicPlotWorld) {
+        super(classicPlotWorld);
+        this.classicPlotWorld = classicPlotWorld;
     }
 
     @Override public boolean setComponent(PlotId plotId, String component,

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/GridPlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/GridPlotManager.java
@@ -1,10 +1,13 @@
 package com.github.intellectualsites.plotsquared.plot.generator;
 
+import com.github.intellectualsites.plotsquared.plot.object.PlotArea;
 import com.github.intellectualsites.plotsquared.plot.object.PlotManager;
 
 /**
  * A plot manager where plots tessellate in a grid formation symmetrical about x=z.
  */
 public abstract class GridPlotManager extends PlotManager {
-
+    public GridPlotManager(PlotArea plotArea) {
+        super(plotArea);
+    }
 }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridGen.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridGen.java
@@ -253,8 +253,8 @@ public class HybridGen extends IndependentPlotGenerator {
         return new HybridPlotWorld(world, id, this, min, max);
     }
 
-    @Override public PlotManager getNewPlotManager() {
-        return new HybridPlotManager();
+    @Override public PlotManager getNewPlotManager(PlotArea plotArea) {
+        return new HybridPlotManager(plotArea);
     }
 
     @Override public void initialize(PlotArea area) {

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridGen.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridGen.java
@@ -253,10 +253,6 @@ public class HybridGen extends IndependentPlotGenerator {
         return new HybridPlotWorld(world, id, this, min, max);
     }
 
-    @Override public PlotManager getNewPlotManager(PlotArea plotArea) {
-        return new HybridPlotManager(plotArea);
-    }
-
     @Override public void initialize(PlotArea area) {
         // All initialization is done in the PlotArea class
     }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridPlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridPlotManager.java
@@ -32,11 +32,11 @@ public class HybridPlotManager extends ClassicPlotManager {
         }
     }
 
-    @Override public void exportTemplate(PlotArea plotArea) throws IOException {
+    @Override public void exportTemplate() throws IOException {
         HashSet<FileBytes> files = Sets.newHashSet(
-            new FileBytes(Settings.Paths.TEMPLATES + "/tmp-data.yml", Template.getBytes(plotArea)));
+            new FileBytes(Settings.Paths.TEMPLATES + "/tmp-data.yml", Template.getBytes(hybridPlotWorld)));
         String dir = "schematics" + File.separator + "GEN_ROAD_SCHEMATIC" + File.separator
-            + plotArea.worldname + File.separator;
+            + hybridPlotWorld.worldname + File.separator;
         try {
             File sideroad =
                 MainUtil.getFile(PlotSquared.get().IMP.getDirectory(), dir + "sideroad.schem");
@@ -59,50 +59,49 @@ public class HybridPlotManager extends ClassicPlotManager {
         } catch (IOException e) {
             e.printStackTrace();
         }
-        Template.zipAll(plotArea.worldname, files);
+        Template.zipAll(hybridPlotWorld.worldname, files);
     }
 
-    @Override public boolean createRoadEast(PlotArea plotArea, Plot plot) {
-        super.createRoadEast(plotArea, plot);
-        HybridPlotWorld hpw = (HybridPlotWorld) plotArea;
+    @Override public boolean createRoadEast(Plot plot) {
+        super.createRoadEast(plot);
         PlotId id = plot.getId();
         PlotId id2 = new PlotId(id.x + 1, id.y);
-        Location bot = getPlotBottomLocAbs(hpw, id2);
-        Location top = getPlotTopLocAbs(hpw, id);
-        Location pos1 = new Location(plotArea.worldname, top.getX() + 1, 0, bot.getZ() - 1);
+        Location bot = getPlotBottomLocAbs(id2);
+        Location top = getPlotTopLocAbs(id);
+        Location pos1 = new Location(hybridPlotWorld.worldname, top.getX() + 1, 0, bot.getZ() - 1);
         Location pos2 =
-            new Location(plotArea.worldname, bot.getX(), Math.min(getWorldHeight(), 255),
+            new Location(hybridPlotWorld.worldname, bot.getX(), Math.min(getWorldHeight(), 255),
                 top.getZ() + 1);
-        MainUtil.resetBiome(plotArea, pos1, pos2);
-        if (!hpw.ROAD_SCHEMATIC_ENABLED) {
+        MainUtil.resetBiome(hybridPlotWorld, pos1, pos2);
+        if (!hybridPlotWorld.ROAD_SCHEMATIC_ENABLED) {
             return true;
         }
-        LocalBlockQueue queue = hpw.getQueue(false);
-        createSchemAbs(hpw, queue, pos1, pos2);
+        LocalBlockQueue queue = hybridPlotWorld.getQueue(false);
+        createSchemAbs(queue, pos1, pos2);
         queue.enqueue();
         return true;
     }
 
-    private void createSchemAbs(HybridPlotWorld hpw, LocalBlockQueue queue, Location pos1,
+    private void createSchemAbs(LocalBlockQueue queue, Location pos1,
         Location pos2) {
-        int size = hpw.SIZE;
+        int size = hybridPlotWorld.SIZE;
         int minY;
         if (Settings.Schematics.PASTE_ON_TOP) {
-            minY = hpw.SCHEM_Y;
+            minY = hybridPlotWorld.SCHEM_Y;
         } else {
             minY = 1;
         }
         for (int x = pos1.getX(); x <= pos2.getX(); x++) {
-            short absX = (short) ((x - hpw.ROAD_OFFSET_X) % size);
+            short absX = (short) ((x - hybridPlotWorld.ROAD_OFFSET_X) % size);
             if (absX < 0) {
                 absX += size;
             }
             for (int z = pos1.getZ(); z <= pos2.getZ(); z++) {
-                short absZ = (short) ((z - hpw.ROAD_OFFSET_Z) % size);
+                short absZ = (short) ((z - hybridPlotWorld.ROAD_OFFSET_Z) % size);
                 if (absZ < 0) {
                     absZ += size;
                 }
-                BaseBlock[] blocks = hpw.G_SCH.get(MathMan.pair(absX, absZ));
+                BaseBlock[] blocks = hybridPlotWorld.G_SCH.get(MathMan.pair(absX, absZ));
                 if (blocks != null) {
                     for (int y = 0; y < blocks.length; y++) {
                         if (blocks[y] != null) {
@@ -114,40 +113,38 @@ public class HybridPlotManager extends ClassicPlotManager {
         }
     }
 
-    @Override public boolean createRoadSouth(PlotArea plotArea, Plot plot) {
-        super.createRoadSouth(plotArea, plot);
-        HybridPlotWorld hpw = (HybridPlotWorld) plotArea;
+    @Override public boolean createRoadSouth(Plot plot) {
+        super.createRoadSouth(plot);
         PlotId id = plot.getId();
         PlotId id2 = new PlotId(id.x, id.y + 1);
-        Location bot = getPlotBottomLocAbs(hpw, id2);
-        Location top = getPlotTopLocAbs(hpw, id);
-        Location pos1 = new Location(plotArea.worldname, bot.getX() - 1, 0, top.getZ() + 1);
+        Location bot = getPlotBottomLocAbs(id2);
+        Location top = getPlotTopLocAbs(id);
+        Location pos1 = new Location(hybridPlotWorld.worldname, bot.getX() - 1, 0, top.getZ() + 1);
         Location pos2 =
-            new Location(plotArea.worldname, top.getX() + 1, Math.min(getWorldHeight(), 255),
+            new Location(hybridPlotWorld.worldname, top.getX() + 1, Math.min(getWorldHeight(), 255),
                 bot.getZ());
-        MainUtil.resetBiome(plotArea, pos1, pos2);
-        if (!hpw.ROAD_SCHEMATIC_ENABLED) {
+        MainUtil.resetBiome(hybridPlotWorld, pos1, pos2);
+        if (!hybridPlotWorld.ROAD_SCHEMATIC_ENABLED) {
             return true;
         }
-        LocalBlockQueue queue = hpw.getQueue(false);
-        createSchemAbs(hpw, queue, pos1, pos2);
+        LocalBlockQueue queue = hybridPlotWorld.getQueue(false);
+        createSchemAbs(queue, pos1, pos2);
         queue.enqueue();
         return true;
     }
 
-    @Override public boolean createRoadSouthEast(PlotArea plotArea, Plot plot) {
-        super.createRoadSouthEast(plotArea, plot);
-        HybridPlotWorld hpw = (HybridPlotWorld) plotArea;
+    @Override public boolean createRoadSouthEast(Plot plot) {
+        super.createRoadSouthEast(plot);
         PlotId id = plot.getId();
         PlotId id2 = new PlotId(id.x + 1, id.y + 1);
-        Location pos1 = getPlotTopLocAbs(hpw, id).add(1, 0, 1);
-        Location pos2 = getPlotBottomLocAbs(hpw, id2);
+        Location pos1 = getPlotTopLocAbs(id).add(1, 0, 1);
+        Location pos2 = getPlotBottomLocAbs(id2);
         pos1.setY(0);
         pos2.setY(Math.min(getWorldHeight(), 255));
-        LocalBlockQueue queue = hpw.getQueue(false);
-        createSchemAbs(hpw, queue, pos1, pos2);
-        if (hpw.ROAD_SCHEMATIC_ENABLED) {
-            createSchemAbs(hpw, queue, pos1, pos2);
+        LocalBlockQueue queue = hybridPlotWorld.getQueue(false);
+        createSchemAbs(queue, pos1, pos2);
+        if (hybridPlotWorld.ROAD_SCHEMATIC_ENABLED) {
+            createSchemAbs(queue, pos1, pos2);
         }
         queue.enqueue();
         return true;
@@ -160,27 +157,26 @@ public class HybridPlotManager extends ClassicPlotManager {
      * don't need to do something quite as complex unless you happen to have 512x512 sized plots.
      * </p>
      */
-    @Override public boolean clearPlot(final PlotArea plotArea, Plot plot,
-        final Runnable whenDone) {
-        final String world = plotArea.worldname;
-        final HybridPlotWorld dpw = (HybridPlotWorld) plotArea;
+    @Override public boolean clearPlot(Plot plot,
+                                       final Runnable whenDone) {
+        final String world = hybridPlotWorld.worldname;
         Location pos1 = plot.getBottomAbs();
         Location pos2 = plot.getExtendedTopAbs();
         // If augmented
         final boolean canRegen =
-            (plotArea.TYPE == 0) && (plotArea.TERRAIN == 0) && REGENERATIVE_CLEAR;
+            (hybridPlotWorld.TYPE == 0) && (hybridPlotWorld.TERRAIN == 0) && REGENERATIVE_CLEAR;
         // The component blocks
-        final BlockBucket plotfloor = dpw.TOP_BLOCK;
-        final BlockBucket filling = dpw.MAIN_BLOCK;
+        final BlockBucket plotfloor = hybridPlotWorld.TOP_BLOCK;
+        final BlockBucket filling = hybridPlotWorld.MAIN_BLOCK;
         final PlotBlock bedrock;
-        if (dpw.PLOT_BEDROCK) {
+        if (hybridPlotWorld.PLOT_BEDROCK) {
             bedrock = PlotBlock.get((short) 7, (byte) 0);
         } else {
             bedrock = PlotBlock.get((short) 0, (byte) 0);
         }
         final PlotBlock air = PlotBlock.get((short) 0, (byte) 0);
-        final String biome = dpw.PLOT_BIOME;
-        final LocalBlockQueue queue = plotArea.getQueue(false);
+        final String biome = hybridPlotWorld.PLOT_BIOME;
+        final LocalBlockQueue queue = hybridPlotWorld.getQueue(false);
         ChunkManager.chunkTask(pos1, pos2, new RunnableVal<int[]>() {
             @Override public void run(int[] value) {
                 // If the chunk isn't near the edge and it isn't an augmented world we can just regen the whole chunk
@@ -197,16 +193,16 @@ public class HybridPlotManager extends ClassicPlotManager {
                 queue.setCuboid(bot, top, bedrock);
                 // Each component has a different layer
                 bot.setY(1);
-                top.setY(dpw.PLOT_HEIGHT);
+                top.setY(hybridPlotWorld.PLOT_HEIGHT);
                 queue.setCuboid(bot, top, filling);
-                bot.setY(dpw.PLOT_HEIGHT);
-                top.setY(dpw.PLOT_HEIGHT + 1);
+                bot.setY(hybridPlotWorld.PLOT_HEIGHT);
+                top.setY(hybridPlotWorld.PLOT_HEIGHT + 1);
                 queue.setCuboid(bot, top, plotfloor);
-                bot.setY(dpw.PLOT_HEIGHT + 1);
+                bot.setY(hybridPlotWorld.PLOT_HEIGHT + 1);
                 top.setY(getWorldHeight());
                 queue.setCuboid(bot, top, air);
                 // And finally set the schematic, the y value is unimportant for this function
-                pastePlotSchematic(dpw, queue, bot, top);
+                pastePlotSchematic(queue, bot, top);
             }
         }, () -> {
             queue.enqueue();
@@ -216,19 +212,18 @@ public class HybridPlotManager extends ClassicPlotManager {
         return true;
     }
 
-    public void pastePlotSchematic(HybridPlotWorld plotWorld, LocalBlockQueue queue,
+    public void pastePlotSchematic(LocalBlockQueue queue,
         Location bottom, Location top) {
-        if (!plotWorld.PLOT_SCHEMATIC) {
+        if (!hybridPlotWorld.PLOT_SCHEMATIC) {
             return;
         }
-        createSchemAbs(plotWorld, queue, bottom, top);
+        createSchemAbs(queue, bottom, top);
     }
 
     /**
      * Remove sign for a plot.
      */
-    @Override public Location getSignLoc(PlotArea plotArea, Plot plot) {
-        HybridPlotWorld dpw = (HybridPlotWorld) plotArea;
-        return dpw.getSignLocation(plot);
+    @Override public Location getSignLoc(Plot plot) {
+        return hybridPlotWorld.getSignLocation(plot);
     }
 }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridPlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridPlotManager.java
@@ -21,6 +21,17 @@ public class HybridPlotManager extends ClassicPlotManager {
 
     public static boolean REGENERATIVE_CLEAR = true;
 
+    private final HybridPlotWorld hybridPlotWorld;
+
+    public HybridPlotManager(PlotArea plotArea) {
+        super(plotArea);
+        if (plotArea instanceof HybridPlotWorld){
+            hybridPlotWorld = (HybridPlotWorld)plotArea;
+        } else {
+            throw new RuntimeException("HybridPlotManager requires plotArea to be an instance of HybridPlotWorld");
+        }
+    }
+
     @Override public void exportTemplate(PlotArea plotArea) throws IOException {
         HashSet<FileBytes> files = Sets.newHashSet(
             new FileBytes(Settings.Paths.TEMPLATES + "/tmp-data.yml", Template.getBytes(plotArea)));

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridPlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridPlotManager.java
@@ -23,13 +23,9 @@ public class HybridPlotManager extends ClassicPlotManager {
 
     private final HybridPlotWorld hybridPlotWorld;
 
-    public HybridPlotManager(PlotArea plotArea) {
-        super(plotArea);
-        if (plotArea instanceof HybridPlotWorld){
-            hybridPlotWorld = (HybridPlotWorld)plotArea;
-        } else {
-            throw new RuntimeException("HybridPlotManager requires plotArea to be an instance of HybridPlotWorld");
-        }
+    public HybridPlotManager(HybridPlotWorld hybridPlotWorld) {
+        super(hybridPlotWorld);
+        this.hybridPlotWorld = hybridPlotWorld;
     }
 
     @Override public void exportTemplate() throws IOException {

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridPlotWorld.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridPlotWorld.java
@@ -7,6 +7,7 @@ import com.github.intellectualsites.plotsquared.plot.object.Location;
 import com.github.intellectualsites.plotsquared.plot.object.Plot;
 import com.github.intellectualsites.plotsquared.plot.object.PlotArea;
 import com.github.intellectualsites.plotsquared.plot.object.PlotId;
+import com.github.intellectualsites.plotsquared.plot.object.PlotManager;
 import com.github.intellectualsites.plotsquared.plot.object.schematic.Schematic;
 import com.github.intellectualsites.plotsquared.plot.util.MainUtil;
 import com.github.intellectualsites.plotsquared.plot.util.MathMan;
@@ -41,6 +42,11 @@ public class HybridPlotWorld extends ClassicPlotWorld {
     public HybridPlotWorld(String worldName, String id, @NotNull IndependentPlotGenerator generator,
         PlotId min, PlotId max) {
         super(worldName, id, generator, min, max);
+    }
+
+    @Override
+    protected PlotManager createManager() {
+        return new HybridPlotManager(this);
     }
 
     public static byte wrap(byte data, int start) {

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridUtils.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridUtils.java
@@ -298,8 +298,8 @@ public abstract class HybridUtils {
             }
         }
         PlotManager manager = area.getPlotManager();
-        PlotId id1 = manager.getPlotId(plotWorld, x, 0, z);
-        PlotId id2 = manager.getPlotId(plotWorld, ex, 0, ez);
+        PlotId id1 = manager.getPlotId(x, 0, z);
+        PlotId id2 = manager.getPlotId(ex, 0, ez);
         x -= plotWorld.ROAD_OFFSET_X;
         z -= plotWorld.ROAD_OFFSET_Z;
         LocalBlockQueue queue = GlobalBlockQueue.IMP.getNewQueue(plotWorld.worldname, false);
@@ -332,7 +332,7 @@ public abstract class HybridUtils {
                         boolean condition;
                         if (toCheck) {
                             condition = manager
-                                .getPlotId(plotWorld, x + X + plotWorld.ROAD_OFFSET_X, 1,
+                                .getPlotId(x + X + plotWorld.ROAD_OFFSET_X, 1,
                                     z + Z + plotWorld.ROAD_OFFSET_Z) == null;
                             //                            condition = MainUtil.isPlotRoad(new Location(plotworld.worldname, x + X, 1, z + Z));
                         } else {

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/IndependentPlotGenerator.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/IndependentPlotGenerator.java
@@ -50,14 +50,6 @@ public abstract class IndependentPlotGenerator {
     public abstract PlotArea getNewPlotArea(String world, String id, PlotId min, PlotId max);
 
     /**
-     * Return a new PlotManager object.
-     *
-     * @return
-     * @param plotArea
-     */
-    public abstract PlotManager getNewPlotManager(PlotArea plotArea);
-
-    /**
      * If any additional setup options need to be changed before world creation.
      * - e.g. If setup doesn't support some standard options
      *

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/IndependentPlotGenerator.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/IndependentPlotGenerator.java
@@ -53,8 +53,9 @@ public abstract class IndependentPlotGenerator {
      * Return a new PlotManager object.
      *
      * @return
+     * @param plotArea
      */
-    public abstract PlotManager getNewPlotManager();
+    public abstract PlotManager getNewPlotManager(PlotArea plotArea);
 
     /**
      * If any additional setup options need to be changed before world creation.

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/SquarePlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/SquarePlotManager.java
@@ -16,13 +16,9 @@ public abstract class SquarePlotManager extends GridPlotManager {
 
     private final SquarePlotWorld squarePlotWorld;
 
-    public SquarePlotManager(PlotArea plotArea) {
-        super(plotArea);
-        if (plotArea instanceof SquarePlotWorld){
-            squarePlotWorld = (SquarePlotWorld)plotArea;
-        } else {
-            throw new RuntimeException("SquarePlotManager requires plotArea to be an instance of SquarePlotWorld");
-        }
+    public SquarePlotManager(SquarePlotWorld squarePlotWorld) {
+        super(squarePlotWorld);
+        this.squarePlotWorld = squarePlotWorld;
     }
 
     @Override

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/SquarePlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/SquarePlotManager.java
@@ -14,6 +14,17 @@ import java.util.Iterator;
  */
 public abstract class SquarePlotManager extends GridPlotManager {
 
+    private final SquarePlotWorld squarePlotWorld;
+
+    public SquarePlotManager(PlotArea plotArea) {
+        super(plotArea);
+        if (plotArea instanceof SquarePlotWorld){
+            squarePlotWorld = (SquarePlotWorld)plotArea;
+        } else {
+            throw new RuntimeException("SquarePlotManager requires plotArea to be an instance of SquarePlotWorld");
+        }
+    }
+
     @Override
     public boolean clearPlot(PlotArea plotArea, final Plot plot, final Runnable whenDone) {
         final HashSet<RegionWrapper> regions = plot.getRegions();

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/SquarePlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/SquarePlotManager.java
@@ -26,7 +26,7 @@ public abstract class SquarePlotManager extends GridPlotManager {
     }
 
     @Override
-    public boolean clearPlot(PlotArea plotArea, final Plot plot, final Runnable whenDone) {
+    public boolean clearPlot(final Plot plot, final Runnable whenDone) {
         final HashSet<RegionWrapper> regions = plot.getRegions();
         Runnable run = new Runnable() {
             @Override public void run() {
@@ -48,39 +48,37 @@ public abstract class SquarePlotManager extends GridPlotManager {
         return true;
     }
 
-    @Override public Location getPlotTopLocAbs(PlotArea plotArea, PlotId plotId) {
-        SquarePlotWorld dpw = (SquarePlotWorld) plotArea;
+    @Override public Location getPlotTopLocAbs(PlotId plotId) {
         int px = plotId.x;
         int pz = plotId.y;
-        int x = (dpw.ROAD_OFFSET_X + (px * (dpw.ROAD_WIDTH + dpw.PLOT_WIDTH))) - (int) Math
-            .floor(dpw.ROAD_WIDTH / 2) - 1;
-        int z = (dpw.ROAD_OFFSET_Z + (pz * (dpw.ROAD_WIDTH + dpw.PLOT_WIDTH))) - (int) Math
-            .floor(dpw.ROAD_WIDTH / 2) - 1;
-        return new Location(plotArea.worldname, x, Math.min(getWorldHeight(), 255), z);
+        int x = (squarePlotWorld.ROAD_OFFSET_X + (px * (squarePlotWorld.ROAD_WIDTH + squarePlotWorld.PLOT_WIDTH))) - (int) Math
+            .floor(squarePlotWorld.ROAD_WIDTH / 2) - 1;
+        int z = (squarePlotWorld.ROAD_OFFSET_Z + (pz * (squarePlotWorld.ROAD_WIDTH + squarePlotWorld.PLOT_WIDTH))) - (int) Math
+            .floor(squarePlotWorld.ROAD_WIDTH / 2) - 1;
+        return new Location(squarePlotWorld.worldname, x, Math.min(getWorldHeight(), 255), z);
     }
 
-    @Override public PlotId getPlotIdAbs(PlotArea plotArea, int x, int y, int z) {
-        SquarePlotWorld dpw = (SquarePlotWorld) plotArea;
-        if (dpw.ROAD_OFFSET_X != 0) {
-            x -= dpw.ROAD_OFFSET_X;
+    @Override public PlotId getPlotIdAbs(int x, int y, int z) {
+        if (squarePlotWorld.ROAD_OFFSET_X != 0) {
+            x -= squarePlotWorld.ROAD_OFFSET_X;
         }
-        if (dpw.ROAD_OFFSET_Z != 0) {
-            z -= dpw.ROAD_OFFSET_Z;
+        if (squarePlotWorld.ROAD_OFFSET_Z != 0) {
+            z -= squarePlotWorld.ROAD_OFFSET_Z;
         }
         int pathWidthLower;
         int end;
-        if (dpw.ROAD_WIDTH == 0) {
+        if (squarePlotWorld.ROAD_WIDTH == 0) {
             pathWidthLower = -1;
-            end = dpw.PLOT_WIDTH;
+            end = squarePlotWorld.PLOT_WIDTH;
         } else {
-            if ((dpw.ROAD_WIDTH % 2) == 0) {
-                pathWidthLower = (dpw.ROAD_WIDTH / 2) - 1;
+            if ((squarePlotWorld.ROAD_WIDTH % 2) == 0) {
+                pathWidthLower = (squarePlotWorld.ROAD_WIDTH / 2) - 1;
             } else {
-                pathWidthLower = dpw.ROAD_WIDTH / 2;
+                pathWidthLower = squarePlotWorld.ROAD_WIDTH / 2;
             }
-            end = pathWidthLower + dpw.PLOT_WIDTH;
+            end = pathWidthLower + squarePlotWorld.PLOT_WIDTH;
         }
-        int size = dpw.PLOT_WIDTH + dpw.ROAD_WIDTH;
+        int size = squarePlotWorld.PLOT_WIDTH + squarePlotWorld.ROAD_WIDTH;
         int idx;
         if (x < 0) {
             idx = x / size;
@@ -128,27 +126,23 @@ public abstract class SquarePlotManager extends GridPlotManager {
         return new PlotId(idx, idz);
     }
 
-    @Override public PlotId getPlotId(PlotArea plotArea, int x, int y, int z) {
+    @Override public PlotId getPlotId(int x, int y, int z) {
         try {
-            SquarePlotWorld dpw = (SquarePlotWorld) plotArea;
-            if (plotArea == null) {
-                return null;
-            }
-            x -= dpw.ROAD_OFFSET_X;
-            z -= dpw.ROAD_OFFSET_Z;
-            int size = dpw.PLOT_WIDTH + dpw.ROAD_WIDTH;
+            x -= squarePlotWorld.ROAD_OFFSET_X;
+            z -= squarePlotWorld.ROAD_OFFSET_Z;
+            int size = squarePlotWorld.PLOT_WIDTH + squarePlotWorld.ROAD_WIDTH;
             int pathWidthLower;
             int end;
-            if (dpw.ROAD_WIDTH == 0) {
+            if (squarePlotWorld.ROAD_WIDTH == 0) {
                 pathWidthLower = -1;
-                end = dpw.PLOT_WIDTH;
+                end = squarePlotWorld.PLOT_WIDTH;
             } else {
-                if ((dpw.ROAD_WIDTH % 2) == 0) {
-                    pathWidthLower = (dpw.ROAD_WIDTH / 2) - 1;
+                if ((squarePlotWorld.ROAD_WIDTH % 2) == 0) {
+                    pathWidthLower = (squarePlotWorld.ROAD_WIDTH / 2) - 1;
                 } else {
-                    pathWidthLower = dpw.ROAD_WIDTH / 2;
+                    pathWidthLower = squarePlotWorld.ROAD_WIDTH / 2;
                 }
-                end = pathWidthLower + dpw.PLOT_WIDTH;
+                end = pathWidthLower + squarePlotWorld.PLOT_WIDTH;
             }
             int dx;
             int rx;
@@ -176,7 +170,7 @@ public abstract class SquarePlotManager extends GridPlotManager {
             if (hash == 0) {
                 return id;
             }
-            Plot plot = plotArea.getOwnedPlotAbs(id);
+            Plot plot = squarePlotWorld.getOwnedPlotAbs(id);
             // Not merged, and standing on road
             if (plot == null) {
                 return null;
@@ -210,7 +204,7 @@ public abstract class SquarePlotManager extends GridPlotManager {
             PlotSquared.debug("invalid location: " + Arrays.toString(merged));
         } catch (Exception ignored) {
             PlotSquared.debug(
-                "Invalid plot / road width in settings.yml for world: " + plotArea.worldname);
+                "Invalid plot / road width in settings.yml for world: " + squarePlotWorld.worldname);
         }
         return null;
     }
@@ -218,14 +212,13 @@ public abstract class SquarePlotManager extends GridPlotManager {
     /**
      * Get the bottom plot loc (some basic math).
      */
-    @Override public Location getPlotBottomLocAbs(PlotArea plotArea, PlotId plotId) {
-        SquarePlotWorld dpw = (SquarePlotWorld) plotArea;
+    @Override public Location getPlotBottomLocAbs(PlotId plotId) {
         int px = plotId.x;
         int pz = plotId.y;
-        int x = (dpw.ROAD_OFFSET_X + (px * (dpw.ROAD_WIDTH + dpw.PLOT_WIDTH))) - dpw.PLOT_WIDTH
-            - (int) Math.floor(dpw.ROAD_WIDTH / 2);
-        int z = (dpw.ROAD_OFFSET_Z + (pz * (dpw.ROAD_WIDTH + dpw.PLOT_WIDTH))) - dpw.PLOT_WIDTH
-            - (int) Math.floor(dpw.ROAD_WIDTH / 2);
-        return new Location(plotArea.worldname, x, plotArea.MIN_BUILD_HEIGHT, z);
+        int x = (squarePlotWorld.ROAD_OFFSET_X + (px * (squarePlotWorld.ROAD_WIDTH + squarePlotWorld.PLOT_WIDTH))) - squarePlotWorld.PLOT_WIDTH
+            - (int) Math.floor(squarePlotWorld.ROAD_WIDTH / 2);
+        int z = (squarePlotWorld.ROAD_OFFSET_Z + (pz * (squarePlotWorld.ROAD_WIDTH + squarePlotWorld.PLOT_WIDTH))) - squarePlotWorld.PLOT_WIDTH
+            - (int) Math.floor(squarePlotWorld.ROAD_WIDTH / 2);
+        return new Location(squarePlotWorld.worldname, x, squarePlotWorld.MIN_BUILD_HEIGHT, z);
     }
 }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/Plot.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/Plot.java
@@ -854,9 +854,9 @@ public class Plot {
                     };
                     for (Plot current : plots) {
                         if (isDelete || current.owner == null) {
-                            manager.unClaimPlot(Plot.this.area, current, null);
+                            manager.unClaimPlot(current, null);
                         } else {
-                            manager.claimPlot(Plot.this.area, current);
+                            manager.claimPlot(current);
                         }
                     }
                     GlobalBlockQueue.IMP.addTask(run);
@@ -868,7 +868,7 @@ public class Plot {
                         .regenerateRegion(current.getBottomAbs(), current.getTopAbs(), false, this);
                     return;
                 }
-                manager.clearPlot(Plot.this.area, current, this);
+                manager.clearPlot(current, this);
             }
         };
         run.run();
@@ -943,20 +943,20 @@ public class Plot {
         }
         PlotManager manager = this.area.getPlotManager();
         if (createRoad) {
-            manager.startPlotUnlink(this.area, ids);
+            manager.startPlotUnlink(ids);
         }
         if (this.area.TERRAIN != 3 && createRoad) {
             for (Plot current : plots) {
                 if (current.getMerged(Direction.EAST)) {
-                    manager.createRoadEast(current.area, current);
+                    manager.createRoadEast(current);
                     if (current.getMerged(Direction.SOUTH)) {
-                        manager.createRoadSouth(current.area, current);
+                        manager.createRoadSouth(current);
                         if (current.getMerged(Direction.SOUTHEAST)) {
-                            manager.createRoadSouthEast(current.area, current);
+                            manager.createRoadSouthEast(current);
                         }
                     }
                 } else if (current.getMerged(Direction.SOUTH)) {
-                    manager.createRoadSouth(current.area, current);
+                    manager.createRoadSouth(current);
                 }
             }
         }
@@ -972,7 +972,7 @@ public class Plot {
             });
         }
         if (createRoad) {
-            manager.finishPlotUnlink(this.area, ids);
+            manager.finishPlotUnlink(ids);
         }
         return true;
     }
@@ -992,7 +992,7 @@ public class Plot {
         }
         PlotManager manager = this.area.getPlotManager();
         if (this.area.ALLOW_SIGNS) {
-            Location loc = manager.getSignLoc(this.area, this);
+            Location loc = manager.getSignLoc(this);
             String id = this.id.x + ";" + this.id.y;
             String[] lines =
                 new String[] {Captions.OWNER_SIGN_LINE_1.formatted().replaceAll("%id%", id),
@@ -1207,7 +1207,7 @@ public class Plot {
         int y =
             isLoaded() ? WorldUtil.IMP.getHighestBlock(getWorldName(), loc.getX(), loc.getZ()) : 62;
         if (area.ALLOW_SIGNS) {
-            y = Math.max(y, getManager().getSignLoc(area, this).getY());
+            y = Math.max(y, getManager().getSignLoc(this).getY());
         }
         loc.setY(1 + y);
         return loc;
@@ -1220,7 +1220,7 @@ public class Plot {
         PlotManager manager = getManager();
         int y = isLoaded() ? WorldUtil.IMP.getHighestBlock(getWorldName(), x, z) : 62;
         if (area.ALLOW_SIGNS && (y <= 0 || y >= 255)) {
-            y = Math.max(y, manager.getSignLoc(area, this).getY() - 1);
+            y = Math.max(y, manager.getSignLoc(this).getY() - 1);
         }
         return new Location(getWorldName(), x, y + 1, z);
     }
@@ -1413,7 +1413,7 @@ public class Plot {
         if (!this.area.ALLOW_SIGNS) {
             return;
         }
-        Location loc = manager.getSignLoc(this.area, this);
+        Location loc = manager.getSignLoc(this);
         LocalBlockQueue queue = GlobalBlockQueue.IMP.getNewQueue(getWorldName(), false);
         queue.setBlock(loc.getX(), loc.getY(), loc.getZ(), PlotBlock.get("air"));
         queue.flush();
@@ -1496,7 +1496,7 @@ public class Plot {
                     }
                 });
         }
-        plotworld.getPlotManager().claimPlot(plotworld, this);
+        plotworld.getPlotManager().claimPlot(this);
         return true;
     }
 
@@ -1565,7 +1565,7 @@ public class Plot {
      * Returns the top location for the plot.
      */
     public Location getTopAbs() {
-        Location top = this.area.getPlotManager().getPlotTopLocAbs(this.area, this.id);
+        Location top = getManager().getPlotTopLocAbs(this.id);
         top.setWorld(getWorldName());
         return top;
     }
@@ -1576,7 +1576,7 @@ public class Plot {
      * Returns the bottom location for the plot.
      */
     public Location getBottomAbs() {
-        Location loc = this.area.getPlotManager().getPlotBottomLocAbs(this.area, this.id);
+        Location loc = getManager().getPlotBottomLocAbs(this.id);
         loc.setWorld(getWorldName());
         return loc;
     }
@@ -1724,7 +1724,7 @@ public class Plot {
             Location pos2 = new Location(this.getWorldName(), bot.getX(), MAX_HEIGHT, top.getZ());
             ChunkManager.manager.regenerateRegion(pos1, pos2, true, null);
         } else {
-            this.area.getPlotManager().removeRoadEast(this.area, this);
+            this.area.getPlotManager().removeRoadEast(this);
         }
     }
 
@@ -2124,7 +2124,7 @@ public class Plot {
             return null;
         }
         try {
-            final Location loc = this.getManager().getSignLoc(this.area, this);
+            final Location loc = this.getManager().getSignLoc(this);
             String[] lines = TaskManager.IMP.sync(new RunnableVal<String[]>() {
                 @Override public void run(String[] value) {
                     ChunkManager.manager.loadChunk(loc.getWorld(), loc.getChunkLoc(), false);
@@ -2193,7 +2193,7 @@ public class Plot {
             Location pos2 = new Location(this.getWorldName(), top.getX(), MAX_HEIGHT, bot.getZ());
             ChunkManager.manager.regenerateRegion(pos1, pos2, true, null);
         } else {
-            this.getManager().removeRoadSouth(this.area, this);
+            this.getManager().removeRoadSouth(this);
         }
     }
 
@@ -2246,7 +2246,7 @@ public class Plot {
                         ArrayList<PlotId> ids = new ArrayList<>();
                         ids.add(current.getId());
                         ids.add(other.getId());
-                        this.getManager().finishPlotMerge(this.area, ids);
+                        this.getManager().finishPlotMerge(ids);
                     }
                 }
             }
@@ -2265,7 +2265,7 @@ public class Plot {
                         ArrayList<PlotId> ids = new ArrayList<>();
                         ids.add(current.getId());
                         ids.add(other.getId());
-                        this.getManager().finishPlotMerge(this.area, ids);
+                        this.getManager().finishPlotMerge(ids);
                     }
                 }
             }
@@ -2284,7 +2284,7 @@ public class Plot {
                         ArrayList<PlotId> ids = new ArrayList<>();
                         ids.add(current.getId());
                         ids.add(other.getId());
-                        this.getManager().finishPlotMerge(this.area, ids);
+                        this.getManager().finishPlotMerge(ids);
                     }
                 }
             }
@@ -2303,7 +2303,7 @@ public class Plot {
                         ArrayList<PlotId> ids = new ArrayList<>();
                         ids.add(current.getId());
                         ids.add(other.getId());
-                        this.getManager().finishPlotMerge(this.area, ids);
+                        this.getManager().finishPlotMerge(ids);
                     }
                 }
             }
@@ -2372,7 +2372,7 @@ public class Plot {
             pos2.setY(MAX_HEIGHT);
             ChunkManager.manager.regenerateRegion(pos1, pos2, true, null);
         } else {
-            this.area.getPlotManager().removeRoadSouthEast(this.area, this);
+            this.area.getPlotManager().removeRoadSouthEast(this);
         }
     }
 
@@ -2813,15 +2813,15 @@ public class Plot {
      */
     public boolean setComponent(String component, BlockBucket blocks) {
         if (StringMan
-            .isEqualToAny(component, getManager().getPlotComponents(this.area, this.getId()))) {
+            .isEqualToAny(component, getManager().getPlotComponents(this.getId()))) {
             EventUtil.manager.callComponentSet(this, component);
         }
-        return this.getManager().setComponent(this.area, this.getId(), component, blocks);
+        return this.getManager().setComponent(this.getId(), component, blocks);
     }
 
     public int getDistanceFromOrigin() {
-        Location bot = getManager().getPlotBottomLocAbs(this.area, id);
-        Location top = getManager().getPlotTopLocAbs(this.area, id);
+        Location bot = getManager().getPlotBottomLocAbs(id);
+        Location top = getManager().getPlotTopLocAbs(id);
         return Math.max(Math.max(Math.abs(bot.getX()), Math.abs(bot.getZ())),
             Math.max(Math.abs(top.getX()), Math.abs(top.getZ())));
     }
@@ -2967,10 +2967,10 @@ public class Plot {
                     if (regions.isEmpty()) {
                         Plot plot = destination.getRelative(0, 0);
                         for (Plot current : plot.getConnectedPlots()) {
-                            getManager().claimPlot(current.getArea(), current);
+                            getManager().claimPlot(current);
                             Plot originPlot = originArea.getPlotAbs(
                                 new PlotId(current.id.x - offset.x, current.id.y - offset.y));
-                            originPlot.getManager().unClaimPlot(originArea, originPlot, null);
+                            originPlot.getManager().unClaimPlot(originPlot, null);
                         }
                         plot.setSign();
                         TaskManager.runTask(whenDone);
@@ -3056,7 +3056,7 @@ public class Plot {
             @Override public void run() {
                 if (regions.isEmpty()) {
                     for (Plot current : getConnectedPlots()) {
-                        destination.getManager().claimPlot(destination.getArea(), destination);
+                        destination.getManager().claimPlot(destination);
                     }
                     destination.setSign();
                     TaskManager.runTask(whenDone);

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotArea.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotArea.java
@@ -81,7 +81,7 @@ public abstract class PlotArea {
         @Nullable final PlotId max) {
         this.worldname = worldName;
         this.id = id;
-        this.manager = generator.getNewPlotManager(this);
+        this.manager = createManager();
         this.generator = generator;
         if (min == null || max == null) {
             if (min != max) {
@@ -101,6 +101,8 @@ public abstract class PlotArea {
             blockBucketChunk = null;
         }
     }
+
+    protected abstract PlotManager createManager();
 
     public LocalBlockQueue getQueue(final boolean autoQueue) {
         return GlobalBlockQueue.IMP.getNewQueue(worldname, autoQueue);

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotArea.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotArea.java
@@ -81,7 +81,7 @@ public abstract class PlotArea {
         @Nullable final PlotId max) {
         this.worldname = worldName;
         this.id = id;
-        this.manager = generator.getNewPlotManager();
+        this.manager = generator.getNewPlotManager(this);
         this.generator = generator;
         if (min == null || max == null) {
             if (min != max) {

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotArea.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotArea.java
@@ -144,8 +144,8 @@ public abstract class PlotArea {
     private RegionWrapper getRegionAbs() {
         if (this.region == null) {
             if (this.min != null) {
-                Location bot = getPlotManager().getPlotBottomLocAbs(this, this.min);
-                Location top = getPlotManager().getPlotTopLocAbs(this, this.max);
+                Location bot = getPlotManager().getPlotBottomLocAbs(this.min);
+                Location top = getPlotManager().getPlotTopLocAbs(this.max);
                 this.region = new RegionWrapper(bot.getX() - 1, top.getX() + 1, bot.getZ() - 1,
                     top.getZ() + 1);
             }
@@ -422,7 +422,7 @@ public abstract class PlotArea {
      */
     @Nullable public Plot getPlotAbs(@Nonnull final Location location) {
         final PlotId pid =
-            this.manager.getPlotId(this, location.getX(), location.getY(), location.getZ());
+            this.manager.getPlotId(location.getX(), location.getY(), location.getZ());
         if (pid == null) {
             return null;
         }
@@ -437,7 +437,7 @@ public abstract class PlotArea {
      */
     @Nullable public Plot getPlot(@Nonnull final Location location) {
         final PlotId pid =
-            this.manager.getPlotId(this, location.getX(), location.getY(), location.getZ());
+            this.manager.getPlotId(location.getX(), location.getY(), location.getZ());
         if (pid == null) {
             return null;
         }
@@ -452,7 +452,7 @@ public abstract class PlotArea {
      */
     @Nullable public Plot getOwnedPlot(@Nonnull final Location location) {
         final PlotId pid =
-            this.manager.getPlotId(this, location.getX(), location.getY(), location.getZ());
+            this.manager.getPlotId(location.getX(), location.getY(), location.getZ());
         if (pid == null) {
             return null;
         }
@@ -468,7 +468,7 @@ public abstract class PlotArea {
      */
     @Nullable public Plot getOwnedPlotAbs(@Nonnull final Location location) {
         final PlotId pid =
-            this.manager.getPlotId(this, location.getX(), location.getY(), location.getZ());
+            this.manager.getPlotId(location.getX(), location.getY(), location.getZ());
         if (pid == null) {
             return null;
         }
@@ -835,7 +835,7 @@ public abstract class PlotArea {
             return false;
         }
 
-        manager.startPlotMerge(this, plotIds);
+        manager.startPlotMerge(plotIds);
         final Set<UUID> trusted = new HashSet<>();
         final Set<UUID> members = new HashSet<>();
         final Set<UUID> denied = new HashSet<>();
@@ -887,7 +887,7 @@ public abstract class PlotArea {
                 }
             }
         }
-        manager.finishPlotMerge(this, plotIds);
+        manager.finishPlotMerge(plotIds);
         return true;
     }
 

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotCluster.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotCluster.java
@@ -132,7 +132,7 @@ public class PlotCluster {
             toReturn = center.getHome();
             if (toReturn.getY() == 0) {
                 PlotManager manager = this.area.getPlotManager();
-                Location loc = manager.getSignLoc(this.area, center);
+                Location loc = manager.getSignLoc(center);
                 toReturn.setY(loc.getY());
             }
         } else {
@@ -157,12 +157,12 @@ public class PlotCluster {
 
     public Location getClusterBottom() {
         PlotManager manager = this.area.getPlotManager();
-        return manager.getPlotBottomLocAbs(this.area, getP1());
+        return manager.getPlotBottomLocAbs(getP1());
     }
 
     public Location getClusterTop() {
         PlotManager manager = this.area.getPlotManager();
-        return manager.getPlotTopLocAbs(this.area, getP2());
+        return manager.getPlotTopLocAbs(getP2());
     }
 
     public boolean intersects(PlotId pos1, PlotId pos2) {

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotManager.java
@@ -10,6 +10,13 @@ import java.util.List;
 
 public abstract class PlotManager {
 
+    private final PlotArea plotArea;
+
+    public PlotManager(PlotArea plotArea) {
+
+        this.plotArea = plotArea;
+    }
+
     /*
      * Plot locations (methods with Abs in them will not need to consider mega
      * plots).

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotManager.java
@@ -13,7 +13,6 @@ public abstract class PlotManager {
     private final PlotArea plotArea;
 
     public PlotManager(PlotArea plotArea) {
-
         this.plotArea = plotArea;
     }
 

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotManager.java
@@ -21,61 +21,61 @@ public abstract class PlotManager {
      * Plot locations (methods with Abs in them will not need to consider mega
      * plots).
      */
-    public abstract PlotId getPlotIdAbs(PlotArea plotArea, int x, int y, int z);
+    public abstract PlotId getPlotIdAbs(int x, int y, int z);
 
-    public abstract PlotId getPlotId(PlotArea plotArea, int x, int y, int z);
+    public abstract PlotId getPlotId(int x, int y, int z);
 
     // If you have a circular plot, just return the corner if it were a square
-    public abstract Location getPlotBottomLocAbs(PlotArea plotArea, PlotId plotId);
+    public abstract Location getPlotBottomLocAbs(PlotId plotId);
 
     // the same applies here
-    public abstract Location getPlotTopLocAbs(PlotArea plotArea, PlotId plotId);
+    public abstract Location getPlotTopLocAbs(PlotId plotId);
 
     /*
      * Plot clearing (return false if you do not support some method)
      */
-    public abstract boolean clearPlot(PlotArea plotArea, Plot plot, Runnable whenDone);
+    public abstract boolean clearPlot(Plot plot, Runnable whenDone);
 
-    public abstract boolean claimPlot(PlotArea plotArea, Plot plot);
+    public abstract boolean claimPlot(Plot plot);
 
-    public abstract boolean unClaimPlot(PlotArea plotArea, Plot plot, Runnable whenDone);
+    public abstract boolean unClaimPlot(Plot plot, Runnable whenDone);
 
-    public abstract Location getSignLoc(PlotArea plotArea, Plot plot);
+    public abstract Location getSignLoc(Plot plot);
 
     /*
      * Plot set functions (return false if you do not support the specific set
      * method).
      */
-    public abstract String[] getPlotComponents(PlotArea plotArea, PlotId plotId);
+    public abstract String[] getPlotComponents(PlotId plotId);
 
-    public abstract boolean setComponent(PlotArea plotArea, PlotId plotId, String component,
-        BlockBucket blocks);
+    public abstract boolean setComponent(PlotId plotId, String component,
+                                         BlockBucket blocks);
 
     /*
      * PLOT MERGING (return false if your generator does not support plot
      * merging).
      */
-    public abstract boolean createRoadEast(PlotArea plotArea, Plot plot);
+    public abstract boolean createRoadEast(Plot plot);
 
-    public abstract boolean createRoadSouth(PlotArea plotArea, Plot plot);
+    public abstract boolean createRoadSouth(Plot plot);
 
-    public abstract boolean createRoadSouthEast(PlotArea plotArea, Plot plot);
+    public abstract boolean createRoadSouthEast(Plot plot);
 
-    public abstract boolean removeRoadEast(PlotArea plotArea, Plot plot);
+    public abstract boolean removeRoadEast(Plot plot);
 
-    public abstract boolean removeRoadSouth(PlotArea plotArea, Plot plot);
+    public abstract boolean removeRoadSouth(Plot plot);
 
-    public abstract boolean removeRoadSouthEast(PlotArea plotArea, Plot plot);
+    public abstract boolean removeRoadSouthEast(Plot plot);
 
-    public abstract boolean startPlotMerge(PlotArea plotArea, List<PlotId> plotIds);
+    public abstract boolean startPlotMerge(List<PlotId> plotIds);
 
-    public abstract boolean startPlotUnlink(PlotArea plotArea, List<PlotId> plotIds);
+    public abstract boolean startPlotUnlink(List<PlotId> plotIds);
 
-    public abstract boolean finishPlotMerge(PlotArea plotArea, List<PlotId> plotIds);
+    public abstract boolean finishPlotMerge(List<PlotId> plotIds);
 
-    public abstract boolean finishPlotUnlink(PlotArea plotArea, List<PlotId> plotIds);
+    public abstract boolean finishPlotUnlink(List<PlotId> plotIds);
 
-    public void exportTemplate(PlotArea plotArea) throws IOException {
+    public void exportTemplate() throws IOException {
         HashSet<FileBytes> files = new HashSet<>(Collections.singletonList(
             new FileBytes(Settings.Paths.TEMPLATES + "/tmp-data.yml",
                 Template.getBytes(plotArea))));

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/worlds/SinglePlotArea.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/worlds/SinglePlotArea.java
@@ -26,6 +26,11 @@ public class SinglePlotArea extends GridPlotWorld {
         this.DEFAULT_HOME = new PlotLoc(Integer.MAX_VALUE, Integer.MAX_VALUE);
     }
 
+    @Override
+    protected PlotManager createManager() {
+        return new SinglePlotManager(this);
+    }
+
     @Override public void loadConfiguration(ConfigurationSection config) {
         VOID = config.getBoolean("void", false);
     }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/worlds/SinglePlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/worlds/SinglePlotManager.java
@@ -14,23 +14,23 @@ public class SinglePlotManager extends PlotManager {
         super(plotArea);
     }
 
-    @Override public PlotId getPlotIdAbs(PlotArea plotArea, int x, int y, int z) {
+    @Override public PlotId getPlotIdAbs(int x, int y, int z) {
         return new PlotId(0, 0);
     }
 
-    @Override public PlotId getPlotId(PlotArea plotArea, int x, int y, int z) {
+    @Override public PlotId getPlotId(int x, int y, int z) {
         return new PlotId(0, 0);
     }
 
-    @Override public Location getPlotBottomLocAbs(PlotArea plotArea, PlotId plotId) {
+    @Override public Location getPlotBottomLocAbs(PlotId plotId) {
         return new Location(plotId.toCommaSeparatedString(), -30000000, 0, -30000000);
     }
 
-    @Override public Location getPlotTopLocAbs(PlotArea plotArea, PlotId plotId) {
+    @Override public Location getPlotTopLocAbs(PlotId plotId) {
         return new Location(plotId.toCommaSeparatedString(), 30000000, 0, 30000000);
     }
 
-    @Override public boolean clearPlot(PlotArea plotArea, Plot plot, final Runnable whenDone) {
+    @Override public boolean clearPlot(Plot plot, final Runnable whenDone) {
         SetupUtils.manager.unload(plot.getWorldName(), false);
         final File worldFolder =
             new File(PlotSquared.get().IMP.getWorldContainer(), plot.getWorldName());
@@ -43,68 +43,68 @@ public class SinglePlotManager extends PlotManager {
         return true;
     }
 
-    @Override public boolean claimPlot(PlotArea plotArea, Plot plot) {
+    @Override public boolean claimPlot(Plot plot) {
         // TODO
         return true;
     }
 
-    @Override public boolean unClaimPlot(PlotArea plotArea, Plot plot, Runnable whenDone) {
+    @Override public boolean unClaimPlot(Plot plot, Runnable whenDone) {
         if (whenDone != null) {
             whenDone.run();
         }
         return true;
     }
 
-    @Override public Location getSignLoc(PlotArea plotArea, Plot plot) {
+    @Override public Location getSignLoc(Plot plot) {
         return null;
     }
 
-    @Override public String[] getPlotComponents(PlotArea plotArea, PlotId plotId) {
+    @Override public String[] getPlotComponents(PlotId plotId) {
         return new String[0];
     }
 
-    @Override public boolean setComponent(PlotArea plotArea, PlotId plotId, String component,
-        BlockBucket blocks) {
+    @Override public boolean setComponent(PlotId plotId, String component,
+                                          BlockBucket blocks) {
         return false;
     }
 
-    @Override public boolean createRoadEast(PlotArea plotArea, Plot plot) {
+    @Override public boolean createRoadEast(Plot plot) {
         return false;
     }
 
-    @Override public boolean createRoadSouth(PlotArea plotArea, Plot plot) {
+    @Override public boolean createRoadSouth(Plot plot) {
         return false;
     }
 
-    @Override public boolean createRoadSouthEast(PlotArea plotArea, Plot plot) {
+    @Override public boolean createRoadSouthEast(Plot plot) {
         return false;
     }
 
-    @Override public boolean removeRoadEast(PlotArea plotArea, Plot plot) {
+    @Override public boolean removeRoadEast(Plot plot) {
         return false;
     }
 
-    @Override public boolean removeRoadSouth(PlotArea plotArea, Plot plot) {
+    @Override public boolean removeRoadSouth(Plot plot) {
         return false;
     }
 
-    @Override public boolean removeRoadSouthEast(PlotArea plotArea, Plot plot) {
+    @Override public boolean removeRoadSouthEast(Plot plot) {
         return false;
     }
 
-    @Override public boolean startPlotMerge(PlotArea plotArea, List<PlotId> plotIds) {
+    @Override public boolean startPlotMerge(List<PlotId> plotIds) {
         return false;
     }
 
-    @Override public boolean startPlotUnlink(PlotArea plotArea, List<PlotId> plotIds) {
+    @Override public boolean startPlotUnlink(List<PlotId> plotIds) {
         return false;
     }
 
-    @Override public boolean finishPlotMerge(PlotArea plotArea, List<PlotId> plotIds) {
+    @Override public boolean finishPlotMerge(List<PlotId> plotIds) {
         return false;
     }
 
-    @Override public boolean finishPlotUnlink(PlotArea plotArea, List<PlotId> plotIds) {
+    @Override public boolean finishPlotUnlink(List<PlotId> plotIds) {
         return false;
     }
 }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/worlds/SinglePlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/worlds/SinglePlotManager.java
@@ -10,6 +10,10 @@ import java.io.File;
 import java.util.List;
 
 public class SinglePlotManager extends PlotManager {
+    public SinglePlotManager(PlotArea plotArea) {
+        super(plotArea);
+    }
+
     @Override public PlotId getPlotIdAbs(PlotArea plotArea, int x, int y, int z) {
         return new PlotId(0, 0);
     }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/worlds/SingleWorldGenerator.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/worlds/SingleWorldGenerator.java
@@ -81,10 +81,6 @@ public class SingleWorldGenerator extends IndependentPlotGenerator {
         return ((SinglePlotAreaManager) PlotSquared.get().getPlotAreaManager()).getArea();
     }
 
-    @Override public PlotManager getNewPlotManager(PlotArea plotArea) {
-        return new SinglePlotManager(plotArea);
-    }
-
     @Override public void initialize(PlotArea area) {
 
     }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/worlds/SingleWorldGenerator.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/worlds/SingleWorldGenerator.java
@@ -81,8 +81,8 @@ public class SingleWorldGenerator extends IndependentPlotGenerator {
         return ((SinglePlotAreaManager) PlotSquared.get().getPlotAreaManager()).getArea();
     }
 
-    @Override public PlotManager getNewPlotManager() {
-        return new SinglePlotManager();
+    @Override public PlotManager getNewPlotManager(PlotArea plotArea) {
+        return new SinglePlotManager(plotArea);
     }
 
     @Override public void initialize(PlotArea area) {


### PR DESCRIPTION
I have made changes that can be summed up as these three key points:
* `PlotManager`s now hold a reference to the `PlotArea` they are managing.
* Removed `PlotArea` from all `PlotManager` methods, as the `PlotManager` has a reference to its `PlotArea`, as per the previous point.
* Moved `PlotManager` creation from the `PlotGenerator` to the `PlotArea`, i.e. a `PlotArea` now creates its own `PlotManager`. This lets it pass on the most specific `PlotArea` subclass possible to its `PlotManager`, greatly reducing the need for down-casting or instanceof checks everywhere.

The constant casting (and occasional use of instanceof) indicated to me that there was a big code smell going on with these classes, and the changes I've made have all but eliminated it. In theory, what I've done shouldn't change anything about the functionality of anything, although it is of course possible I've missed something, in which case, let me know.

There are some remaining undesirable down-castings and instanceof uses in other places, which indicates that there are likely leaky abstractions and poor encapsulation still remaining in the code.