### PR TITLE
If all players are denied from a plot, this will allow administrators…

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEvents.java
@@ -946,7 +946,7 @@ public class PlayerEvents extends PlotListener implements Listener {
             || area.isForcingPlotChat())) {
             return;
         }
-        if (plot.isDenied(plotPlayer.getUUID())) {
+        if (plot.isDenied(plotPlayer.getUUID()) && !plotPlayer.hasPermission("plots.admin.command.chat")) {
             return;
         }
         event.setCancelled(true);

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEvents.java
@@ -946,7 +946,7 @@ public class PlayerEvents extends PlotListener implements Listener {
             || area.isForcingPlotChat())) {
             return;
         }
-        if (plot.isDenied(plotPlayer.getUUID()) && !plotPlayer.hasPermission("plots.admin.command.chat")) {
+        if (plot.isDenied(plotPlayer.getUUID()) && !Permissions.hasPermission(plotPlayer, Captions.PERMISSION_COMMANDS_CHAT)) {
             return;
         }
         event.setCancelled(true);

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEvents.java
@@ -946,7 +946,7 @@ public class PlayerEvents extends PlotListener implements Listener {
             || area.isForcingPlotChat())) {
             return;
         }
-        if (plot.isDenied(plotPlayer.getUUID()) && !Permissions.hasPermission(plotPlayer, Captions.PERMISSION_COMMANDS_CHAT)) {
+        if (plot.isDenied(plotPlayer.getUUID()) && !Permissions.hasPermission(plotPlayer, Captions.PERMISSION_ADMIN_CHAT_BYPASS)) {
             return;
         }
         event.setCancelled(true);

--- a/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
@@ -183,6 +183,7 @@ public enum Captions implements Caption {
     PERMISSION_ALIAS_SET_OBSOLETE("plots.set.alias", "static.permissions"), // Note this is for backwards compatibility
     PERMISSION_ALIAS_SET("plots.alias.set", "static.permissions"),
     PERMISSION_ALIAS_REMOVE("plots.alias.remove", "static.permissions"),
+    PERMISSION_ADMIN_CHAT_BYPASS("plots.admin.chat.bypass", "static.permissions"),
     //</editor-fold>
     //<editor-fold desc="Static Console">
     CONSOLE_JAVA_OUTDATED(


### PR DESCRIPTION
… with permission to see chatspy, talk in plots they have been denied from.

## Overview
This will allow staff members/administrators to speak in the plot chat of a plot they have been denied. This will be useful for private conversations with plot owners when all players are denied, or, allowing server staff to continue to speak in the plot, even if they have been denied by players trying to evade them.

**Fixes N/A**

## Description
When a staff member or administrator tries to speak in a plot where everyone is denied, they cannot, this will resolve that making life easier for server staff. This adds a further check to PlayerEvents, checking that the user does not have permission to see chatspy before canceling the event.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/breaking/CONTRIBUTING.md)