### PR TITLE
Make removing * remove the Everyone node before removing all members

### DIFF
--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Remove.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Remove.java
@@ -66,18 +66,7 @@ import java.util.UUID;
                 Set<UUID> uuids = MainUtil.getUUIDsFromString(args[0]);
                 if (!uuids.isEmpty()) {
                     for (UUID uuid : uuids) {
-                        if (uuid == DBFunc.EVERYONE) {
-                            if (plot.removeTrusted(uuid)) {
-                                EventUtil.manager.callTrusted(player, plot, uuid, false);
-                                count++;
-                            } else if (plot.removeMember(uuid)) {
-                                EventUtil.manager.callMember(player, plot, uuid, false);
-                                count++;
-                            } else if (plot.removeDenied(uuid)) {
-                                EventUtil.manager.callDenied(player, plot, uuid, false);
-                                count++;
-                            }
-                        } else if (plot.getTrusted().contains(uuid)) {
+                        if (plot.getTrusted().contains(uuid)) {
                             if (plot.removeTrusted(uuid)) {
                                 EventUtil.manager.callTrusted(player, plot, uuid, false);
                                 count++;
@@ -89,6 +78,17 @@ import java.util.UUID;
                             }
                         } else if (plot.getDenied().contains(uuid)) {
                             if (plot.removeDenied(uuid)) {
+                                EventUtil.manager.callDenied(player, plot, uuid, false);
+                                count++;
+                            }
+                        } else if (uuid == DBFunc.EVERYONE) {
+                            if (plot.removeTrusted(uuid)) {
+                                EventUtil.manager.callTrusted(player, plot, uuid, false);
+                                count++;
+                            } else if (plot.removeMember(uuid)) {
+                                EventUtil.manager.callMember(player, plot, uuid, false);
+                                count++;
+                            } else if (plot.removeDenied(uuid)) {
                                 EventUtil.manager.callDenied(player, plot, uuid, false);
                                 count++;
                             }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets

If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://github.com/IntellectualSites/PlotSquared/issues/new/choose
-->

**Fixes #2499**

## Description
Changes the behaviour of /p remove.

Current behaviour:
* Untrust `*` if it exists
* Untrust everyone
* Unadd `*` if it exists
* Unadd everyone
* Undeny `*` if it exists
* Undeny everyone

New behaviour:
* Untrust `*` if it exists
* Unadd `*` if it exists
* Undeny `*` if it exists
* Untrust everyone
* Unadd everyone
* Undeny everyone

This makes it possible to undeny `*` without having to remove all trusted and added players first.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/breaking/CONTRIBUTING.md)