### PR TITLE
Blocklist flags fix

### DIFF
--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -1387,7 +1387,7 @@ import java.util.regex.Pattern;
                 Optional<Set<BlockType>> destroy = plot.getFlag(Flags.BREAK);
                 Block block = event.getBlock();
                 if (destroy.isPresent() && destroy.get()
-                    .contains(BukkitBlockUtil.get(block)) || Permissions
+                    .contains(BukkitAdapter.asBlockType(block.getType())) || Permissions
                     .hasPermission(plotPlayer, Captions.PERMISSION_ADMIN_DESTROY_OTHER)) {
                     return;
                 }
@@ -2470,7 +2470,7 @@ import java.util.regex.Pattern;
                 Captions.PERMISSION_ADMIN_BUILD_UNOWNED);
             event.setCancelled(true);
         } else if (!plot.isAdded(pp.getUUID())) {
-            if (Flags.USE.contains(plot, BukkitBlockUtil.get(block))) {
+            if (Flags.USE.contains(plot, BukkitAdapter.asBlockType(block.getType()))) {
                 return;
             }
             if (Permissions.hasPermission(pp, Captions.PERMISSION_ADMIN_BUILD_OTHER)) {
@@ -2532,7 +2532,7 @@ import java.util.regex.Pattern;
         } else if (!plot.isAdded(plotPlayer.getUUID())) {
             Optional<Set<BlockType>> use = plot.getFlag(Flags.USE);
             Block block = event.getBlockClicked();
-            if (use.isPresent() && use.get().contains(BukkitBlockUtil.get(block))) {
+            if (use.isPresent() && use.get().contains(BukkitAdapter.asBlockType(block.getType()))) {
                 return;
             }
             if (Permissions.hasPermission(plotPlayer, Captions.PERMISSION_ADMIN_BUILD_OTHER)) {

--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -1914,8 +1914,8 @@ import java.util.regex.Pattern;
                     Location location = BukkitUtil.getLocation(block.getLocation());
                     Material finalType = type;
                     if (!EventUtil.manager
-                        .checkPlayerBlockEvent(pp, PlayerBlockEventType.SPAWN_MOB, location, () -> BukkitAdapter.asBlockType(
-                            finalType).getDefaultState(), true)) {
+                        .checkPlayerBlockEvent(pp, PlayerBlockEventType.SPAWN_MOB, location, BukkitAdapter.asBlockType(
+                            finalType), true)) {
                         event.setCancelled(true);
                         event.setUseItemInHand(Event.Result.DENY);
                     }
@@ -1933,14 +1933,14 @@ import java.util.regex.Pattern;
             return;
         }
         PlayerBlockEventType eventType = null;
-        Supplier<BlockState> lb;
+        BlockType lb;
         Location location;
         Action action = event.getAction();
         switch (action) {
             case PHYSICAL: {
                 eventType = PlayerBlockEventType.TRIGGER_PHYSICAL;
                 Block block = event.getClickedBlock();
-                lb = BukkitBlockUtil.supply(block);
+                lb = BukkitAdapter.asBlockType(block.getType());
                 location = BukkitUtil.getLocation(block.getLocation());
                 break;
             }
@@ -2109,7 +2109,7 @@ import java.util.regex.Pattern;
                             eventType = PlayerBlockEventType.INTERACT_BLOCK;
                         }
                 }
-                lb = BukkitBlockUtil.supply(block);
+                lb = BukkitAdapter.asBlockType(block.getType());
                 if (eventType != null && (eventType != PlayerBlockEventType.INTERACT_BLOCK
                     || !player.isSneaking())) {
                     break;
@@ -2128,7 +2128,7 @@ import java.util.regex.Pattern;
                     type = offType;
                 }
                 // in the following, lb needs to have the material of the item in hand i.e. type
-                lb =  BukkitBlockUtil.supply(type);
+                lb = BukkitAdapter.asBlockType(type);
                 if (type.isBlock()) {
                     location = BukkitUtil
                         .getLocation(block.getRelative(event.getBlockFace()).getLocation());
@@ -2211,7 +2211,7 @@ import java.util.regex.Pattern;
                 Block block = event.getClickedBlock();
                 location = BukkitUtil.getLocation(block.getLocation());
                 eventType = PlayerBlockEventType.BREAK_BLOCK;
-                lb = BukkitBlockUtil.supply(block);
+                lb = BukkitAdapter.asBlockType(block.getType());
                 break;
             default:
                 return;
@@ -3091,7 +3091,7 @@ import java.util.regex.Pattern;
                 Set<BlockType> place = plot.getFlag(Flags.PLACE, null);
                 if (place != null) {
                     Block block = event.getBlock();
-                    if (place.contains(BukkitBlockUtil.get(block))) {
+                    if (place.contains(BukkitAdapter.asBlockType(block.getType()))) {
                         return;
                     }
                 }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/util/EventUtil.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/util/EventUtil.java
@@ -103,7 +103,7 @@ public abstract class EventUtil {
     }
 
     public boolean checkPlayerBlockEvent(PlotPlayer player, PlayerBlockEventType type,
-        Location location, Supplier<BlockState> block, boolean notifyPerms) {
+        Location location, BlockType blockType, boolean notifyPerms) {
         PlotArea area = location.getPlotArea();
         assert area != null;
         Plot plot = area.getPlot(location);
@@ -133,7 +133,7 @@ public abstract class EventUtil {
                 if (use.isPresent()) {
                     Set<BlockType> value = use.get();
                     if (value.contains(BlockTypes.AIR) || value
-                        .contains(block.get())) {
+                        .contains(blockType)) {
                         return true;
                     }
                 }
@@ -141,7 +141,7 @@ public abstract class EventUtil {
                 if (destroy.isPresent()) {
                     Set<BlockType> value = destroy.get();
                     if (value.contains(BlockTypes.AIR) || value
-                        .contains(block.get())) {
+                        .contains(blockType)) {
                         return true;
                     }
                 }
@@ -226,7 +226,7 @@ public abstract class EventUtil {
                 Optional<Set<BlockType>> flagValue = plot.getFlag(Flags.USE);
                 Set<BlockType> value = flagValue.orElse(null);
                 if (value == null || !value.contains(BlockTypes.AIR) && !value
-                    .contains(block.get())) {
+                    .contains(blockType)) {
                     return Permissions.hasPermission(player,
                         Captions.PERMISSION_ADMIN_INTERACT_OTHER.getTranslated(), false)
                         || !(!notifyPerms || MainUtil
@@ -249,7 +249,7 @@ public abstract class EventUtil {
                 Optional<Set<BlockType>> flagValue = plot.getFlag(Flags.PLACE);
                 Set<BlockType> value = flagValue.orElse(null);
                 if (value == null || !value.contains(BlockTypes.AIR) && !value
-                    .contains(block.get())) {
+                    .contains(blockType)) {
                     if (Permissions.hasPermission(player,
                         Captions.PERMISSION_ADMIN_BUILD_OTHER.getTranslated(), false)) {
                         return true;
@@ -276,7 +276,7 @@ public abstract class EventUtil {
                 Optional<Set<BlockType>> flagValue = plot.getFlag(Flags.USE);
                 Set<BlockType> value = flagValue.orElse(null);
                 if (value == null || !value.contains(BlockTypes.AIR) && !value
-                    .contains(block.get())) {
+                    .contains(blockType)) {
                     if (Permissions.hasPermission(player,
                         Captions.PERMISSION_ADMIN_INTERACT_OTHER.getTranslated(),
                             false)) {
@@ -303,7 +303,7 @@ public abstract class EventUtil {
                 Optional<Set<BlockType>> flagValue = plot.getFlag(Flags.USE);
                 Set<BlockType> value = flagValue.orElse(null);
                 if (value == null || !value.contains(BlockTypes.AIR) && !value
-                    .contains(block.get())) {
+                    .contains(blockType)) {
                     if (Permissions.hasPermission(player,
                         Captions.PERMISSION_ADMIN_INTERACT_OTHER.getTranslated(),
                             false)) {
@@ -332,7 +332,7 @@ public abstract class EventUtil {
                 Optional<Set<BlockType>> flag = plot.getFlag(Flags.USE);
                 Set<BlockType> value = flag.orElse(null);
                 if (value == null || !value.contains(BlockTypes.AIR) && !value
-                    .contains(block.get())) {
+                    .contains(blockType)) {
                     if (Permissions.hasPermission(player,
                         Captions.PERMISSION_ADMIN_INTERACT_OTHER.getTranslated(),
                             false)) {
@@ -362,7 +362,7 @@ public abstract class EventUtil {
                 Optional<Set<BlockType>> flag = plot.getFlag(Flags.USE);
                 Set<BlockType> value = flag.orElse(null);
                 if (value == null || !value.contains(BlockTypes.AIR) && !value
-                    .contains(block.get())) {
+                    .contains(blockType)) {
                     if (Permissions.hasPermission(player,
                         Captions.PERMISSION_ADMIN_INTERACT_OTHER.getTranslated(),
                             false)) {
@@ -392,7 +392,7 @@ public abstract class EventUtil {
                 Optional<Set<BlockType>> flagValue = plot.getFlag(Flags.PLACE);
                 Set<BlockType> value = flagValue.orElse(null);
                 if (value == null || !value.contains(BlockTypes.AIR) && !value
-                    .contains(block.get())) {
+                    .contains(blockType)) {
                     if (Permissions.hasPermission(player,
                         Captions.PERMISSION_ADMIN_INTERACT_OTHER.getTranslated(),
                             false)) {
@@ -422,7 +422,7 @@ public abstract class EventUtil {
                 Optional<Set<BlockType>> flag = plot.getFlag(Flags.PLACE);
                 Set<BlockType> value = flag.orElse(null);
                 if (value == null || !value.contains(BlockTypes.AIR) && !value
-                    .contains(block.get())) {
+                    .contains(blockType)) {
                     if (Permissions.hasPermission(player,
                         Captions.PERMISSION_ADMIN_INTERACT_OTHER.getTranslated(),
                             false)) {
@@ -453,7 +453,7 @@ public abstract class EventUtil {
                 Optional<Set<BlockType>> flag = plot.getFlag(Flags.PLACE);
                 Set<BlockType> value = flag.orElse(null);
                 if (value == null || !value.contains(BlockTypes.AIR) && !value
-                    .contains(block.get())) {
+                    .contains(blockType)) {
                     if (Permissions.hasPermission(player,
                         Captions.PERMISSION_ADMIN_INTERACT_OTHER.getTranslated(),
                             false)) {


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets

If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://github.com/IntellectualSites/PlotSquared/issues/new/choose
-->
This fixes the issue that the plot flags which contain blocktype (material) lists no longer work as intended.

**Fixes #2573**

## Description
* changed parameter type of EventUtil::checkPlayerBlockEvent from `Supplier<BlockState>` to `BlockType`. Using a supplier seems unneccessary overhhead, since *every* usage would have been `() -> someExpression` - better use `someExpression` directly. Also, at one location a local variable had to be used which could not be final, and lambda expressions require them to be final. 
* changed locations where EventUtil::checkPlayerBlockEvent is used to use the correct type
* also fixed other usages of these flags in `PlayerEvents`

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/breaking/CONTRIBUTING.md)