### PR TITLE
Prevent NPE for report comments

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/database/SQLManager.java
+++ b/Core/src/main/java/com/plotsquared/core/database/SQLManager.java
@@ -248,10 +248,7 @@ import java.util.concurrent.atomic.AtomicInteger;
         return this.notifyTasks;
     }
 
-    public synchronized void addPlotTask(Plot plot, UniqueStatement task) {
-        if (plot == null) {
-            plot = new Plot(null, new PlotId(Integer.MAX_VALUE, Integer.MAX_VALUE));
-        }
+    public synchronized void addPlotTask(@NotNull Plot plot, UniqueStatement task) {
         Queue<UniqueStatement> tasks = this.plotTasks.get(plot);
         if (tasks == null) {
             tasks = new ConcurrentLinkedQueue<>();

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -204,7 +204,7 @@ public class Plot {
      * @param id   the plot id
      * @see Plot#getPlot(Location) for existing plots
      */
-    public Plot(PlotArea area, @NotNull PlotId id) {
+    public Plot(@NotNull PlotArea area, @NotNull PlotId id) {
         this(area, id, null, 0);
     }
 

--- a/Core/src/main/java/com/plotsquared/core/plot/comment/InboxReport.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/comment/InboxReport.java
@@ -35,7 +35,7 @@ import java.util.List;
 public class InboxReport extends CommentInbox {
 
     @Override public boolean getComments(Plot plot, final RunnableVal<List<PlotComment>> whenDone) {
-        DBFunc.getComments(null, toString(), new RunnableVal<List<PlotComment>>() {
+        DBFunc.getComments(plot, toString(), new RunnableVal<List<PlotComment>>() {
             @Override public void run(List<PlotComment> value) {
                 whenDone.value = value;
                 TaskManager.runTask(whenDone);


### PR DESCRIPTION
The `addPlotTask` could not be invoked successfully with a null plot as it created a new plot with a null PlotArea, so I removed the check and annotated it instead. 
I didn't tracked down every 31 usages of this method to find possible usages with null, so maybe we should check that parameter with `Objects.requireNonNull` to throw an exception early. Would be happy about feedback regarding that.