### PR TITLE
Remove all direct access to Plot.owner

### DIFF
--- a/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/commands/DebugUUID.java
+++ b/Bukkit/src/main/java/com/github/intellectualsites/plotsquared/bukkit/commands/DebugUUID.java
@@ -231,9 +231,9 @@ import java.util.UUID;
             MainUtil.sendMessage(player, "&7 - Updating plot objects");
 
             for (Plot plot : PlotSquared.get().getPlots()) {
-                UUID value = uCMap.get(plot.owner);
+                UUID value = uCMap.get(plot.getOwnerAbs());
                 if (value != null) {
-                    plot.owner = value;
+                    plot.setOwnerAbs(value);
                 }
                 plot.getTrusted().clear();
                 plot.getMembers().clear();
@@ -250,9 +250,9 @@ import java.util.UUID;
                 if (!result) {
                     MainUtil.sendMessage(player, "&cConversion failed! Attempting recovery");
                     for (Plot plot : PlotSquared.get().getPlots()) {
-                        UUID value = uCReverse.get(plot.owner);
+                        UUID value = uCReverse.get(plot.getOwnerAbs());
                         if (value != null) {
-                            plot.owner = value;
+                            plot.setOwnerAbs(value);
                         }
                     }
                     DBFunc.createPlotsAndData(new ArrayList<>(PlotSquared.get().getPlots()),

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/PlotSquared.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/PlotSquared.java
@@ -347,8 +347,8 @@ import java.util.zip.ZipInputStream;
                 UUIDHandler.add(new StringWrapper("*"), DBFunc.EVERYONE);
                 forEachPlotRaw(plot -> {
                     if (plot.hasOwner() && plot.temp != -1) {
-                        if (UUIDHandler.getName(plot.owner) == null) {
-                            UUIDHandler.implementation.unknown.add(plot.owner);
+                        if (UUIDHandler.getName(plot.getOwnerAbs()) == null) {
+                            UUIDHandler.implementation.unknown.add(plot.getOwnerAbs());
                         }
                     }
                 });
@@ -736,7 +736,7 @@ import java.util.zip.ZipInputStream;
         } else {
             list = new ArrayList<>(input);
         }
-        list.sort(Comparator.comparingLong(a -> ExpireManager.IMP.getTimestamp(a.owner)));
+        list.sort(Comparator.comparingLong(a -> ExpireManager.IMP.getTimestamp(a.getOwnerAbs())));
         return list;
     }
 

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Auto.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Auto.java
@@ -138,7 +138,7 @@ public class Auto extends SubCommand {
             return;
         }
         whenDone.value = plot;
-        plot.owner = player.getUUID();
+        plot.setOwnerAbs(player.getUUID());
         DBFunc.createPlotSafe(plot, whenDone,
             () -> autoClaimFromDatabase(player, area, plot.getId(), whenDone));
     }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Buy.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Buy.java
@@ -59,8 +59,8 @@ public class Buy extends Command {
         confirm.run(this, () -> {
             Captions.REMOVED_BALANCE.send(player, price);
             EconHandler.manager
-                .depositMoney(UUIDHandler.getUUIDWrapper().getOfflinePlayer(plot.owner), price);
-            PlotPlayer owner = UUIDHandler.getPlayer(plot.owner);
+                .depositMoney(UUIDHandler.getUUIDWrapper().getOfflinePlayer(plot.getOwnerAbs()), price);
+            PlotPlayer owner = UUIDHandler.getPlayer(plot.getOwnerAbs());
             if (owner != null) {
                 Captions.PLOT_SOLD.send(owner, plot.getId(), player.getName(), price);
             }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Claim.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Claim.java
@@ -97,7 +97,7 @@ public class Claim extends SubCommand {
         if (border != Integer.MAX_VALUE && plot.getDistanceFromOrigin() > border && !force) {
             return !sendMessage(player, Captions.BORDER);
         }
-        plot.owner = player.getUUID();
+        plot.setOwnerAbs(player.getUUID());
         final String finalSchematic = schematic;
         DBFunc.createPlotSafe(plot, () -> TaskManager.IMP.sync(new RunnableVal<Object>() {
             @Override public void run(Object value) {
@@ -105,7 +105,7 @@ public class Claim extends SubCommand {
                     PlotSquared.get().getLogger().log(Captions.PREFIX.getTranslated() +
                         String.format("Failed to claim plot %s", plot.getId().toCommaSeparatedString()));
                     sendMessage(player, Captions.PLOT_NOT_CLAIMED);
-                    plot.owner = null;
+                    plot.setOwnerAbs(null);
                 } else if (area.isAutoMerge()) {
                     PlotMergeEvent event = PlotSquared.get().getEventDispatcher()
                         .callMerge(plot, Direction.ALL, Integer.MAX_VALUE, player);
@@ -120,7 +120,7 @@ public class Claim extends SubCommand {
             PlotSquared.get().getLogger().log(Captions.PREFIX.getTranslated() +
                 String.format("Failed to add plot %s to the database", plot.getId().toCommaSeparatedString()));
             sendMessage(player, Captions.PLOT_NOT_CLAIMED);
-            plot.owner = null;
+            plot.setOwnerAbs(null);
         });
         return true;
     }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Owner.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Owner.java
@@ -49,7 +49,7 @@ public class Owner extends SetCommand {
             uuid = null;
         }
         PlotChangeOwnerEvent event = PlotSquared.get().getEventDispatcher()
-            .callOwnerChange(player, plot, plot.hasOwner() ? plot.owner : null, uuid,
+            .callOwnerChange(player, plot, plot.hasOwner() ? plot.getOwnerAbs() : null, uuid,
                 plot.hasOwner());
         if (event.getEventResult() == Result.DENY) {
             sendMessage(player, Captions.EVENT_DENIED, "Owner change");

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Purge.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/commands/Purge.java
@@ -121,7 +121,7 @@ public class Purge extends SubCommand {
             if (added != null && !plot.isAdded(added)) {
                 continue;
             }
-            if (unknown && UUIDHandler.getName(plot.owner) != null) {
+            if (unknown && UUIDHandler.getName(plot.getOwnerAbs()) != null) {
                 continue;
             }
             toDelete.addAll(plot.getConnectedPlots());
@@ -144,7 +144,7 @@ public class Purge extends SubCommand {
                     if (added != null && !plot.isAdded(added)) {
                         continue;
                     }
-                    if (unknown && UUIDHandler.getName(plot.owner) != null) {
+                    if (unknown && UUIDHandler.getName(plot.getOwnerAbs()) != null) {
                         continue;
                     }
                     toDelete.add(plot);

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/database/SQLManager.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/database/SQLManager.java
@@ -718,7 +718,7 @@ import java.util.concurrent.atomic.AtomicInteger;
                 stmt.setInt(i * 5 + 1, plot.getId().x);
                 stmt.setInt(i * 5 + 2, plot.getId().y);
                 try {
-                    stmt.setString(i * 5 + 3, plot.owner.toString());
+                    stmt.setString(i * 5 + 3, plot.getOwnerAbs().toString());
                 } catch (SQLException ignored) {
                     stmt.setString(i * 5 + 3, everyone.toString());
                 }
@@ -732,7 +732,7 @@ import java.util.concurrent.atomic.AtomicInteger;
                 stmt.setInt(i * 6 + 2, plot.getId().x);
                 stmt.setInt(i * 6 + 3, plot.getId().y);
                 try {
-                    stmt.setString(i * 6 + 4, plot.owner.toString());
+                    stmt.setString(i * 6 + 4, plot.getOwnerAbs().toString());
                 } catch (SQLException ignored) {
                     stmt.setString(i * 6 + 4, everyone.toString());
                 }
@@ -743,7 +743,7 @@ import java.util.concurrent.atomic.AtomicInteger;
             @Override public void setSQL(PreparedStatement stmt, Plot plot) throws SQLException {
                 stmt.setInt(1, plot.getId().x);
                 stmt.setInt(2, plot.getId().y);
-                stmt.setString(3, plot.owner.toString());
+                stmt.setString(3, plot.getOwnerAbs().toString());
                 stmt.setString(4, plot.getArea().toString());
                 stmt.setTimestamp(5, new Timestamp(plot.getTimestamp()));
 
@@ -982,7 +982,7 @@ import java.util.concurrent.atomic.AtomicInteger;
             @Override public void set(PreparedStatement statement) throws SQLException {
                 statement.setInt(1, plot.getId().x);
                 statement.setInt(2, plot.getId().y);
-                statement.setString(3, plot.owner.toString());
+                statement.setString(3, plot.getOwnerAbs().toString());
                 statement.setString(4, plot.getArea().toString());
                 statement.setTimestamp(5, new Timestamp(plot.getTimestamp()));
                 statement.setString(6, plot.getArea().toString());
@@ -1051,7 +1051,7 @@ import java.util.concurrent.atomic.AtomicInteger;
             @Override public void set(PreparedStatement statement) throws SQLException {
                 statement.setInt(1, plot.getId().x);
                 statement.setInt(2, plot.getId().y);
-                statement.setString(3, plot.owner.toString());
+                statement.setString(3, plot.getOwnerAbs().toString());
                 statement.setString(4, plot.getArea().toString());
                 statement.setTimestamp(5, new Timestamp(plot.getTimestamp()));
             }
@@ -1356,7 +1356,7 @@ import java.util.concurrent.atomic.AtomicInteger;
     @Override public void delete(final Plot plot) {
         PlotSquared.debug(
             "Deleting plot... Id: " + plot.getId() + " World: " + plot.getWorldName() + " Owner: "
-                + plot.owner + " Index: " + plot.temp);
+                + plot.getOwnerAbs() + " Index: " + plot.temp);
         deleteSettings(plot);
         deleteDenied(plot);
         deleteHelpers(plot);
@@ -1384,7 +1384,7 @@ import java.util.concurrent.atomic.AtomicInteger;
     @Override public void createPlotSettings(final int id, Plot plot) {
         PlotSquared.debug(
             "Creating plot... Id: " + plot.getId() + " World: " + plot.getWorldName() + " Owner: "
-                + plot.owner + " Index: " + id);
+                + plot.getOwnerAbs() + " Index: " + id);
         addPlotTask(plot, new UniqueStatement("createPlotSettings") {
             @Override public void set(PreparedStatement statement) throws SQLException {
                 statement.setInt(1, id);
@@ -3002,10 +3002,10 @@ import java.util.concurrent.atomic.AtomicInteger;
                 continue;
             }
             // owner
-            if (!plot.owner.equals(dataPlot.owner)) {
+            if (!plot.getOwnerAbs().equals(dataPlot.getOwnerAbs())) {
                 PlotSquared
-                    .debug("&8 - &7Setting owner: " + plot + " -> " + MainUtil.getName(plot.owner));
-                setOwner(plot, plot.owner);
+                    .debug("&8 - &7Setting owner: " + plot + " -> " + MainUtil.getName(plot.getOwnerAbs()));
+                setOwner(plot, plot.getOwnerAbs());
             }
             // trusted
             if (!plot.getTrusted().equals(dataPlot.getTrusted())) {

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/Plot.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/Plot.java
@@ -411,16 +411,13 @@ public class Plot {
     }
 
     /**
-     * plot owner
+     * Get the plot owner of this particular sub-plot.
      * (Merged plots can have multiple owners)
-     * Direct access is Deprecated: use getOwners()
+     * Direct access is discouraged: use getOwners()
      *
      * @see #getOwnerAbs() getOwnerAbs() to get the owner as stored in the database
-     * @deprecated A mega-plot may have multiple owners
-     * and this method only considers the
-     * owner of this particular sub-plot.
      */
-    @Deprecated public UUID getOwner() {
+    public UUID getOwner() {
         if (MainUtil.isServerOwned(this)) {
             return DBFunc.SERVER;
         }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/Plot.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/Plot.java
@@ -90,16 +90,10 @@ public class Plot {
     private static Set<CuboidRegion> regions_cache;
 
     @NotNull private final PlotId id;
-
     /**
-     * plot owner
-     * (Merged plots can have multiple owners)
-     * Direct access is Deprecated: use getOwners()
-     *
-     * @deprecated
+     * Plot flag container
      */
-    private UUID owner;
-
+    @Getter private final FlagContainer flagContainer = new FlagContainer(null);
     /**
      * Has the plot changed since the last save cycle?
      */
@@ -113,54 +107,49 @@ public class Plot {
      * @deprecated magical
      */
     @Deprecated public int temp;
-
+    /**
+     * plot owner
+     * (Merged plots can have multiple owners)
+     * Direct access is Deprecated: use getOwners()
+     *
+     * @deprecated
+     */
+    private UUID owner;
     /**
      * Plot creation timestamp (not accurate if the plot was created before this was implemented)<br>
      * - Milliseconds since the epoch<br>
      */
     private long timestamp;
-
     /**
      * List of trusted (with plot permissions).
      */
     private HashSet<UUID> trusted;
-
     /**
      * List of members users (with plot permissions).
      */
     private HashSet<UUID> members;
-
     /**
      * List of denied players.
      */
     private HashSet<UUID> denied;
-
     /**
      * External settings class.
      * - Please favor the methods over direct access to this class<br>
      * - The methods are more likely to be left unchanged from version changes<br>
      */
     private PlotSettings settings;
-
     private PlotArea area;
-
     /**
      * Session only plot metadata (session is until the server stops)<br>
      * <br>
      * For persistent metadata use the flag system
      */
     private ConcurrentHashMap<String, Object> meta;
-
     /**
      * The cached origin plot.
      * - The origin plot is used for plot grouping and relational data
      */
     private Plot origin;
-
-    /**
-     * Plot flag container
-     */
-    @Getter private final FlagContainer flagContainer = new FlagContainer(null);
 
     /**
      * Constructor for a new plot.
@@ -289,16 +278,16 @@ public class Plot {
     /**
      * Get the owner of this exact plot, as it is
      * stored in the database.
-     *
+     * <p>
      * If the plot is a mega-plot, then the method returns
      * the owner of this particular subplot.
-     *
+     * <p>
      * Unlike {@link #getOwner()} this method does not
      * consider factors such as {@link com.github.intellectualsites.plotsquared.plot.flags.implementations.ServerPlotFlag}
      * that could alter the de facto owner of the plot.
      *
      * @return The plot owner of this particular (sub-)plot
-     *         as stored in the database, if one exists. Else, null.
+     * as stored in the database, if one exists. Else, null.
      */
     @Nullable public UUID getOwnerAbs() {
         return this.owner;
@@ -426,10 +415,10 @@ public class Plot {
      * (Merged plots can have multiple owners)
      * Direct access is Deprecated: use getOwners()
      *
-     * @deprecated A mega-plot may have multiple owners
-     *             and this method only considers the
-     *             owner of this particular sub-plot.
      * @see #getOwnerAbs() getOwnerAbs() to get the owner as stored in the database
+     * @deprecated A mega-plot may have multiple owners
+     * and this method only considers the
+     * owner of this particular sub-plot.
      */
     @Deprecated public UUID getOwner() {
         if (MainUtil.isServerOwned(this)) {
@@ -1088,7 +1077,9 @@ public class Plot {
                         "%plr%", name),
                     Captions.OWNER_SIGN_LINE_4.formatted().replaceAll("%id%", id).replaceAll(
                         "%plr%", name)};
-            WorldUtil.IMP.setSign(this.getWorldName(), location.getX(), location.getY(), location.getZ(), lines);
+            WorldUtil.IMP
+                .setSign(this.getWorldName(), location.getX(), location.getY(), location.getZ(),
+                    lines);
         }
     }
 
@@ -1368,7 +1359,7 @@ public class Plot {
         WorldUtil.IMP.getHighestBlock(getWorldName(), location.getX(), location.getZ(), y -> {
             int height = y;
             if (area.allowSigns()) {
-               height = Math.max(y, getManager().getSignLoc(this).getY());
+                height = Math.max(y, getManager().getSignLoc(this).getY());
             }
             location.setY(1 + height);
             result.accept(location);
@@ -1378,8 +1369,7 @@ public class Plot {
     /**
      * @deprecated May cause synchronous chunk loads
      */
-    @Deprecated
-    public Location getCenterSynchronous() {
+    @Deprecated public Location getCenterSynchronous() {
         Location[] corners = getCorners();
         Location top = corners[0];
         Location bot = corners[1];
@@ -1389,7 +1379,8 @@ public class Plot {
         if (!isLoaded()) {
             return location;
         }
-        int y = WorldUtil.IMP.getHighestBlockSynchronous(getWorldName(), location.getX(), location.getZ());
+        int y = WorldUtil.IMP
+            .getHighestBlockSynchronous(getWorldName(), location.getX(), location.getZ());
         if (area.allowSigns()) {
             y = Math.max(y, getManager().getSignLoc(this).getY());
         }
@@ -1400,8 +1391,7 @@ public class Plot {
     /**
      * @deprecated May cause synchronous chunk loads
      */
-    @Deprecated
-    public Location getSideSynchronous() {
+    @Deprecated public Location getSideSynchronous() {
         CuboidRegion largest = getLargestRegion();
         int x = (largest.getMaximumPoint().getX() >> 1) - (largest.getMinimumPoint().getX() >> 1)
             + largest.getMinimumPoint().getX();
@@ -1440,8 +1430,7 @@ public class Plot {
     /**
      * @deprecated May cause synchronous chunk loading
      */
-    @Deprecated
-    public Location getHomeSynchronous() {
+    @Deprecated public Location getHomeSynchronous() {
         BlockLoc home = this.getPosition();
         if (home == null || home.getX() == 0 && home.getZ() == 0) {
             return this.getDefaultHomeSynchronous(true);
@@ -1455,8 +1444,8 @@ public class Plot {
             }
             if (!WorldUtil.IMP.getBlockSynchronous(location).getBlockType().getMaterial().isAir()) {
                 location.setY(Math.max(1 + WorldUtil.IMP
-                        .getHighestBlockSynchronous(this.getWorldName(), location.getX(), location.getZ()),
-                    bottom.getY()));
+                    .getHighestBlockSynchronous(this.getWorldName(), location.getX(),
+                        location.getZ()), bottom.getY()));
             }
             return location;
         }
@@ -1481,11 +1470,11 @@ public class Plot {
             WorldUtil.IMP.getBlock(location, block -> {
                 if (!block.getBlockType().getMaterial().isAir()) {
                     WorldUtil.IMP
-                        .getHighestBlock(this.getWorldName(), location.getX(), location.getZ(), y -> {
-                            location.setY(Math.max(1 + y,
-                                bottom.getY()));
-                            result.accept(location);
-                        });
+                        .getHighestBlock(this.getWorldName(), location.getX(), location.getZ(),
+                            y -> {
+                                location.setY(Math.max(1 + y, bottom.getY()));
+                                result.accept(location);
+                            });
                 } else {
                     result.accept(location);
                 }
@@ -1524,8 +1513,7 @@ public class Plot {
     /**
      * @deprecated May cause synchronous chunk loads
      */
-    @Deprecated
-    public Location getDefaultHomeSynchronous(final boolean member) {
+    @Deprecated public Location getDefaultHomeSynchronous(final boolean member) {
         Plot plot = this.getBasePlot(false);
         PlotLoc loc = member ? area.getDefaultHome() : area.getNonmemberHome();
         if (loc != null) {
@@ -1545,7 +1533,9 @@ public class Plot {
                 z = bot.getZ() + loc.getZ();
             }
             int y = loc.getY() < 1 ?
-                (isLoaded() ? WorldUtil.IMP.getHighestBlockSynchronous(plot.getWorldName(), x, z) + 1 : 63) :
+                (isLoaded() ?
+                    WorldUtil.IMP.getHighestBlockSynchronous(plot.getWorldName(), x, z) + 1 :
+                    63) :
                 loc.getY();
             return new Location(plot.getWorldName(), x, y, z);
         }
@@ -1574,8 +1564,8 @@ public class Plot {
             }
             if (loc.getY() < 1) {
                 if (isLoaded()) {
-                    WorldUtil.IMP.getHighestBlock(plot.getWorldName(), x, z, y ->
-                        result.accept(new Location(plot.getWorldName(), x, y + 1, z)));
+                    WorldUtil.IMP.getHighestBlock(plot.getWorldName(), x, z,
+                        y -> result.accept(new Location(plot.getWorldName(), x, y + 1, z)));
                 } else {
                     result.accept(new Location(plot.getWorldName(), x, 63, z));
                 }
@@ -1737,8 +1727,8 @@ public class Plot {
 
     public boolean claim(final PlotPlayer player, boolean teleport, String schematic) {
         if (!canClaim(player)) {
-            PlotSquared.debug(Captions.PREFIX.getTranslated() +
-                String.format("Player %s attempted to claim plot %s, but was not allowed",
+            PlotSquared.debug(Captions.PREFIX.getTranslated() + String
+                .format("Player %s attempted to claim plot %s, but was not allowed",
                     player.getName(), this.getId().toCommaSeparatedString()));
             return false;
         }
@@ -1750,9 +1740,9 @@ public class Plot {
 
         if (updateDB) {
             if (!create(player.getUUID(), true)) {
-                PlotSquared.debug(Captions.PREFIX.getTranslated() +
-                    String.format("Player %s attempted to claim plot %s, but the database failed to update",
-                        player.getName(), this.getId().toCommaSeparatedString()));
+                PlotSquared.debug(Captions.PREFIX.getTranslated() + String.format(
+                    "Player %s attempted to claim plot %s, but the database failed to update",
+                    player.getName(), this.getId().toCommaSeparatedString()));
                 return false;
             }
         } else {
@@ -1761,7 +1751,8 @@ public class Plot {
         setSign(player.getName());
         MainUtil.sendMessage(player, Captions.CLAIMED);
         if (teleport && Settings.Teleport.ON_CLAIM) {
-            teleportPlayer(player, TeleportCause.COMMAND, result -> {});
+            teleportPlayer(player, TeleportCause.COMMAND, result -> {
+            });
         }
         PlotArea plotworld = getArea();
         if (plotworld.isSchematicOnClaim()) {
@@ -1838,9 +1829,9 @@ public class Plot {
             });
             return true;
         }
-        PlotSquared.get().getLogger().log(Captions.PREFIX.getTranslated() +
-            String.format("Failed to add plot %s to plot area %s", this.getId().toCommaSeparatedString(),
-            this.area.toString()));
+        PlotSquared.get().getLogger().log(Captions.PREFIX.getTranslated() + String
+            .format("Failed to add plot %s to plot area %s", this.getId().toCommaSeparatedString(),
+                this.area.toString()));
         return false;
     }
 
@@ -1862,17 +1853,17 @@ public class Plot {
      * @return the name of the biome
      */
     public void getBiome(Consumer<BiomeType> result) {
-        this.getCenter(location ->
-            WorldUtil.IMP.getBiome(location.getWorld(), location.getX(), location.getZ(), result));
+        this.getCenter(location -> WorldUtil.IMP
+            .getBiome(location.getWorld(), location.getX(), location.getZ(), result));
     }
 
     /**
      * @deprecated May cause synchronous chunk loads
      */
-    @Deprecated
-    public BiomeType getBiomeSynchronous() {
+    @Deprecated public BiomeType getBiomeSynchronous() {
         final Location location = this.getCenterSynchronous();
-        return WorldUtil.IMP.getBiomeSynchronous(location.getWorld(), location.getX(), location.getZ());
+        return WorldUtil.IMP
+            .getBiomeSynchronous(location.getWorld(), location.getX(), location.getZ());
     }
 
     //TODO Better documentation needed.
@@ -1900,7 +1891,7 @@ public class Plot {
     /**
      * Swaps the settings for two plots.
      *
-     * @param plot     the plot to swap data with
+     * @param plot the plot to swap data with
      * @return Future containing the result
      */
     public CompletableFuture<Boolean> swapData(Plot plot) {
@@ -2020,14 +2011,16 @@ public class Plot {
      * - Used when a plot is merged<br>
      */
     public void removeRoadEast() {
-        if (this.area.getType() != PlotAreaType.NORMAL && this.area.getTerrain() == PlotAreaTerrainType.ROAD) {
+        if (this.area.getType() != PlotAreaType.NORMAL
+            && this.area.getTerrain() == PlotAreaTerrainType.ROAD) {
             Plot other = this.getRelative(Direction.EAST);
             Location bot = other.getBottomAbs();
             Location top = this.getTopAbs();
             Location pos1 = new Location(this.getWorldName(), top.getX(), 0, bot.getZ());
             Location pos2 = new Location(this.getWorldName(), bot.getX(), MAX_HEIGHT, top.getZ());
             ChunkManager.manager.regenerateRegion(pos1, pos2, true, null);
-        } else if (this.area.getTerrain() != PlotAreaTerrainType.ALL) { // no road generated => no road to remove
+        } else if (this.area.getTerrain()
+            != PlotAreaTerrainType.ALL) { // no road generated => no road to remove
             this.area.getPlotManager().removeRoadEast(this);
         }
     }
@@ -2465,14 +2458,16 @@ public class Plot {
      * - Used when a plot is merged<br>
      */
     public void removeRoadSouth() {
-        if (this.area.getType() != PlotAreaType.NORMAL && this.area.getTerrain() == PlotAreaTerrainType.ROAD) {
+        if (this.area.getType() != PlotAreaType.NORMAL
+            && this.area.getTerrain() == PlotAreaTerrainType.ROAD) {
             Plot other = this.getRelative(Direction.SOUTH);
             Location bot = other.getBottomAbs();
             Location top = this.getTopAbs();
             Location pos1 = new Location(this.getWorldName(), bot.getX(), 0, top.getZ());
             Location pos2 = new Location(this.getWorldName(), top.getX(), MAX_HEIGHT, bot.getZ());
             ChunkManager.manager.regenerateRegion(pos1, pos2, true, null);
-        } else if (this.area.getTerrain() != PlotAreaTerrainType.ALL) { // no road generated => no road to remove
+        } else if (this.area.getTerrain()
+            != PlotAreaTerrainType.ALL) { // no road generated => no road to remove
             this.getManager().removeRoadSouth(this);
         }
     }
@@ -2641,14 +2636,16 @@ public class Plot {
      * Remove the SE road (only effects terrain)
      */
     public void removeRoadSouthEast() {
-        if (this.area.getType() != PlotAreaType.NORMAL && this.area.getTerrain() == PlotAreaTerrainType.ROAD) {
+        if (this.area.getType() != PlotAreaType.NORMAL
+            && this.area.getTerrain() == PlotAreaTerrainType.ROAD) {
             Plot other = this.getRelative(1, 1);
             Location pos1 = this.getTopAbs().add(1, 0, 1);
             Location pos2 = other.getBottomAbs().subtract(1, 0, 1);
             pos1.setY(0);
             pos2.setY(MAX_HEIGHT);
             ChunkManager.manager.regenerateRegion(pos1, pos2, true, null);
-        } else if (this.area.getTerrain() != PlotAreaTerrainType.ALL) { // no road generated => no road to remove
+        } else if (this.area.getTerrain()
+            != PlotAreaTerrainType.ALL) { // no road generated => no road to remove
             this.area.getPlotManager().removeRoadSouthEast(this);
         }
     }
@@ -2789,8 +2786,8 @@ public class Plot {
             if (current.getOwnerAbs() == null || current.settings == null) {
                 // Invalid plot
                 // merged onto unclaimed plot
-                PlotSquared
-                    .debug("Ignoring invalid merged plot: " + current + " | " + current.getOwnerAbs());
+                PlotSquared.debug(
+                    "Ignoring invalid merged plot: " + current + " | " + current.getOwnerAbs());
                 continue;
             }
             tmpSet.add(current);
@@ -3045,23 +3042,27 @@ public class Plot {
      * @param cause  the cause of the teleport
      * @return if the teleport succeeded
      */
-    public void teleportPlayer(final PlotPlayer player, TeleportCause cause, Consumer<Boolean> resultConsumer) {
+    public void teleportPlayer(final PlotPlayer player, TeleportCause cause,
+        Consumer<Boolean> resultConsumer) {
         Plot plot = this.getBasePlot(false);
         Result result =
-            PlotSquared.get().getEventDispatcher().callTeleport(player, player.getLocation(), plot).getEventResult();
+            PlotSquared.get().getEventDispatcher().callTeleport(player, player.getLocation(), plot)
+                .getEventResult();
         if (result == Result.DENY) {
             sendMessage(player, Captions.EVENT_DENIED, "Teleport");
             resultConsumer.accept(false);
             return;
         }
         final Consumer<Location> locationConsumer = location -> {
-            if (Settings.Teleport.DELAY == 0 || Permissions.hasPermission(player, "plots.teleport.delay.bypass")) {
+            if (Settings.Teleport.DELAY == 0 || Permissions
+                .hasPermission(player, "plots.teleport.delay.bypass")) {
                 MainUtil.sendMessage(player, Captions.TELEPORTED_TO_PLOT);
                 player.teleport(location, cause);
                 resultConsumer.accept(true);
                 return;
             }
-            MainUtil.sendMessage(player, Captions.TELEPORT_IN_SECONDS, Settings.Teleport.DELAY + "");
+            MainUtil
+                .sendMessage(player, Captions.TELEPORT_IN_SECONDS, Settings.Teleport.DELAY + "");
             final String name = player.getName();
             TaskManager.TELEPORT_QUEUE.add(name);
             TaskManager.runTaskLater(() -> {
@@ -3114,7 +3115,8 @@ public class Plot {
      * @return
      */
     public boolean setComponent(String component, Pattern blocks) {
-        PlotComponentSetEvent event = PlotSquared.get().getEventDispatcher().callComponentSet(this, component, blocks);
+        PlotComponentSetEvent event =
+            PlotSquared.get().getEventDispatcher().callComponentSet(this, component, blocks);
         component = event.getComponent();
         blocks = event.getPattern();
         return this.getManager().setComponent(this.getId(), component, blocks);
@@ -3212,7 +3214,8 @@ public class Plot {
      * @param allowSwap   whether to swap plots
      * @return success
      */
-    public CompletableFuture<Boolean> move(final Plot destination, final Runnable whenDone, boolean allowSwap) {
+    public CompletableFuture<Boolean> move(final Plot destination, final Runnable whenDone,
+        boolean allowSwap) {
         final PlotId offset = new PlotId(destination.getId().x - this.getId().x,
             destination.getId().y - this.getId().y);
         Location db = destination.getBottomAbs();
@@ -3293,7 +3296,8 @@ public class Plot {
                     @Override public void run() {
                         if (regions.isEmpty()) {
                             Plot plot = destination.getRelative(0, 0);
-                            Plot originPlot = originArea.getPlotAbs(new PlotId(plot.id.x - offset.x, plot.id.y - offset.y));
+                            Plot originPlot = originArea
+                                .getPlotAbs(new PlotId(plot.id.x - offset.x, plot.id.y - offset.y));
                             final Runnable clearDone = () -> {
                                 for (final Plot current : plot.getConnectedPlots()) {
                                     getManager().claimPlot(current);

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/Plot.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/Plot.java
@@ -487,7 +487,7 @@ public class Plot {
      * @return true if the player is added/trusted or is the owner
      */
     public boolean isAdded(UUID uuid) {
-        if (this.getOwnerAbs() == null || getDenied().contains(uuid)) {
+        if (!this.hasOwner() || getDenied().contains(uuid)) {
             return false;
         }
         if (isOwner(uuid)) {
@@ -911,7 +911,7 @@ public class Plot {
                         TaskManager.runTask(whenDone);
                     };
                     for (Plot current : plots) {
-                        if (isDelete || current.getOwnerAbs() == null) {
+                        if (isDelete || !current.hasOwner()) {
                             manager.unClaimPlot(current, null);
                         } else {
                             manager.claimPlot(current);
@@ -1313,7 +1313,7 @@ public class Plot {
      * @return false if the Plot has no owner, otherwise true.
      */
     public boolean unclaim() {
-        if (this.getOwnerAbs() == null) {
+        if (!this.hasOwner()) {
             return false;
         }
         for (Plot current : getConnectedPlots()) {
@@ -1698,7 +1698,7 @@ public class Plot {
      * Sets the plot sign if plot signs are enabled.
      */
     public void setSign() {
-        if (this.getOwnerAbs() == null) {
+        if (!this.hasOwner()) {
             this.setSign("unknown");
             return;
         }
@@ -1892,7 +1892,7 @@ public class Plot {
      * @return Future containing the result
      */
     public CompletableFuture<Boolean> swapData(Plot plot) {
-        if (this.getOwnerAbs() == null) {
+        if (!this.hasOwner()) {
             if (plot != null && plot.hasOwner()) {
                 plot.moveData(this, null);
                 return CompletableFuture.completedFuture(true);
@@ -1927,7 +1927,7 @@ public class Plot {
      * @return
      */
     public boolean moveData(Plot plot, Runnable whenDone) {
-        if (this.getOwnerAbs() == null) {
+        if (!this.hasOwner()) {
             PlotSquared.debug(plot + " is unowned (single)");
             TaskManager.runTask(whenDone);
             return false;
@@ -2480,7 +2480,7 @@ public class Plot {
      */
     public boolean autoMerge(Direction dir, int max, UUID uuid, boolean removeRoads) {
         //Ignore merging if there is no owner for the plot
-        if (this.getOwnerAbs() == null) {
+        if (!this.hasOwner()) {
             return false;
         }
         Set<Plot> connected = this.getConnectedPlots();
@@ -2780,7 +2780,7 @@ public class Plot {
         }
         Plot current;
         while ((current = frontier.poll()) != null) {
-            if (current.getOwnerAbs() == null || current.settings == null) {
+            if (!current.hasOwner() || current.settings == null) {
                 // Invalid plot
                 // merged onto unclaimed plot
                 PlotSquared.debug(
@@ -3088,7 +3088,7 @@ public class Plot {
      * @return true if the owner of the Plot is online
      */
     public boolean isOnline() {
-        if (this.getOwnerAbs() == null) {
+        if (!this.hasOwner()) {
             return false;
         }
         if (!isMerged()) {
@@ -3219,7 +3219,7 @@ public class Plot {
         Location ob = this.getBottomAbs();
         final int offsetX = db.getX() - ob.getX();
         final int offsetZ = db.getZ() - ob.getZ();
-        if (this.getOwnerAbs() == null) {
+        if (!this.hasOwner()) {
             TaskManager.runTaskLater(whenDone, 1);
             return CompletableFuture.completedFuture(false);
         }
@@ -3338,7 +3338,7 @@ public class Plot {
         Location ob = this.getBottomAbs();
         final int offsetX = db.getX() - ob.getX();
         final int offsetZ = db.getZ() - ob.getZ();
-        if (this.getOwnerAbs() == null) {
+        if (!this.hasOwner()) {
             TaskManager.runTaskLater(whenDone, 1);
             return false;
         }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/Plot.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/Plot.java
@@ -487,7 +487,7 @@ public class Plot {
      * @return true if the player is added/trusted or is the owner
      */
     public boolean isAdded(UUID uuid) {
-        if (this.hasOwner() || getDenied().contains(uuid)) {
+        if (this.getOwnerAbs() == null || getDenied().contains(uuid)) {
             return false;
         }
         if (isOwner(uuid)) {
@@ -911,7 +911,7 @@ public class Plot {
                         TaskManager.runTask(whenDone);
                     };
                     for (Plot current : plots) {
-                        if (isDelete || current.hasOwner()) {
+                        if (isDelete || current.getOwnerAbs() == null) {
                             manager.unClaimPlot(current, null);
                         } else {
                             manager.claimPlot(current);
@@ -1313,7 +1313,7 @@ public class Plot {
      * @return false if the Plot has no owner, otherwise true.
      */
     public boolean unclaim() {
-        if (this.hasOwner()) {
+        if (this.getOwnerAbs() == null) {
             return false;
         }
         for (Plot current : getConnectedPlots()) {
@@ -1698,7 +1698,7 @@ public class Plot {
      * Sets the plot sign if plot signs are enabled.
      */
     public void setSign() {
-        if (this.hasOwner()) {
+        if (this.getOwnerAbs() == null) {
             this.setSign("unknown");
             return;
         }
@@ -1892,7 +1892,7 @@ public class Plot {
      * @return Future containing the result
      */
     public CompletableFuture<Boolean> swapData(Plot plot) {
-        if (this.hasOwner()) {
+        if (this.getOwnerAbs() == null) {
             if (plot != null && plot.hasOwner()) {
                 plot.moveData(this, null);
                 return CompletableFuture.completedFuture(true);
@@ -1927,7 +1927,7 @@ public class Plot {
      * @return
      */
     public boolean moveData(Plot plot, Runnable whenDone) {
-        if (this.hasOwner()) {
+        if (this.getOwnerAbs() == null) {
             PlotSquared.debug(plot + " is unowned (single)");
             TaskManager.runTask(whenDone);
             return false;
@@ -2480,7 +2480,7 @@ public class Plot {
      */
     public boolean autoMerge(Direction dir, int max, UUID uuid, boolean removeRoads) {
         //Ignore merging if there is no owner for the plot
-        if (this.hasOwner()) {
+        if (this.getOwnerAbs() == null) {
             return false;
         }
         Set<Plot> connected = this.getConnectedPlots();
@@ -2780,7 +2780,7 @@ public class Plot {
         }
         Plot current;
         while ((current = frontier.poll()) != null) {
-            if (current.hasOwner() || current.settings == null) {
+            if (current.getOwnerAbs() == null || current.settings == null) {
                 // Invalid plot
                 // merged onto unclaimed plot
                 PlotSquared.debug(
@@ -3088,7 +3088,7 @@ public class Plot {
      * @return true if the owner of the Plot is online
      */
     public boolean isOnline() {
-        if (this.hasOwner()) {
+        if (this.getOwnerAbs() == null) {
             return false;
         }
         if (!isMerged()) {
@@ -3219,7 +3219,7 @@ public class Plot {
         Location ob = this.getBottomAbs();
         final int offsetX = db.getX() - ob.getX();
         final int offsetZ = db.getZ() - ob.getZ();
-        if (this.hasOwner()) {
+        if (this.getOwnerAbs() == null) {
             TaskManager.runTaskLater(whenDone, 1);
             return CompletableFuture.completedFuture(false);
         }
@@ -3338,7 +3338,7 @@ public class Plot {
         Location ob = this.getBottomAbs();
         final int offsetX = db.getX() - ob.getX();
         final int offsetZ = db.getZ() - ob.getZ();
-        if (this.hasOwner()) {
+        if (this.getOwnerAbs() == null) {
             TaskManager.runTaskLater(whenDone, 1);
             return false;
         }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/Plot.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/Plot.java
@@ -490,7 +490,7 @@ public class Plot {
      * @return true if the player is added/trusted or is the owner
      */
     public boolean isAdded(UUID uuid) {
-        if (this.getOwnerAbs() == null || getDenied().contains(uuid)) {
+        if (this.hasOwner() || getDenied().contains(uuid)) {
             return false;
         }
         if (isOwner(uuid)) {
@@ -914,7 +914,7 @@ public class Plot {
                         TaskManager.runTask(whenDone);
                     };
                     for (Plot current : plots) {
-                        if (isDelete || current.getOwnerAbs() == null) {
+                        if (isDelete || current.hasOwner()) {
                             manager.unClaimPlot(current, null);
                         } else {
                             manager.claimPlot(current);
@@ -1316,7 +1316,7 @@ public class Plot {
      * @return false if the Plot has no owner, otherwise true.
      */
     public boolean unclaim() {
-        if (this.getOwnerAbs() == null) {
+        if (this.hasOwner()) {
             return false;
         }
         for (Plot current : getConnectedPlots()) {
@@ -1701,7 +1701,7 @@ public class Plot {
      * Sets the plot sign if plot signs are enabled.
      */
     public void setSign() {
-        if (this.getOwnerAbs() == null) {
+        if (this.hasOwner()) {
             this.setSign("unknown");
             return;
         }
@@ -1895,7 +1895,7 @@ public class Plot {
      * @return Future containing the result
      */
     public CompletableFuture<Boolean> swapData(Plot plot) {
-        if (this.getOwnerAbs() == null) {
+        if (this.hasOwner()) {
             if (plot != null && plot.hasOwner()) {
                 plot.moveData(this, null);
                 return CompletableFuture.completedFuture(true);
@@ -1930,7 +1930,7 @@ public class Plot {
      * @return
      */
     public boolean moveData(Plot plot, Runnable whenDone) {
-        if (this.getOwnerAbs() == null) {
+        if (this.hasOwner()) {
             PlotSquared.debug(plot + " is unowned (single)");
             TaskManager.runTask(whenDone);
             return false;
@@ -2483,7 +2483,7 @@ public class Plot {
      */
     public boolean autoMerge(Direction dir, int max, UUID uuid, boolean removeRoads) {
         //Ignore merging if there is no owner for the plot
-        if (this.getOwnerAbs() == null) {
+        if (this.hasOwner()) {
             return false;
         }
         Set<Plot> connected = this.getConnectedPlots();
@@ -2783,7 +2783,7 @@ public class Plot {
         }
         Plot current;
         while ((current = frontier.poll()) != null) {
-            if (current.getOwnerAbs() == null || current.settings == null) {
+            if (current.hasOwner() || current.settings == null) {
                 // Invalid plot
                 // merged onto unclaimed plot
                 PlotSquared.debug(
@@ -3091,7 +3091,7 @@ public class Plot {
      * @return true if the owner of the Plot is online
      */
     public boolean isOnline() {
-        if (this.getOwnerAbs() == null) {
+        if (this.hasOwner()) {
             return false;
         }
         if (!isMerged()) {
@@ -3222,7 +3222,7 @@ public class Plot {
         Location ob = this.getBottomAbs();
         final int offsetX = db.getX() - ob.getX();
         final int offsetZ = db.getZ() - ob.getZ();
-        if (this.getOwnerAbs() == null) {
+        if (this.hasOwner()) {
             TaskManager.runTaskLater(whenDone, 1);
             return CompletableFuture.completedFuture(false);
         }
@@ -3341,7 +3341,7 @@ public class Plot {
         Location ob = this.getBottomAbs();
         final int offsetX = db.getX() - ob.getX();
         final int offsetZ = db.getZ() - ob.getZ();
-        if (this.getOwnerAbs() == null) {
+        if (this.hasOwner()) {
             TaskManager.runTaskLater(whenDone, 1);
             return false;
         }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotArea.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotArea.java
@@ -503,7 +503,7 @@ public abstract class PlotArea {
         }
         final HashSet<Plot> myPlots = new HashSet<>();
         forEachPlotAbs(value -> {
-            if (uuid.equals(value.owner)) {
+            if (uuid.equals(value.getOwnerAbs())) {
                 myPlots.add(value);
             }
         });

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotHandler.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotHandler.java
@@ -1,11 +1,14 @@
 package com.github.intellectualsites.plotsquared.plot.object;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Set;
 import java.util.UUID;
 
 public class PlotHandler {
-    public static boolean sameOwners(final Plot plot1, final Plot plot2) {
-        if (plot1.owner == null || plot2.owner == null) {
+
+    public static boolean sameOwners(@NotNull final Plot plot1, @NotNull final Plot plot2) {
+        if (plot1.getOwnerAbs() == null || plot2.getOwnerAbs() == null) {
             return false;
         }
         final Set<UUID> owners = plot1.getOwners();
@@ -16,4 +19,5 @@ public class PlotHandler {
         }
         return false;
     }
+
 }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotHandler.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotHandler.java
@@ -8,11 +8,11 @@ import java.util.UUID;
 public class PlotHandler {
 
     public static boolean sameOwners(@NotNull final Plot plot1, @NotNull final Plot plot2) {
-        if (plot1.getOwnerAbs() == null || plot2.getOwnerAbs() == null) {
+        if (!(plot1.hasOwner() && plot2.hasOwner())) {
             return false;
         }
         final Set<UUID> owners = plot1.getOwners();
-        for (UUID owner : owners) {
+        for (final UUID owner : owners) {
             if (plot2.isOwner(owner)) {
                 return true;
             }

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotHandler.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotHandler.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 public class PlotHandler {
 
     public static boolean sameOwners(@NotNull final Plot plot1, @NotNull final Plot plot2) {
-        if (plot1.hasOwner() || plot2.hasOwner()) {
+        if (plot1.getOwnerAbs() == null || plot2.getOwnerAbs() == null) {
             return false;
         }
         final Set<UUID> owners = plot1.getOwners();

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotHandler.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/PlotHandler.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 public class PlotHandler {
 
     public static boolean sameOwners(@NotNull final Plot plot1, @NotNull final Plot plot2) {
-        if (plot1.getOwnerAbs() == null || plot2.getOwnerAbs() == null) {
+        if (plot1.hasOwner() || plot2.hasOwner()) {
             return false;
         }
         final Set<UUID> owners = plot1.getOwners();

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/worlds/SinglePlotArea.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/object/worlds/SinglePlotArea.java
@@ -171,7 +171,7 @@ public class SinglePlotArea extends GridPlotWorld {
         PlotSettings s = p.getSettings();
 
         final FlagContainer oldContainer = p.getFlagContainer();
-        p = new SinglePlot(p.getId(), p.owner, p.getTrusted(), p.getMembers(), p.getDenied(),
+        p = new SinglePlot(p.getId(), p.getOwnerAbs(), p.getTrusted(), p.getMembers(), p.getDenied(),
             s.getAlias(), s.getPosition(), null, this, s.getMerged(), p.getTimestamp(), p.temp);
         p.getFlagContainer().addAll(oldContainer);
 

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/util/UUIDHandler.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/util/UUIDHandler.java
@@ -61,7 +61,7 @@ public class UUIDHandler {
         final HashSet<UUID> uuids = new HashSet<>();
         PlotSquared.get().forEachPlotRaw(plot -> {
             if (plot.hasOwner()) {
-                uuids.add(plot.owner);
+                uuids.add(plot.getOwnerAbs());
                 uuids.addAll(plot.getTrusted());
                 uuids.addAll(plot.getMembers());
                 uuids.addAll(plot.getDenied());
@@ -107,8 +107,8 @@ public class UUIDHandler {
         return implementation.getName(uuid);
     }
 
-    public static PlotPlayer getPlayer(UUID uuid) {
-        if (implementation == null) {
+    @Nullable public static PlotPlayer getPlayer(@Nullable final UUID uuid) {
+        if (implementation == null || uuid == null) {
             return null;
         }
         return check(implementation.getPlayer(uuid));

--- a/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/util/UUIDHandlerImplementation.java
+++ b/Core/src/main/java/com/github/intellectualsites/plotsquared/plot/util/UUIDHandlerImplementation.java
@@ -130,8 +130,8 @@ public abstract class UUIDHandlerImplementation {
                     UUIDHandlerImplementation.this.unknown.remove(offline);
                     Set<Plot> plots = PlotSquared.get().getPlotsAbs(offline);
                     if (!plots.isEmpty()) {
-                        for (Plot plot : plots) {
-                            plot.owner = uuid;
+                        for (final Plot plot : plots) {
+                            plot.setOwnerAbs(uuid);
                         }
                         DBFunc.replaceUUID(offline, uuid);
                         PlotSquared.debug("&cDetected invalid UUID stored for: " + name.value);
@@ -152,8 +152,8 @@ public abstract class UUIDHandlerImplementation {
                     UUIDHandlerImplementation.this.unknown.remove(offlineUpper);
                     Set<Plot> plots = PlotSquared.get().getPlotsAbs(offlineUpper);
                     if (!plots.isEmpty()) {
-                        for (Plot plot : plots) {
-                            plot.owner = uuid;
+                        for (final Plot plot : plots) {
+                            plot.setOwnerAbs(uuid);
                         }
                         replace(offlineUpper, uuid, name.value);
                     }
@@ -166,8 +166,8 @@ public abstract class UUIDHandlerImplementation {
                 if (!existing.equals(uuid)) {
                     Set<Plot> plots = PlotSquared.get().getPlots(existing);
                     if (!plots.isEmpty()) {
-                        for (Plot plot : plots) {
-                            plot.owner = uuid;
+                        for (final Plot plot : plots) {
+                            plot.setOwnerAbs(uuid);
                         }
                         replace(existing, uuid, name.value);
                     }


### PR DESCRIPTION
Remove all direct access to Plot.owner

New methods were added for access to the absolute owner of a plot, and the documentation of the owner getters to clarify the purpose of the methods.