### PR TITLE
Override setblock setting Pattern in ChunkBlockQueue

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/queue/ChunkBlockQueue.java
+++ b/Core/src/main/java/com/plotsquared/core/queue/ChunkBlockQueue.java
@@ -26,6 +26,7 @@
 package com.plotsquared.core.queue;
 
 import com.plotsquared.core.location.Location;
+import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BaseBlock;
@@ -76,6 +77,11 @@ public class ChunkBlockQueue extends ScopedLocalBlockQueue {
 
     @Override public boolean setBlock(int x, int y, int z, BlockState id) {
         this.storeCache(x, y, z, id);
+        return true;
+    }
+
+    @Override public boolean setBlock(int x, int y, int z, Pattern pattern) {
+        this.storeCache(x, y, z, pattern.apply(BlockVector3.at(x, y, z)).toImmutableState());
         return true;
     }
 


### PR DESCRIPTION
- Should stop NPE during plot analysis
- Without overriding this method, DelegateLocalBlockQueue setblock Pattern is called
- DelegateLocalBlockQueue's setblocks use parent.setBlock, but we set that to null in ChunkBlockQueue
- ChunkBlockQueue is simply just to cache the values from generation to use in analysis
- Therefore there is no need to setblocks in any other Queue implementation

ChunkBlockQueue is only used in HubridUtils to cache the generated chunk.