### PR TITLE
Improve "everyone" args and update a few command messages

### DIFF
--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/commands/Argument.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/commands/Argument.java
@@ -33,7 +33,7 @@ public abstract class Argument<T> {
         }
     };
     public static final Argument<String> PlayerName =
-        new Argument<String>("PlayerName", "<player>") {
+        new Argument<String>("PlayerName", "<player|*>") {
             @Override public String parse(String in) {
                 return in.length() <= 16 ? in : null;
             }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Add.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Add.java
@@ -1,6 +1,5 @@
 package com.github.intellectualsites.plotsquared.plot.commands;
 
-import com.github.intellectualsites.plotsquared.commands.Argument;
 import com.github.intellectualsites.plotsquared.commands.Command;
 import com.github.intellectualsites.plotsquared.commands.CommandDeclaration;
 import com.github.intellectualsites.plotsquared.plot.config.Captions;
@@ -35,7 +34,7 @@ import java.util.concurrent.CompletableFuture;
         checkTrue(plot.isOwner(player.getUUID()) || Permissions
                 .hasPermission(player, Captions.PERMISSION_ADMIN_COMMAND_TRUST),
             Captions.NO_PLOT_PERMS);
-        checkTrue(args.length == 1, Captions.COMMAND_SYNTAX, "/plot add <player|*>");
+        checkTrue(args.length == 1, Captions.COMMAND_SYNTAX, getUsage());
         final Set<UUID> uuids = MainUtil.getUUIDsFromString(args[0]);
         checkTrue(!uuids.isEmpty(), Captions.INVALID_PLAYER, args[0]);
         Iterator<UUID> iterator = uuids.iterator();

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Add.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Add.java
@@ -1,5 +1,6 @@
 package com.github.intellectualsites.plotsquared.plot.commands;
 
+import com.github.intellectualsites.plotsquared.commands.Argument;
 import com.github.intellectualsites.plotsquared.commands.Command;
 import com.github.intellectualsites.plotsquared.commands.CommandDeclaration;
 import com.github.intellectualsites.plotsquared.plot.config.Captions;
@@ -19,7 +20,7 @@ import java.util.concurrent.CompletableFuture;
 
 @CommandDeclaration(command = "add",
     description = "Allow a user to build in a plot while you are online",
-    usage = "/plot add <player>", category = CommandCategory.SETTINGS, permission = "plots.add",
+    usage = "/plot add <player|*>", category = CommandCategory.SETTINGS, permission = "plots.add",
     requiredType = RequiredType.PLAYER) public class Add extends Command {
 
     public Add() {

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Add.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Add.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 @CommandDeclaration(command = "add",
-    description = "Allow a user to build in a plot while you are online",
+    description = "Allow a user to build in a plot while the plot owner is online.",
     usage = "/plot add <player|*>", category = CommandCategory.SETTINGS, permission = "plots.add",
     requiredType = RequiredType.PLAYER) public class Add extends Command {
 
@@ -35,7 +35,7 @@ import java.util.concurrent.CompletableFuture;
         checkTrue(plot.isOwner(player.getUUID()) || Permissions
                 .hasPermission(player, Captions.PERMISSION_ADMIN_COMMAND_TRUST),
             Captions.NO_PLOT_PERMS);
-        checkTrue(args.length == 1, Captions.COMMAND_SYNTAX, getUsage());
+        checkTrue(args.length == 1, Captions.COMMAND_SYNTAX, "/plot add <player|*>");
         final Set<UUID> uuids = MainUtil.getUUIDsFromString(args[0]);
         checkTrue(!uuids.isEmpty(), Captions.INVALID_PLAYER, args[0]);
         Iterator<UUID> iterator = uuids.iterator();

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Alias.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Alias.java
@@ -46,7 +46,7 @@ import com.github.intellectualsites.plotsquared.plot.util.UUIDHandler;
         switch (args[0].toLowerCase()) {
             case "set":
                 if (args.length != 2) {
-                    Captions.COMMAND_SYNTAX.send(player, "/plot alias <set> <value>");
+                    Captions.COMMAND_SYNTAX.send(player, getUsage());
                     return false;
                 }
 
@@ -74,7 +74,7 @@ import com.github.intellectualsites.plotsquared.plot.util.UUIDHandler;
 
     private boolean setAlias(PlotPlayer player, Plot plot, String alias) {
         if (alias.isEmpty()) {
-            Captions.COMMAND_SYNTAX.send(player, "/plot alias <set> <value>");
+            Captions.COMMAND_SYNTAX.send(player, getUsage());
             return false;
         }
         if (alias.length() >= 50) {

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Claim.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Claim.java
@@ -18,7 +18,7 @@ import com.google.common.primitives.Ints;
 
 @CommandDeclaration(command = "claim", aliases = "c",
     description = "Claim the current plot you're standing on", category = CommandCategory.CLAIMING,
-    requiredType = RequiredType.NONE, permission = "plots.claim", usage = "/plot claim")
+    requiredType = RequiredType.PLAYER, permission = "plots.claim", usage = "/plot claim")
 public class Claim extends SubCommand {
 
     @Override public boolean onCommand(final PlotPlayer player, String[] args) {

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Clear.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Clear.java
@@ -16,7 +16,7 @@ import com.github.intellectualsites.plotsquared.plot.util.block.GlobalBlockQueue
 
 import java.util.concurrent.CompletableFuture;
 
-@CommandDeclaration(command = "clear", description = "Clear the plot you stand on",
+@CommandDeclaration(command = "clear", description = "Clear the plot you stand on", requiredType = RequiredType.NONE,
     permission = "plots.clear", category = CommandCategory.APPEARANCE, usage = "/plot clear",
     aliases = "reset", confirmation = true) public class Clear extends Command {
 

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/CreateRoadSchematic.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/CreateRoadSchematic.java
@@ -10,7 +10,7 @@ import com.github.intellectualsites.plotsquared.plot.object.PlotPlayer;
 import com.github.intellectualsites.plotsquared.plot.util.MainUtil;
 
 @CommandDeclaration(command = "createroadschematic", aliases = {"crs"},
-    category = CommandCategory.ADMINISTRATION, requiredType = RequiredType.NONE,
+    category = CommandCategory.ADMINISTRATION, requiredType = RequiredType.PLAYER,
     permission = "plots.createroadschematic",
     description = "Add a road schematic to your world using the roads around your current plot",
     usage = "/plot createroadschematic") public class CreateRoadSchematic extends SubCommand {

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Deny.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Deny.java
@@ -19,7 +19,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @CommandDeclaration(command = "deny", aliases = {"d", "ban"},
-    description = "Deny a user from a plot", usage = "/plot deny <player>",
+    description = "Deny a user from a plot", usage = "/plot deny <player|*>",
     category = CommandCategory.SETTINGS, requiredType = RequiredType.PLAYER) public class Deny
     extends SubCommand {
 

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Deny.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Deny.java
@@ -19,7 +19,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @CommandDeclaration(command = "deny", aliases = {"d", "ban"},
-    description = "Deny a user from a plot", usage = "/plot deny <player|*>",
+    description = "Deny a user from entering a plot", usage = "/plot deny <player|*>",
     category = CommandCategory.SETTINGS, requiredType = RequiredType.PLAYER) public class Deny
     extends SubCommand {
 

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Kick.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Kick.java
@@ -18,7 +18,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @CommandDeclaration(command = "kick", aliases = "k", description = "Kick a player from your plot",
-    permission = "plots.kick", usage = "/plot kick <player>", category = CommandCategory.TELEPORT,
+    permission = "plots.kick", usage = "/plot kick <player|*>", category = CommandCategory.TELEPORT,
     requiredType = RequiredType.PLAYER) public class Kick extends SubCommand {
 
     public Kick() {

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Remove.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Remove.java
@@ -18,7 +18,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @CommandDeclaration(command = "remove", aliases = {"r", "untrust", "ut", "undeny", "unban", "ud"},
-    description = "Remove a player from a plot", usage = "/plot remove <player>",
+    description = "Remove a player from a plot", usage = "/plot remove <player|*>",
     category = CommandCategory.SETTINGS, requiredType = RequiredType.NONE,
     permission = "plots.remove") public class Remove extends SubCommand {
 

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Trust.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Trust.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 @CommandDeclaration(command = "trust", aliases = {"t"}, requiredType = RequiredType.PLAYER,
-    usage = "/plot trust <player>",
+    usage = "/plot trust <player|*>",
     description = "Allow a user to build in a plot and use WorldEdit while you are offline",
     category = CommandCategory.SETTINGS) public class Trust extends Command {
 

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Trust.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Trust.java
@@ -37,7 +37,7 @@ import java.util.concurrent.CompletableFuture;
         checkTrue(currentPlot.isOwner(player.getUUID()) || Permissions
                 .hasPermission(player, Captions.PERMISSION_ADMIN_COMMAND_TRUST),
             Captions.NO_PLOT_PERMS);
-        checkTrue(args.length == 1, Captions.COMMAND_SYNTAX, "/plot trust <player|*>");
+        checkTrue(args.length == 1, Captions.COMMAND_SYNTAX, getUsage());
         final Set<UUID> uuids = MainUtil.getUUIDsFromString(args[0]);
         checkTrue(!uuids.isEmpty(), Captions.INVALID_PLAYER, args[0]);
         Iterator<UUID> iterator = uuids.iterator();

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Trust.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Trust.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletableFuture;
 
 @CommandDeclaration(command = "trust", aliases = {"t"}, requiredType = RequiredType.PLAYER,
     usage = "/plot trust <player|*>",
-    description = "Allow a user to build in a plot and use WorldEdit while you are offline",
+    description = "Allow a user to build in a plot and use WorldEdit while the plot owner is offline.",
     category = CommandCategory.SETTINGS) public class Trust extends Command {
 
     public Trust() {
@@ -37,7 +37,7 @@ import java.util.concurrent.CompletableFuture;
         checkTrue(currentPlot.isOwner(player.getUUID()) || Permissions
                 .hasPermission(player, Captions.PERMISSION_ADMIN_COMMAND_TRUST),
             Captions.NO_PLOT_PERMS);
-        checkTrue(args.length == 1, Captions.COMMAND_SYNTAX, getUsage());
+        checkTrue(args.length == 1, Captions.COMMAND_SYNTAX, "/plot trust <player|*>");
         final Set<UUID> uuids = MainUtil.getUUIDsFromString(args[0]);
         checkTrue(!uuids.isEmpty(), Captions.INVALID_PLAYER, args[0]);
         Iterator<UUID> iterator = uuids.iterator();


### PR DESCRIPTION
## Overview

- Add everyone aliases (`*`) to the commands it supports. Commands like trust, add, remove, etc. Support * (everyone) and should be documented in the command like all other commands do.

- Clean up some command descriptions with better fitting descriptions.

- Update requiredTypes for some commands with values which fit better and.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/breaking/CONTRIBUTING.md)