### PR TITLE
Fix DebugClaimTest

### DIFF
--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/DebugClaimTest.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/DebugClaimTest.java
@@ -3,7 +3,6 @@ package com.github.intellectualsites.plotsquared.plot.commands;
 import com.github.intellectualsites.plotsquared.commands.CommandDeclaration;
 import com.github.intellectualsites.plotsquared.plot.PlotSquared;
 import com.github.intellectualsites.plotsquared.plot.config.Captions;
-import com.github.intellectualsites.plotsquared.plot.database.DBFunc;
 import com.github.intellectualsites.plotsquared.plot.object.Location;
 import com.github.intellectualsites.plotsquared.plot.object.Plot;
 import com.github.intellectualsites.plotsquared.plot.object.PlotArea;
@@ -55,11 +54,10 @@ public class DebugClaimTest extends SubCommand {
         MainUtil.sendMessage(player,
             "&3Sign Block&8->&3Plot&8: Found an excess of 250,000 chunks. Limiting search radius... (~3.8 min)");
         PlotManager manager = area.getPlotManager();
-        ArrayList<Plot> plots = new ArrayList<>();
         CompletableFuture.runAsync(() -> {
-            ArrayList<PlotId> plotSelectionIds = MainUtil.getPlotSelectionIds(min, max);
-            MainUtil.sendMessage(player, plotSelectionIds.size() + " plot ids to check!");
-            for (PlotId id : plotSelectionIds) {
+            ArrayList<PlotId> ids = MainUtil.getPlotSelectionIds(min, max);
+            MainUtil.sendMessage(player, "&3Sign Block&8->&3Plot&8: " + ids.size() + " plot ids to check!");
+            for (PlotId id : ids) {
                 Plot plot = area.getPlotAbs(id);
                 if (plot.hasOwner()) {
                     MainUtil.sendMessage(player, " - &cDB Already contains: " + plot.getId());
@@ -90,7 +88,7 @@ public class DebugClaimTest extends SubCommand {
                             if (uuid != null) {
                                 MainUtil.sendMessage(player, " - &aFound plot: " + plot.getId() + " : " + line);
                                 plot.setOwner(uuid);
-                                plots.add(plot);
+                                MainUtil.sendMessage(player, " - &8Updated plot: " + plot.getId());
                             } else {
                                 MainUtil.sendMessage(player, " - &cInvalid PlayerName: " + plot.getId() + " : " + line);
                             }
@@ -98,19 +96,7 @@ public class DebugClaimTest extends SubCommand {
                     }
                 }).join();
             }
-        }).thenRun(() -> {
-            MainUtil.sendMessage(player, "&3Sign Block&8->&3Plot&8: Finished scan. Updating data...");
-            if (!plots.isEmpty()) {
-                MainUtil.sendMessage(player, "&3Sign Block&8->&3Plot&8: &7Updating '" + plots.size() + "' plots!");
-                DBFunc.createPlotsAndData(plots, () -> MainUtil.sendMessage(player, "&6Database update finished!"));
-                for (Plot plot1 : plots) {
-                    plot1.create();
-                }
-                MainUtil.sendMessage(player, "&3Sign Block&8->&3Plot&8: &7Complete!");
-            } else {
-                MainUtil.sendMessage(player, "&3Sign Block&8->&3Plot&8: No plots were found for the given search.");
-            }
-        });
+        }).thenRun(() -> MainUtil.sendMessage(player, "&3Sign Block&8->&3Plot&8: Finished scan."));
         return true;
     }
 }


### PR DESCRIPTION
## Description

### Previous Problems 

- Before, only one plot was processed at all (`return true;` in the last line of the loop).
- Also, the `thenRun` Runnable would have been executed for each processed plot (didn't happen of course).
- This would have been also in conflict with the other plots if the chunks were loaded asynchronously.

### Solutions

I used the CompletableFuture class to simply run this operation asynchronous. I'm not aware of which issues could occure, especially when accessing the sign. I tried to use `TaskManager.objectTask(...)` too, but this will stop the server when the server timeout is reached. I'm not quite sure why, looking at its implementation.
~~I'm joining the chunk loading as the `DBFunc.createPlotsAndData(...)` should run after all plots were processed.~~ *This method isn't called now anymore. Still, a success message is sent when finished.*

With that changes, I was able to restore larger amounts of plots without issues (like >5000 plots). 

### New Problems

- As mentioned before, async world access could be an issue.
- TPS will drop anyways
- A lot of memory is required, and it will pause until the GC freed some. That will slow down the whole plot processing.

### Remaining problems which aren't related

- Merged plots aren't restored correctly as they only have one sign

--

This is the best I came up with for now. I'm happy to hear what you're thinking about it.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/breaking/CONTRIBUTING.md)