### PR TITLE
Fix interact handling for sneaking players

### DIFF
--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/listeners/PlayerEvents.java
@@ -1925,13 +1925,21 @@ import java.util.regex.Pattern;
             case RIGHT_CLICK_BLOCK: {
                 Material blockType = block.getType();
                 eventType = PlayerBlockEventType.INTERACT_BLOCK;
-                if (blockType.isInteractable() && player.isSneaking()) {
-                    return; //this returns so the block place event is called
-                }
                 blocktype1 = BukkitAdapter.asBlockType(block.getType());
-                if (!player.isSneaking()) {
-                    break;
+
+                if (blockType.isInteractable()) {
+                    if (!player.isSneaking()) {
+                        break;
+                    }
+                    ItemStack hand = player.getInventory().getItemInMainHand();
+                    ItemStack offHand = player.getInventory().getItemInOffHand();
+
+                    // sneaking players interact with blocks if both hands are empty
+                    if (hand.getType() == Material.AIR && offHand.getType() == Material.AIR) {
+                        break;
+                    }
                 }
+
                 Material type = event.getMaterial();
 
                 // in the following, lb needs to have the material of the item in hand i.e. type


### PR DESCRIPTION
## Overview

One of the most important issues this fixes is that chests can be accessed anywhere while sneaking with empty hands; this is #2632. I later noticed that this also fixes a bunch of other problems related to interacting with blocks and sneaking.

**Fixes #2632**

## Description

In the current version of PlotSquared (4.428 on the dev builds Jenkins page), some problems related to sneaking are:
- Players can interact with *any* interactable block while sneaking with empty hands on *any* plot or road, such as doors, beds, dragon eggs, chests, shulker boxes, enchanting tables and buttons.
- Players can place boats on interactable blocks on *any* plot or road while sneaking.
- Players can throw eggs when pointing their cursor at an interactable block on *any* plot or road while sneaking.
- Placing a block while *not* sneaking somewhere you don't have permission, displays the permission error for the use flag instead of the build flag.
- Probably a lot more.

This pull request fixes these issues. However, it should be noted that I only tested whether these exact issues were fixed and whether block placing is still protected. I also only tested on git-Spigot-56f8471-6567017 (MC: 1.14.4). Testing whether all place, interact, etc. protections are still in place doesn't really seem necessary to me, but if you have a few specific things that you want to be tested, I'd be open to testing them.

Finally a word about the code. The hand and off hand air check are not really necessary, i.e. lines 1934 to 1939 can be removed without changing the functionality. However, it may be more clear what is going on to future maintainers if they are left in.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/breaking/CONTRIBUTING.md)