### PR TITLE
Fix the plot border after road regeneration

### DIFF
--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/DebugRoadRegen.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/DebugRoadRegen.java
@@ -2,6 +2,9 @@ package com.github.intellectualsites.plotsquared.plot.commands;
 
 import com.github.intellectualsites.plotsquared.commands.CommandDeclaration;
 import com.github.intellectualsites.plotsquared.plot.config.Captions;
+import com.github.intellectualsites.plotsquared.plot.generator.HybridPlotManager;
+import com.github.intellectualsites.plotsquared.plot.generator.HybridPlotWorld;
+import com.github.intellectualsites.plotsquared.plot.generator.HybridUtils;
 import com.github.intellectualsites.plotsquared.plot.object.Location;
 import com.github.intellectualsites.plotsquared.plot.object.Plot;
 import com.github.intellectualsites.plotsquared.plot.object.PlotArea;
@@ -9,13 +12,37 @@ import com.github.intellectualsites.plotsquared.plot.object.PlotManager;
 import com.github.intellectualsites.plotsquared.plot.object.PlotPlayer;
 import com.github.intellectualsites.plotsquared.plot.util.MainUtil;
 
-@CommandDeclaration(command = "debugroadregen", usage = "/plot debugroadregen",
+import java.util.Arrays;
+
+@CommandDeclaration(command = "debugroadregen", usage = DebugRoadRegen.USAGE,
     requiredType = RequiredType.NONE,
-    description = "Regenerate all roads based on the road schematic",
+    description = "Regenerate roads in the plot or region the user is, based on the road schematic",
     category = CommandCategory.DEBUG, permission = "plots.debugroadregen")
 public class DebugRoadRegen extends SubCommand {
+    public static final String USAGE = "/plot debugroadregen <plot|region [height]>";
 
     @Override public boolean onCommand(PlotPlayer player, String[] args) {
+        if (args.length < 1) {
+            MainUtil.sendMessage(player, Captions.COMMAND_SYNTAX,
+                DebugRoadRegen.USAGE);
+            return false;
+        }
+        String kind = args[0].toLowerCase();
+        switch (kind) {
+            case "plot":
+                return regenPlot(player);
+
+            case "region":
+                return regenRegion(player, Arrays.copyOfRange(args, 1, args.length));
+
+            default:
+                MainUtil.sendMessage(player, Captions.COMMAND_SYNTAX,
+                    DebugRoadRegen.USAGE);
+                return false;
+        }
+    }
+
+    public boolean regenPlot(PlotPlayer player) {
         Location loc = player.getLocation();
         PlotArea area = loc.getPlotArea();
         if (area == null) {
@@ -34,6 +61,48 @@ public class DebugRoadRegen extends SubCommand {
             MainUtil.sendMessage(player, "&6Regenerating plot south/east roads: " + plot.getId()
                 + "\n&6 - Result: &aSuccess");
             MainUtil.sendMessage(player, "&cTo regenerate all roads: /plot regenallroads");
+        }
+        return true;
+    }
+
+    public boolean regenRegion(PlotPlayer player, String[] args) {
+        int height = 0;
+        if (args.length == 1) {
+            try {
+                height = Integer.parseInt(args[0]);
+            } catch (NumberFormatException ignored) {
+                MainUtil.sendMessage(player, Captions.NOT_VALID_NUMBER, "(0, 256)");
+                MainUtil.sendMessage(player, Captions.COMMAND_SYNTAX,
+                    DebugRoadRegen.USAGE);
+                return false;
+            }
+        } else if (args.length != 0) {
+            MainUtil.sendMessage(player, Captions.COMMAND_SYNTAX,
+                DebugRoadRegen.USAGE);
+            return false;
+        }
+
+        Location loc = player.getLocation();
+        PlotArea area = loc.getPlotArea();
+        if (area == null) {
+            return sendMessage(player, Captions.NOT_IN_PLOT_WORLD);
+        }
+        Plot plot = player.getCurrentPlot();
+        PlotManager manager = area.getPlotManager();
+        if (!(manager instanceof HybridPlotManager)) {
+            MainUtil.sendMessage(player, Captions.NOT_VALID_PLOT_WORLD);
+            return true;
+        }
+        MainUtil
+            .sendMessage(player, "&cIf no schematic is set, the following will not do anything");
+        MainUtil.sendMessage(player,
+            "&7 - To set a schematic, stand in a plot and use &c/plot createroadschematic");
+        MainUtil.sendMessage(player, "&cTo regenerate all roads: /plot regenallroads");
+        boolean result = HybridUtils.manager.scheduleSingleRegionRoadUpdate(plot, height);
+        if (!result) {
+            MainUtil.sendMessage(player,
+                "&cCannot schedule mass schematic update! (Is one already in progress?)");
+            return false;
         }
         return true;
     }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/ClassicPlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/ClassicPlotManager.java
@@ -250,17 +250,28 @@ public class ClassicPlotManager extends SquarePlotManager {
         Location top = plot.getExtendedTopAbs().add(1, 0, 1);
         LocalBlockQueue queue = classicPlotWorld.getQueue(false);
         int y = classicPlotWorld.WALL_HEIGHT + 1;
+        StringPlotBlock air = PlotBlock.get("air");
         if (!plot.getMerged(Direction.NORTH)) {
             int z = bot.getZ();
             for (int x = bot.getX(); x < top.getX(); x++) {
                 queue.setBlock(x, y, z, blocks.getBlock());
             }
+            // Replace all blocks above the wall with air
+            queue.setCuboid(
+                    new Location(top.getWorld(), top.getX(), y + 1, bot.getZ()),
+                    new Location(bot.getWorld(), bot.getX(), 255, bot.getZ()),
+                    air);
         }
         if (!plot.getMerged(Direction.WEST)) {
             int x = bot.getX();
             for (int z = bot.getZ(); z < top.getZ(); z++) {
                 queue.setBlock(x, y, z, blocks.getBlock());
             }
+            // Replace all blocks above the wall with air
+            queue.setCuboid(
+                    new Location(top.getWorld(), bot.getX(), y + 1, top.getZ()),
+                    new Location(bot.getWorld(), bot.getX(), 255, bot.getZ()),
+                    air);
         }
         if (!plot.getMerged(Direction.SOUTH)) {
             int z = top.getZ();
@@ -268,6 +279,11 @@ public class ClassicPlotManager extends SquarePlotManager {
                  x < top.getX() + (plot.getMerged(Direction.EAST) ? 0 : 1); x++) {
                 queue.setBlock(x, y, z, blocks.getBlock());
             }
+            // Replace all blocks above the wall with air
+            queue.setCuboid(
+                    new Location(top.getWorld(), top.getX(), y + 1, top.getZ()),
+                    new Location(bot.getWorld(), bot.getX(), 255, top.getZ()),
+                    air);
         }
         if (!plot.getMerged(Direction.EAST)) {
             int x = top.getX();
@@ -275,6 +291,11 @@ public class ClassicPlotManager extends SquarePlotManager {
                  z < top.getZ() + (plot.getMerged(Direction.SOUTH) ? 0 : 1); z++) {
                 queue.setBlock(x, y, z, blocks.getBlock());
             }
+            // Replace all blocks above the wall with air
+            queue.setCuboid(
+                    new Location(top.getWorld(), top.getX(), y + 1, top.getZ()),
+                    new Location(bot.getWorld(), top.getX(), 255, bot.getZ()),
+                    air);
         }
         queue.enqueue();
         return true;
@@ -436,6 +457,17 @@ public class ClassicPlotManager extends SquarePlotManager {
     @Override public boolean finishPlotUnlink(List<PlotId> plotIds) {
         final BlockBucket block = classicPlotWorld.CLAIMED_WALL_BLOCK;
         plotIds.forEach(id -> setWall(id, block));
+        return true;
+    }
+
+    @Override public boolean regenerateAllPlotWalls() {
+        for (Plot plot : classicPlotWorld.getPlots()) {
+            if (plot.hasOwner()) {
+                setWall(plot.getId(), classicPlotWorld.CLAIMED_WALL_BLOCK);
+            } else {
+                setWall(plot.getId(), classicPlotWorld.WALL_BLOCK);
+            }
+        }
         return true;
     }
 

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridUtils.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridUtils.java
@@ -153,6 +153,9 @@ public abstract class HybridUtils {
                     PlotSquared.debug("PROGRESS: " + 100 * (2048 - chunks.size()) / 2048 + "%");
                 }
                 if (regions.isEmpty() && chunks.isEmpty()) {
+                    PlotSquared.debug("&3Regenerating plot walls");
+                    regeneratePlotWalls(area);
+
                     HybridUtils.UPDATE = false;
                     PlotSquared.debug(Captions.PREFIX.s() + "Finished road conversion");
                     // CANCEL TASK
@@ -376,5 +379,10 @@ public abstract class HybridUtils {
             }
         }
         return false;
+    }
+
+    public boolean regeneratePlotWalls(final PlotArea area) {
+        PlotManager plotManager = area.getPlotManager();
+        return plotManager.regenerateAllPlotWalls();
     }
 }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridUtils.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/generator/HybridUtils.java
@@ -130,6 +130,16 @@ public abstract class HybridUtils {
         return scheduleRoadUpdate(area, regions, extend);
     }
 
+    public boolean scheduleSingleRegionRoadUpdate(Plot plot, int extend) {
+        if (HybridUtils.UPDATE) {
+            return false;
+        }
+        HybridUtils.UPDATE = true;
+        Set<ChunkLoc> regions = new HashSet<>();
+        regions.add(ChunkManager.manager.getChunkChunk(plot.getCenter()));
+        return scheduleRoadUpdate(plot.getArea(), regions, extend);
+    }
+
     public boolean scheduleRoadUpdate(final PlotArea area, Set<ChunkLoc> rgs, final int extend) {
         HybridUtils.regions = rgs;
         HybridUtils.area = area;

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotManager.java
@@ -85,4 +85,6 @@ public abstract class PlotManager {
         return 255;
     }
 
+    public abstract boolean regenerateAllPlotWalls();
+
 }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/worlds/SinglePlotManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/worlds/SinglePlotManager.java
@@ -107,4 +107,6 @@ public class SinglePlotManager extends PlotManager {
     @Override public boolean finishPlotUnlink(List<PlotId> plotIds) {
         return false;
     }
+
+    @Override public boolean regenerateAllPlotWalls() { return false; }
 }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/util/block/LocalBlockQueue.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/util/block/LocalBlockQueue.java
@@ -97,9 +97,15 @@ public abstract class LocalBlockQueue {
     }
 
     public void setCuboid(Location pos1, Location pos2, PlotBlock block) {
-        for (int y = pos1.getY(); y <= Math.min(255, pos2.getY()); y++) {
-            for (int x = pos1.getX(); x <= pos2.getX(); x++) {
-                for (int z = pos1.getZ(); z <= pos2.getZ(); z++) {
+        int yMin = Math.min(pos1.getY(), pos2.getY());
+        int yMax = Math.min(255, Math.max(pos1.getY(), pos2.getY()));
+        int xMin = Math.min(pos1.getX(), pos2.getX());
+        int xMax = Math.max(pos1.getX(), pos2.getX());
+        int zMin = Math.min(pos1.getZ(), pos2.getZ());
+        int zMax = Math.max(pos1.getZ(), pos2.getZ());
+        for (int y = yMin; y <= yMax; y++) {
+            for (int x = xMin; x <= xMax; x++) {
+                for (int z = zMin; z <= zMax; z++) {
                     setBlock(x, y, z, block);
                 }
             }
@@ -107,9 +113,15 @@ public abstract class LocalBlockQueue {
     }
 
     public void setCuboid(Location pos1, Location pos2, BlockBucket blocks) {
-        for (int y = pos1.getY(); y <= Math.min(255, pos2.getY()); y++) {
-            for (int x = pos1.getX(); x <= pos2.getX(); x++) {
-                for (int z = pos1.getZ(); z <= pos2.getZ(); z++) {
+        int yMin = Math.min(pos1.getY(), pos2.getY());
+        int yMax = Math.min(255, Math.max(pos1.getY(), pos2.getY()));
+        int xMin = Math.min(pos1.getX(), pos2.getX());
+        int xMax = Math.max(pos1.getX(), pos2.getX());
+        int zMin = Math.min(pos1.getZ(), pos2.getZ());
+        int zMax = Math.max(pos1.getZ(), pos2.getZ());
+        for (int y = yMin; y <= yMax; y++) {
+            for (int x = xMin; x <= xMax; x++) {
+                for (int z = zMin; z <= zMax; z++) {
                     setBlock(x, y, z, blocks.getBlock());
                 }
             }


### PR DESCRIPTION
Also includes addition to debugroadregen command to let you run the real road generation code in a single mcr instead of having to rely on the very buggy plot-based test, which only creates roads on the south and east side, only works on single plots, and which damages merged plots next to the plots it gets used on.