### PR TITLE
Fixes #2800 Allow to wrap OfflinePlayers in 1.15.2

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/OfflinePlayerUtil.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/OfflinePlayerUtil.java
@@ -90,7 +90,10 @@ public class OfflinePlayerUtil {
         Object worldServer = getWorldServer();
         Class<?> playerInteractClass = getNmsClass("PlayerInteractManager");
         Class<?> worldClass = getNmsClass("World");
-        Constructor c = makeConstructor(playerInteractClass, worldClass);
+        Constructor<?> c = makeConstructor(playerInteractClass, worldClass);
+        if (c == null) {
+            c = makeConstructor(playerInteractClass, getNmsClass("WorldServer"));
+        }
         return callConstructor(c, worldServer);
     }
 


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets

If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://github.com/IntellectualSites/PlotSquared/issues/new/choose
-->

**Fixes #2800**

## Description
See the Issue for the Description.
I don't know if this never used to work (as in the constructor wasn't available on earlier versions) or if this has changed with 1.15 or 1.14, but with this PR it should be backwards compatible.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/breaking/CONTRIBUTING.md)