### PR TITLE
New plot flag untrusted-visit

### DIFF
--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -697,7 +697,11 @@ import java.util.regex.Pattern;
                 Plot plot = area.getPlot(location);
                 if (plot != null) {
                     final boolean result = Flags.DENY_TELEPORT.allowsTeleport(plotPlayer, plot);
-                    if (!result) {
+                    // there is one possibility to still allow teleportation:
+                    // to is identical to the plot's home location, and untrusted-visit is true
+                    // i.e. untrusted-visit can override deny-teleport
+                    // this is acceptable, because otherwise it wouldn't make sense to have both flags set
+                    if (!result && !(Flags.UNTRUSTED_VISIT.isTrue(plot) && plot.getHome().equals(location))) {
                         MainUtil.sendMessage(plotPlayer, Captions.NO_PERMISSION_EVENT,
                             Captions.PERMISSION_ADMIN_ENTRY_DENIED);
                         event.setCancelled(true);

--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -701,7 +701,7 @@ import java.util.regex.Pattern;
                     // to is identical to the plot's home location, and untrusted-visit is true
                     // i.e. untrusted-visit can override deny-teleport
                     // this is acceptable, because otherwise it wouldn't make sense to have both flags set
-                    if (!result && !(Flags.UNTRUSTED_VISIT.isTrue(plot) && plot.getHome().equals(location))) {
+                    if (!result && !(Flags.UNTRUSTED_VISIT.isTrue(plot) && plot.getHome().equals(BukkitUtil.getLocationFull(to)))) {
                         MainUtil.sendMessage(plotPlayer, Captions.NO_PERMISSION_EVENT,
                             Captions.PERMISSION_ADMIN_ENTRY_DENIED);
                         event.setCancelled(true);

--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/util/BukkitUtil.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/util/BukkitUtil.java
@@ -212,12 +212,14 @@ import java.util.Set;
 
     public static Location getLocation(@NonNull final org.bukkit.Location location) {
         return new Location(location.getWorld().getName(), MathMan.roundInt(location.getX()),
-            MathMan.roundInt(location.getY()), MathMan.roundInt(location.getZ()));
+            MathMan.roundInt(location.getY()), MathMan.roundInt(location.getZ()),
+            location.getYaw(), location.getPitch());
     }
 
     public static org.bukkit.Location getLocation(@NonNull final Location location) {
         return new org.bukkit.Location(getWorld(location.getWorld()), location.getX(),
-            location.getY(), location.getZ());
+            location.getY(), location.getZ(),
+            location.getYaw(), location.getPitch());
     }
 
     public static World getWorld(@NonNull final String string) {

--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/util/BukkitUtil.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/util/BukkitUtil.java
@@ -215,6 +215,12 @@ import java.util.Set;
             MathMan.roundInt(location.getY()), MathMan.roundInt(location.getZ()));
     }
 
+    public static Location getLocationFull(@NonNull final org.bukkit.Location location) {
+      return new Location(location.getWorld().getName(), MathMan.roundInt(location.getX()),
+          MathMan.roundInt(location.getY()), MathMan.roundInt(location.getZ()),
+          location.getYaw(), location.getPitch());
+    }
+
     public static org.bukkit.Location getLocation(@NonNull final Location location) {
         return new org.bukkit.Location(getWorld(location.getWorld()), location.getX(),
             location.getY(), location.getZ());

--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/util/BukkitUtil.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/util/BukkitUtil.java
@@ -212,14 +212,12 @@ import java.util.Set;
 
     public static Location getLocation(@NonNull final org.bukkit.Location location) {
         return new Location(location.getWorld().getName(), MathMan.roundInt(location.getX()),
-            MathMan.roundInt(location.getY()), MathMan.roundInt(location.getZ()),
-            location.getYaw(), location.getPitch());
+            MathMan.roundInt(location.getY()), MathMan.roundInt(location.getZ()));
     }
 
     public static org.bukkit.Location getLocation(@NonNull final Location location) {
         return new org.bukkit.Location(getWorld(location.getWorld()), location.getX(),
-            location.getY(), location.getZ(),
-            location.getYaw(), location.getPitch());
+            location.getY(), location.getZ());
     }
 
     public static World getWorld(@NonNull final String string) {

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Visit.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Visit.java
@@ -5,6 +5,7 @@ import com.github.intellectualsites.plotsquared.commands.CommandDeclaration;
 import com.github.intellectualsites.plotsquared.plot.PlotSquared;
 import com.github.intellectualsites.plotsquared.plot.config.Captions;
 import com.github.intellectualsites.plotsquared.plot.config.Settings;
+import com.github.intellectualsites.plotsquared.plot.flag.Flags;
 import com.github.intellectualsites.plotsquared.plot.object.*;
 import com.github.intellectualsites.plotsquared.plot.util.MainUtil;
 import com.github.intellectualsites.plotsquared.plot.util.MathMan;
@@ -129,7 +130,8 @@ import java.util.concurrent.CompletableFuture;
                 return CompletableFuture.completedFuture(false);
             }
         } else {
-            if (!Permissions.hasPermission(player, Captions.PERMISSION_VISIT_OTHER)) {
+            if (!Permissions.hasPermission(player, Captions.PERMISSION_VISIT_OTHER) &&
+                !Flags.UNTRUSTED_VISIT.isTrue(plot)) {
                 Captions.NO_PERMISSION.send(player, Captions.PERMISSION_VISIT_OTHER);
                 return CompletableFuture.completedFuture(false);
             }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/flag/Flags.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/flag/Flags.java
@@ -121,6 +121,7 @@ public final class Flags {
     public static final BooleanFlag SLEEP = new BooleanFlag("sleep");
     public static final TeleportDenyFlag DENY_TELEPORT = new TeleportDenyFlag("deny-teleport");
     public static final BooleanFlag DENY_EXIT = new BooleanFlag("deny-exit");
+    public static final BooleanFlag UNTRUSTED_VISIT = new BooleanFlag("untrusted-visit");
 
 
     private static final HashMap<String, Flag<?>> flags;


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets

If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://github.com/IntellectualSites/PlotSquared/issues/new/choose
-->
This adds a new flag 'untrusted-visit' which allows plot owners to make their plot(s) reachable to everyone via the visit command. 


**Fixes IntellectualSites/PlotSquaredSuggestions#64**

## Description
Besides adding the new flag itself, it is checked in two locations:
* in the Visit command: to allow visiting if the player is not trusted and doesn't have the permission `plots.visit.other` (i.e. main functionality of the flag)
* in the onTeleport event, where `deny-teleport` is checked.
  The reasoning here is that you'll want `untrusted-visit` to override `deny-teleport`, or else it won't make sense to set both flags. With this change you can prevent players to teleport within your plot (at least with my bugfix #2506 or equivalent changes), but still allow visits (denying teleports is mandatory for things like e.g. labyrinths or jump'n'run courses (else cheating would be possible with ender pearls or chorus fruits), but if they can't use visit, they'll have to walk to the plot). 
Note that this is only implemented for bukkit (because deny-teleport is only checked for bukkit as well, and also because I can't test the others ;) ).

The last change is adding a new method getLocationFull to BukkitUtil, which transforms a bukkit Location into a PlotSquared Location _including_ yaw and pitch, since this is required for the location compare, and adding the copying of yaw and pitch to one of the existing ``getLocation` methods gave me a bad feeling regarding side effects. 

So the flag is considered only under very specific conditions, so it shouldn't have any side effects to other functionality. 

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/breaking/CONTRIBUTING.md)