### PR TITLE
Lazily initialize block tags

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/database/SQLManager.java
+++ b/Core/src/main/java/com/plotsquared/core/database/SQLManager.java
@@ -42,6 +42,7 @@ import com.plotsquared.core.plot.flag.FlagContainer;
 import com.plotsquared.core.plot.flag.FlagParseException;
 import com.plotsquared.core.plot.flag.GlobalFlagContainer;
 import com.plotsquared.core.plot.flag.PlotFlag;
+import com.plotsquared.core.plot.flag.types.BlockTypeListFlag;
 import com.plotsquared.core.util.MainUtil;
 import com.plotsquared.core.util.StringMan;
 import com.plotsquared.core.util.task.RunnableVal;
@@ -1962,6 +1963,7 @@ public class SQLManager implements AbstractDB {
 
                 try (final ResultSet resultSet = statement
                     .executeQuery("SELECT * FROM `" + this.prefix + "plot_flags`")) {
+                    BlockTypeListFlag.skipCategoryVerification = true; // allow invalid tags, as initialized lazily
                     final ArrayList<Integer> toDelete = new ArrayList<>();
                     final Map<Plot, Collection<PlotFlag<?, ?>>> invalidFlags = new HashMap<>();
                     while (resultSet.next()) {
@@ -1978,6 +1980,7 @@ public class SQLManager implements AbstractDB {
                                 try {
                                     plot.getFlagContainer().addFlag(plotFlag.parse(value));
                                 } catch (final FlagParseException e) {
+                                    e.printStackTrace();
                                     PlotSquared
                                         .debug("Plot with ID " + id + " has an invalid value:");
                                     PlotSquared.debug(Captions.FLAG_PARSE_ERROR.getTranslated()
@@ -1997,6 +2000,7 @@ public class SQLManager implements AbstractDB {
                                 + " in `plot_flags` does not exist. Create this plot or set `database-purger: true` in the settings.yml.");
                         }
                     }
+                    BlockTypeListFlag.skipCategoryVerification = false; // don't allow invalid tags anymore
                     if (Settings.Enabled_Components.DATABASE_PURGER) {
                         for (final Map.Entry<Plot, Collection<PlotFlag<?, ?>>> plotFlagEntry : invalidFlags
                             .entrySet()) {

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/types/BlockTypeWrapper.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/types/BlockTypeWrapper.java
@@ -26,7 +26,9 @@
 package com.plotsquared.core.plot.flag.types;
 
 import com.google.common.base.Preconditions;
+import com.plotsquared.core.PlotSquared;
 import com.sk89q.worldedit.world.block.BlockCategory;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockType;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -97,7 +99,11 @@ public class BlockTypeWrapper {
 
     public BlockCategory getBlockCategory() {
         if (this.blockCategory == null && this.blockCategoryId != null) { // only if name is available
-            this.blockCategory = Preconditions.checkNotNull(BlockCategory.REGISTRY.get(this.blockCategoryId));
+            this.blockCategory = BlockCategory.REGISTRY.get(this.blockCategoryId);
+            if (this.blockCategory == null) {
+                PlotSquared.debug("- Block category #" + this.blockCategoryId + " does not exist");
+                this.blockCategory = new NullBlockCategory(this.blockCategoryId);
+            }
         }
         return this.blockCategory;
     }
@@ -115,6 +121,21 @@ public class BlockTypeWrapper {
 
     public static BlockTypeWrapper get(final String blockCategoryId) {
         return blockCategories.computeIfAbsent(blockCategoryId, BlockTypeWrapper::new);
+    }
+
+    /**
+     * Prevents exceptions when loading/saving block categories
+     */
+    private static class NullBlockCategory extends BlockCategory {
+
+        public NullBlockCategory(String id) {
+            super(id);
+        }
+
+        @Override
+        public <B extends BlockStateHolder<B>> boolean contains(B blockStateHolder) {
+            return false;
+        }
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/types/BlockTypeWrapper.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/types/BlockTypeWrapper.java
@@ -25,12 +25,12 @@
  */
 package com.plotsquared.core.plot.flag.types;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.plotsquared.core.PlotSquared;
 import com.sk89q.worldedit.world.block.BlockCategory;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockType;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -42,12 +42,11 @@ import java.util.Map;
  * Container that class either contains a {@link BlockType}
  * or a {@link BlockCategory}
  */
-@EqualsAndHashCode
 public class BlockTypeWrapper {
 
     @Nullable @Getter private final BlockType blockType;
-    @Nullable private BlockCategory blockCategory;
     @Nullable private final String blockCategoryId;
+    @Nullable private BlockCategory blockCategory;
 
     private BlockTypeWrapper(@NotNull final BlockType blockType) {
         this.blockType = Preconditions.checkNotNull(blockType);
@@ -58,13 +57,13 @@ public class BlockTypeWrapper {
     private BlockTypeWrapper(@NotNull final BlockCategory blockCategory) {
         this.blockType = null;
         this.blockCategory = Preconditions.checkNotNull(blockCategory);
-        this.blockCategoryId = null;
+        this.blockCategoryId = blockCategory.getId(); // used in toString()/equals()/hashCode()
     }
 
     private BlockTypeWrapper(@NotNull final String blockCategoryId) {
         this.blockType = null;
-        this.blockCategoryId = Preconditions.checkNotNull(blockCategoryId);
         this.blockCategory = null;
+        this.blockCategoryId = Preconditions.checkNotNull(blockCategoryId);
     }
 
     @Override public String toString() {
@@ -75,8 +74,8 @@ public class BlockTypeWrapper {
             } else {
                 return key;
             }
-        } else if (this.getBlockCategory() != null) { // calling the method will initialize it lazily
-            final String key = this.getBlockCategory().toString();
+        } else if (this.blockCategoryId != null) {
+            final String key = this.blockCategoryId;
             if (key.startsWith("minecraft:")) {
                 return '#' + key.substring(10);
             } else {
@@ -97,15 +96,43 @@ public class BlockTypeWrapper {
         }
     }
 
+    /**
+     * Returns the block category associated with this wrapper.
+     * <br/>
+     * Invocation will try to lazily initialize the block category if it's not
+     * set yet but the category id is present. If {@link BlockCategory#REGISTRY} is already populated
+     * but does not contain a category with the given name, a BLockCategory containing no items
+     * is returned.
+     * If this wrapper does not wrap a BlockCategory, null is returned.
+     * <br/>
+     * <b>If {@link BlockCategory#REGISTRY} isn't populated yet, null is returned.</b>
+     *
+     * @return the block category represented by this wrapper.
+     */
+    @Nullable
     public BlockCategory getBlockCategory() {
         if (this.blockCategory == null && this.blockCategoryId != null) { // only if name is available
             this.blockCategory = BlockCategory.REGISTRY.get(this.blockCategoryId);
-            if (this.blockCategory == null) {
+            if (this.blockCategory == null && !BlockCategory.REGISTRY.values().isEmpty()) {
                 PlotSquared.debug("- Block category #" + this.blockCategoryId + " does not exist");
                 this.blockCategory = new NullBlockCategory(this.blockCategoryId);
             }
         }
         return this.blockCategory;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BlockTypeWrapper that = (BlockTypeWrapper) o;
+        return Objects.equal(this.blockType, that.blockType) &&
+                Objects.equal(this.blockCategoryId, that.blockCategoryId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.blockType, this.blockCategoryId);
     }
 
     private static final Map<BlockType, BlockTypeWrapper> blockTypes = new HashMap<>();

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/types/BlockTypeWrapper.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/types/BlockTypeWrapper.java
@@ -61,9 +61,9 @@ public class BlockTypeWrapper {
         this.blockCategoryId = null;
     }
 
-    public BlockTypeWrapper(@Nullable String blockCategoryId) {
+    private BlockTypeWrapper(@NotNull final String blockCategoryId) {
         this.blockType = null;
-        this.blockCategoryId = blockCategoryId;
+        this.blockCategoryId = Preconditions.checkNotNull(blockCategoryId);
         this.blockCategory = null;
     }
 

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/types/BlockTypeWrapper.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/types/BlockTypeWrapper.java
@@ -101,7 +101,7 @@ public class BlockTypeWrapper {
      * <br/>
      * Invocation will try to lazily initialize the block category if it's not
      * set yet but the category id is present. If {@link BlockCategory#REGISTRY} is already populated
-     * but does not contain a category with the given name, a BLockCategory containing no items
+     * but does not contain a category with the given name, a BlockCategory containing no items
      * is returned.
      * If this wrapper does not wrap a BlockCategory, null is returned.
      * <br/>


### PR DESCRIPTION
This PR fixes block categories being loaded later by WE. It disables the validation process when loading the flags from the database.

Things that need to be considered:
- Currently, it simply throws an NPE if the category does not exist when initialiting lazily
- The hashCode method generated by lombok for the BlockTypeWrapper most likely fails to work correctly. Probably we set the string even if it was created using a BlockCategory and exclude the BlockCategory from the hashCode
