### PR TITLE
Fix that players cannot place hanging entities

### DIFF
--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -2357,7 +2357,7 @@ import java.util.regex.Pattern;
             return;
         }
         Player p = event.getPlayer();
-        if (p != null) {
+        if (p == null) {
             PlotSquared.debug("PlotSquared does not support HangingPlaceEvent for non-players.");
             event.setCancelled(true);
             return;


### PR DESCRIPTION
## Overview

There's a small typo in the HangingPlaceEvent listener that prevents players from placing hanging entities (item frames, paintings and leads).

**Fixes #2630**

## Description

One can see the message "PlotSquared does not support HangingPlaceEvent for non-players." being printed at the very end of the log included in #2630. The first part of their console log seems to be caused by the fact that the user is running the plugin on a 1.13 server instead of 1.14 (where sweet berries were introduced) and is not relevant to this pull request.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/breaking/CONTRIBUTING.md)