### PR TITLE
Cancel Plot-Claim if event was cancelled

### DIFF
--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/Plot.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/Plot.java
@@ -1513,9 +1513,14 @@ public class Plot {
 
     public boolean claim(final PlotPlayer player, boolean teleport, String schematic,
         boolean updateDB) {
+        
         boolean result = EventUtil.manager.callClaim(player, this, false);
+        if(!result) {
+            return false;
+        }
+        
         if (updateDB) {
-            if (!result || (!create(player.getUUID(), true))) {
+            if (!create(player.getUUID(), true)) {
                 return false;
             }
         } else {


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets

If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://github.com/IntellectualSites/PlotSquared/issues/new/choose
-->

**Fixes #2691**

## Description
Cancels the plot claim process if the event was cancelled
-> ignores updateDB, because the event should also be able to abort the process when the database is updated