### PR TITLE
Place flag bugfix (fixxes issue #2524)

### DIFF
--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -2042,14 +2042,14 @@ import java.util.regex.Pattern;
                 if (type == Material.AIR) {
                     type = offType;
                 }
+                // in the following, lb needs to have the material of the item in hand i.e. type
+                lb = new BukkitLazyBlock(PlotBlock.get(type.toString()));
                 if (type.isBlock()) {
                     location = BukkitUtil
                         .getLocation(block.getRelative(event.getBlockFace()).getLocation());
                     eventType = PlayerBlockEventType.PLACE_BLOCK;
-                    lb = new BukkitLazyBlock(new StringPlotBlock(type.toString())); 
                     break;
                 }
-                lb = new BukkitLazyBlock(PlotBlock.get(type.toString()));
                 if (type.toString().toLowerCase().endsWith("egg")) {
                     eventType = PlayerBlockEventType.SPAWN_MOB;
                 } else {

--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -2046,6 +2046,7 @@ import java.util.regex.Pattern;
                     location = BukkitUtil
                         .getLocation(block.getRelative(event.getBlockFace()).getLocation());
                     eventType = PlayerBlockEventType.PLACE_BLOCK;
+                    lb = new BukkitLazyBlock(new StringPlotBlock(type.toString())); 
                     break;
                 }
                 lb = new BukkitLazyBlock(PlotBlock.get(type.toString()));


### PR DESCRIPTION
## Overview
Fixes the problem with the "place" flag as described in  #2524 (or below) .

**Fixes #2524**

## Description
Players who are not trusted in a block are supposed to be able to place blocks that are added to the "place" flag.
However, due to a Bug in [PlayerEvents](https://github.com/IntellectualSites/PlotSquared/blob/breaking/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java), the wrong material (namely that of the block that was clicked on) is passed to EventUtil.checkPlayerBlockEvent.

This pull request fixes the issue by changing the material of the block before it is passed to EventUtil.checkPlayerBlockEvent. This is done be simply moving a line some lines up.

It is only changed if the action passed to EventUtil is PLACE_BLOCK, [where](https://github.com/IntellectualSites/PlotSquared/blob/breaking/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/util/EventUtil.java#L229) the block is only used to check against the "place" flag, which is exactly what we want. There should be no side effects, as far as I can tell, since the block isn't used anywhere else (and if the condition will not trigger, the material change would have happened anyway). 

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code 
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/breaking/CONTRIBUTING.md)