### PR TITLE
Bugfixes for deny-teleport

### DIFF
--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -679,37 +679,34 @@ import java.util.regex.Pattern;
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onTeleport(PlayerTeleportEvent event) {
-        if (event.getTo() == null || event.getFrom() == null || !event.getFrom().getWorld()
-            .equals(event.getTo().getWorld())) {
-            final Object lastLoc =
-                BukkitUtil.getPlayer(event.getPlayer()).deleteMeta(PlotPlayer.META_LOCATION);
-            final Object lastPlot =
-                BukkitUtil.getPlayer(event.getPlayer()).deleteMeta(PlotPlayer.META_LAST_PLOT);
-            org.bukkit.Location to = event.getTo();
-            if (to != null) {
-                Player player = event.getPlayer();
-                PlotPlayer plotPlayer = PlotPlayer.wrap(player);
-                Location location = BukkitUtil.getLocation(to);
-                PlotArea area = location.getPlotArea();
-                if (area == null) {
-                    return;
-                }
-                Plot plot = area.getPlot(location);
-                if (plot != null) {
-                    final boolean result = Flags.DENY_TELEPORT.allowsTeleport(plotPlayer, plot);
-                    if (!result) {
-                        MainUtil.sendMessage(plotPlayer, Captions.NO_PERMISSION_EVENT,
-                            Captions.PERMISSION_ADMIN_ENTRY_DENIED);
-                        event.setCancelled(true);
-                        if (lastLoc != null) {
-                            plotPlayer.setMeta(PlotPlayer.META_LOCATION, lastLoc);
-                        }
-                        if (lastPlot != null) {
-                            plotPlayer.setMeta(PlotPlayer.META_LAST_PLOT, lastPlot);
-                        }
-                    } else {
-                        plotEntry(plotPlayer, plot);
+        final Object lastLoc =
+            BukkitUtil.getPlayer(event.getPlayer()).deleteMeta(PlotPlayer.META_LOCATION);
+        final Object lastPlot =
+            BukkitUtil.getPlayer(event.getPlayer()).deleteMeta(PlotPlayer.META_LAST_PLOT);
+        org.bukkit.Location to = event.getTo();
+        if (to != null) {
+            Player player = event.getPlayer();
+            PlotPlayer plotPlayer = PlotPlayer.wrap(player);
+            Location location = BukkitUtil.getLocation(to);
+            PlotArea area = location.getPlotArea();
+            if (area == null) {
+                return;
+            }
+            Plot plot = area.getPlot(location);
+            if (plot != null) {
+                final boolean result = Flags.DENY_TELEPORT.allowsTeleport(plotPlayer, plot);
+                if (!result) {
+                    MainUtil.sendMessage(plotPlayer, Captions.NO_PERMISSION_EVENT,
+                        Captions.PERMISSION_ADMIN_ENTRY_DENIED);
+                    event.setCancelled(true);
+                    if (lastLoc != null) {
+                        plotPlayer.setMeta(PlotPlayer.META_LOCATION, lastLoc);
                     }
+                    if (lastPlot != null) {
+                        plotPlayer.setMeta(PlotPlayer.META_LAST_PLOT, lastPlot);
+                    }
+                } else {
+                    plotEntry(plotPlayer, plot);
                 }
             }
         }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/flag/TeleportDenyFlag.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/flag/TeleportDenyFlag.java
@@ -22,14 +22,14 @@ public class TeleportDenyFlag extends EnumFlag {
                 result = !plot.getMembers().contains(player.getUUID());
                 break;
             case "nonmembers":
-                result = !plot.isAdded(player.getUUID());
+                result = plot.isAdded(player.getUUID());
                 break;
             case "nontrusted":
-                result = !plot.getTrusted().contains(player.getUUID()) && !plot
+                result = plot.getTrusted().contains(player.getUUID()) || plot
                     .isOwner(player.getUUID());
                 break;
             case "nonowners":
-                result = !plot.isOwner(player.getUUID());
+                result = plot.isOwner(player.getUUID());
                 break;
             default:
                 return true;


### PR DESCRIPTION
## Overview
Bugfixes for some issues of the flag deny-teleport that I encountered. 

**Fixes #{issue number}**
#2504 
#2505 

## Description
The fix for #2504 simply negates the conditions for various values of the flag. **If I misunderstood the meaning of the flag, _all_ conditions in the swicth must be negated.**

The fix for #2505 removes the condition that prevents the code from triggering in the mentioned cases. As far as I can tell, the condition serves no purpose and might be a relict of previous changes ...

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/breaking/CONTRIBUTING.md)