### PR TITLE
Plot backup system

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitMain.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitMain.java
@@ -52,6 +52,9 @@ import com.plotsquared.bukkit.util.uuid.OfflineUUIDWrapper;
 import com.plotsquared.bukkit.util.uuid.SQLUUIDHandler;
 import com.plotsquared.core.IPlotMain;
 import com.plotsquared.core.PlotSquared;
+import com.plotsquared.core.backup.BackupManager;
+import com.plotsquared.core.backup.NullBackupManager;
+import com.plotsquared.core.backup.SimpleBackupManager;
 import com.plotsquared.core.configuration.Captions;
 import com.plotsquared.core.configuration.ChatFormatter;
 import com.plotsquared.core.configuration.ConfigurationNode;
@@ -136,6 +139,7 @@ import static com.plotsquared.core.util.ReflectionUtils.getRefClass;
 
 public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain {
 
+    private static final int BSTATS_ID = 1404;
     @Getter private static WorldEdit worldEdit;
 
     static {
@@ -151,7 +155,7 @@ public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain 
     private Method methodUnloadChunk0;
     private boolean methodUnloadSetup = false;
     private boolean metricsStarted;
-    private static final int BSTATS_ID = 1404;
+    @Getter private BackupManager backupManager;
 
     @Override public int[] getServerVersion() {
         if (this.version == null) {
@@ -228,6 +232,15 @@ public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain 
             } catch (Exception e) {
                 e.printStackTrace();
             }
+        }
+
+        try {
+            this.backupManager = new SimpleBackupManager();
+        } catch (final Exception e) {
+            PlotSquared.log(Captions.PREFIX + "&6Failed to initialize backup manager");
+            e.printStackTrace();
+            PlotSquared.log(Captions.PREFIX + "&6Backup features will be disabled");
+            this.backupManager = new NullBackupManager();
         }
     }
 
@@ -886,4 +899,5 @@ public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain 
             ((WorldEditPlugin) Bukkit.getPluginManager().getPlugin("WorldEdit"));
         return wePlugin.wrapCommandSender(console);
     }
+
 }

--- a/Core/src/main/java/com/plotsquared/core/IPlotMain.java
+++ b/Core/src/main/java/com/plotsquared/core/IPlotMain.java
@@ -25,6 +25,7 @@
  */
 package com.plotsquared.core;
 
+import com.plotsquared.core.backup.BackupManager;
 import com.plotsquared.core.generator.GeneratorWrapper;
 import com.plotsquared.core.generator.HybridUtils;
 import com.plotsquared.core.generator.IndependentPlotGenerator;
@@ -262,4 +263,12 @@ public interface IPlotMain extends ILogger {
     List<Map.Entry<Map.Entry<String, String>, Boolean>> getPluginIds();
 
     Actor getConsole();
+
+    /**
+     * Get the backup manager instance
+     *
+     * @return Backup manager
+     */
+    BackupManager getBackupManager();
+
 }

--- a/Core/src/main/java/com/plotsquared/core/backup/Backup.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/Backup.java
@@ -1,0 +1,43 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.backup;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+import java.nio.file.Path;
+
+/**
+ * Object representing a plot backup. This does not actually contain the
+ * backup itself, it is just a pointer to an available backup
+ */
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE) public class Backup {
+
+    private final BackupProfile owner;
+    private final long creationTime;
+    private final Path file;
+
+}

--- a/Core/src/main/java/com/plotsquared/core/backup/Backup.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/Backup.java
@@ -26,18 +26,35 @@
 package com.plotsquared.core.backup;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.Nullable;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
  * Object representing a plot backup. This does not actually contain the
  * backup itself, it is just a pointer to an available backup
  */
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE) public class Backup {
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE) @Getter public class Backup {
 
     private final BackupProfile owner;
     private final long creationTime;
-    private final Path file;
+    @Nullable private final Path file;
+
+    /**
+     * Delete the backup
+     */
+    public void delete() {
+        if (file != null) {
+            try {
+                Files.deleteIfExists(file);
+            } catch (final IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/backup/BackupManager.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/BackupManager.java
@@ -34,7 +34,7 @@ import java.util.concurrent.CompletableFuture;
 public interface BackupManager {
 
     /**
-     * Get  the backup profile for a plot based on its
+     * Get the backup profile for a plot based on its
      * current owner (if there is one)
      *
      * @param plot Plot to get the backup profile for

--- a/Core/src/main/java/com/plotsquared/core/backup/BackupManager.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/BackupManager.java
@@ -43,8 +43,9 @@ public interface BackupManager {
     @NotNull BackupProfile getProfile(@NotNull final Plot plot);
 
     /**
-     * This will perform an automatic backup of the plot iff the plot has an owner
-     * and automatic backups are enabled. Otherwise it will complete immediately.
+     * This will perform an automatic backup of the plot iff the plot has an owner,
+     * automatic backups are enabled and the plot is not merged.
+     * Otherwise it will complete immediately.
      *
      * @param plot Plot to perform the automatic backup on
      * @return Future that completes when the backup is finished

--- a/Core/src/main/java/com/plotsquared/core/backup/BackupManager.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/BackupManager.java
@@ -25,13 +25,29 @@
  */
 package com.plotsquared.core.backup;
 
+import com.plotsquared.core.PlotSquared;
+import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
-import java.util.concurrent.CompletableFuture;
+import java.util.Objects;
 
 public interface BackupManager {
+
+    /**
+     * This will perform an automatic backup of the plot iff the plot has an owner,
+     * automatic backups are enabled and the plot is not merged.
+     * Otherwise it will complete immediately.
+     *
+     * @param player   Player that triggered the backup
+     * @param plot     Plot to perform the automatic backup on
+     * @param whenDone Action that runs when the automatic backup has been completed
+     */
+    static void backup(@Nullable PlotPlayer player, @NotNull final Plot plot, @NotNull Runnable whenDone) {
+        Objects.requireNonNull(PlotSquared.imp()).getBackupManager().automaticBackup(player, plot, whenDone);
+    }
 
     /**
      * Get the backup profile for a plot based on its
@@ -47,10 +63,11 @@ public interface BackupManager {
      * automatic backups are enabled and the plot is not merged.
      * Otherwise it will complete immediately.
      *
-     * @param plot Plot to perform the automatic backup on
-     * @return Future that completes when the backup is finished
+     * @param player   Player that triggered the backup
+     * @param plot     Plot to perform the automatic backup on
+     * @param whenDone Action that runs when the automatic backup has been completed
      */
-    @NotNull CompletableFuture<?> automaticBackup(@NotNull final Plot plot);
+    void automaticBackup(@Nullable PlotPlayer player, @NotNull final Plot plot, @NotNull Runnable whenDone);
 
     /**
      * Get the directory in which backups are stored

--- a/Core/src/main/java/com/plotsquared/core/backup/BackupManager.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/BackupManager.java
@@ -1,0 +1,61 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.backup;
+
+import com.plotsquared.core.PlotSquared;
+import com.plotsquared.core.plot.Plot;
+import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class BackupManager {
+
+    @Getter private final Path backupPath;
+
+    public BackupManager() throws Exception {
+        this.backupPath = PlotSquared.imp().getDirectory().toPath().resolve("backups");
+        if (!Files.exists(backupPath)) {
+            Files.createDirectory(backupPath);
+        }
+    }
+
+    /**
+     * Get  the backup profile for a plot based on its
+     * current owner (if there is one)
+     *
+     * @param plot Plot to get the backup profile for
+     * @return Backup profile
+     */
+    @NotNull public BackupProfile getProfile(@NotNull final Plot plot) {
+        if (plot.hasOwner()) {
+            return new PlayerBackupProfile(plot.getOwnerAbs(), plot, this);
+        }
+        return new NullBackupProfile();
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/backup/BackupProfile.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/BackupProfile.java
@@ -64,7 +64,8 @@ public interface BackupProfile {
     /**
      * Restore a backup
      *
-     * @return Backup to restore
+     * @param backup Backup to restore
+     * @return Future that completes when the backup has finished
      */
     @NotNull CompletableFuture<Void> restoreBackup(@NotNull final Backup backup);
 

--- a/Core/src/main/java/com/plotsquared/core/backup/BackupProfile.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/BackupProfile.java
@@ -1,0 +1,57 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.backup;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public interface BackupProfile {
+
+    /**
+     * Asynchronously populate a list of available backups under this profile
+     *
+     * @return Future that will be completed with available backups
+     */
+    @NotNull CompletableFuture<List<Backup>> listBackups();
+
+    /**
+     * Remove all backups stored for this profile
+     */
+    void destroy() throws IOException;
+
+    /**
+     * Get the directory containing the backups for this profile.
+     * This directory may not actually exist.
+     *
+     * @return Folder that contains the backups for this profile
+     */
+    @NotNull Path getBackupDirectory();
+
+}

--- a/Core/src/main/java/com/plotsquared/core/backup/BackupProfile.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/BackupProfile.java
@@ -62,4 +62,11 @@ public interface BackupProfile {
      */
     @NotNull CompletableFuture<Backup> createBackup();
 
+    /**
+     * Restore a backup
+     *
+     * @return Backup to restore
+     */
+    @NotNull CompletableFuture<Void> restoreBackup(@NotNull final Backup backup);
+
 }

--- a/Core/src/main/java/com/plotsquared/core/backup/BackupProfile.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/BackupProfile.java
@@ -27,7 +27,6 @@ package com.plotsquared.core.backup;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -44,7 +43,7 @@ public interface BackupProfile {
     /**
      * Remove all backups stored for this profile
      */
-    void destroy() throws IOException;
+    void destroy();
 
     /**
      * Get the directory containing the backups for this profile.

--- a/Core/src/main/java/com/plotsquared/core/backup/BackupProfile.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/BackupProfile.java
@@ -54,4 +54,12 @@ public interface BackupProfile {
      */
     @NotNull Path getBackupDirectory();
 
+    /**
+     * Create a backup of the plot. If the profile is at the
+     * maximum backup capacity, the oldest backup will be deleted.
+     *
+     * @return Future that completes with the created backup.
+     */
+    @NotNull CompletableFuture<Backup> createBackup();
+
 }

--- a/Core/src/main/java/com/plotsquared/core/backup/NullBackupManager.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/NullBackupManager.java
@@ -25,53 +25,37 @@
  */
 package com.plotsquared.core.backup;
 
+import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.plot.Plot;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
-public interface BackupManager {
+/**
+ * {@inheritDoc}
+ */
+public class NullBackupManager implements BackupManager {
 
-    /**
-     * Get  the backup profile for a plot based on its
-     * current owner (if there is one)
-     *
-     * @param plot Plot to get the backup profile for
-     * @return Backup profile
-     */
-    @NotNull BackupProfile getProfile(@NotNull final Plot plot);
+    @Override @NotNull public BackupProfile getProfile(@NotNull Plot plot) {
+        return new NullBackupProfile();
+    }
 
-    /**
-     * This will perform an automatic backup of the plot iff the plot has an owner
-     * and automatic backups are enabled. Otherwise it will complete immediately.
-     *
-     * @param plot Plot to perform the automatic backup on
-     * @return Future that completes when the backup is finished
-     */
-    @NotNull CompletableFuture<?> automaticBackup(@NotNull final Plot plot);
+    @Override @NotNull public CompletableFuture<?> automaticBackup(@NotNull Plot plot) {
+        return CompletableFuture.completedFuture(null);
+    }
 
-    /**
-     * Get the directory in which backups are stored
-     *
-     * @return Backup directory path
-     */
-    @NotNull Path getBackupPath();
+    @Override @NotNull public Path getBackupPath() {
+        return Objects.requireNonNull(PlotSquared.imp()).getDirectory().toPath();
+    }
 
-    /**
-     * Get the maximum amount of backups that may be stored for
-     * a plot-owner combo
-     *
-     * @return Backup limit
-     */
-    int getBackupLimit();
+    @Override public int getBackupLimit() {
+        return 0;
+    }
 
-    /**
-     * Returns true if (potentially) destructive actions should cause
-     * PlotSquared to create automatic plot backups
-     *
-     * @return True if automatic backups are enabled
-     */
-    boolean shouldAutomaticallyBackup();
+    @Override public boolean shouldAutomaticallyBackup() {
+        return false;
+    }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/backup/NullBackupManager.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/NullBackupManager.java
@@ -26,12 +26,13 @@
 package com.plotsquared.core.backup;
 
 import com.plotsquared.core.PlotSquared;
+import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * {@inheritDoc}
@@ -42,8 +43,9 @@ public class NullBackupManager implements BackupManager {
         return new NullBackupProfile();
     }
 
-    @Override @NotNull public CompletableFuture<?> automaticBackup(@NotNull Plot plot) {
-        return CompletableFuture.completedFuture(null);
+    @Override public void automaticBackup(@Nullable PlotPlayer plotPlayer,
+        @NotNull Plot plot, @NotNull Runnable whenDone) {
+        whenDone.run();
     }
 
     @Override @NotNull public Path getBackupPath() {

--- a/Core/src/main/java/com/plotsquared/core/backup/NullBackupProfile.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/NullBackupProfile.java
@@ -54,4 +54,8 @@ public class NullBackupProfile implements BackupProfile {
         throw new UnsupportedOperationException("Cannot create backup of an unowned plot");
     }
 
+    @Override @NotNull public CompletableFuture<Void> restoreBackup(@NotNull final Backup backup) {
+        return CompletableFuture.completedFuture(null);
+    }
+
 }

--- a/Core/src/main/java/com/plotsquared/core/backup/NullBackupProfile.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/NullBackupProfile.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * Backup profile for a plot without an owner
+ * {@inheritDoc}
  */
 public class NullBackupProfile implements BackupProfile {
 
@@ -47,6 +48,10 @@ public class NullBackupProfile implements BackupProfile {
 
     @Override @NotNull public Path getBackupDirectory() {
         return new File(".").toPath();
+    }
+
+    @Override @NotNull public CompletableFuture<Backup> createBackup() {
+        throw new UnsupportedOperationException("Cannot create backup of an unowned plot");
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/backup/NullBackupProfile.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/NullBackupProfile.java
@@ -1,0 +1,52 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.backup;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Backup profile for a plot without an owner
+ */
+public class NullBackupProfile implements BackupProfile {
+
+    @Override @NotNull public CompletableFuture<List<Backup>> listBackups() {
+        return CompletableFuture.completedFuture(Collections.emptyList());
+    }
+
+    @Override public void destroy(){
+    }
+
+    @Override @NotNull public Path getBackupDirectory() {
+        return new File(".").toPath();
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/backup/PlayerBackupProfile.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/PlayerBackupProfile.java
@@ -102,10 +102,14 @@ public class PlayerBackupProfile implements BackupProfile {
         }
     }
 
-    @Override public void destroy() throws IOException {
-        Files.delete(this.getBackupDirectory());
-        // Invalidate backup cache
-        this.backupCache = null;
+    @Override public void destroy() {
+        this.listBackups().whenCompleteAsync((backups, error) -> {
+           if (error != null) {
+               error.printStackTrace();
+           }
+           backups.forEach(Backup::delete);
+           this.backupCache = null;
+        });
     }
 
     @NotNull public Path getBackupDirectory() {

--- a/Core/src/main/java/com/plotsquared/core/backup/PlayerBackupProfile.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/PlayerBackupProfile.java
@@ -95,7 +95,7 @@ public class PlayerBackupProfile implements BackupProfile {
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
-                return backups;
+                return (this.backupCache = backups);
             });
         }
     }

--- a/Core/src/main/java/com/plotsquared/core/backup/PlayerBackupProfile.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/PlayerBackupProfile.java
@@ -1,0 +1,97 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.backup;
+
+import com.plotsquared.core.plot.Plot;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A profile associated with a player (normally a plot owner) and a
+ * plot, which is used to store and retrieve plot backups
+ * {@inheritDoc}
+ */
+@RequiredArgsConstructor
+public class PlayerBackupProfile implements BackupProfile {
+
+    private final UUID owner;
+    private final Plot plot;
+    private final BackupManager backupManager;
+
+    private static boolean isValidFile(@NotNull final Path path) {
+        final String name = path.getFileName().toString();
+        return name.endsWith(".schem") || name.endsWith(".schematic");
+    }
+
+    @NotNull public CompletableFuture<List<Backup>> listBackups() {
+        return CompletableFuture.supplyAsync(() -> {
+            final Path path = this.getBackupDirectory();
+            if (!Files.exists(path)) {
+                try {
+                    Files.createDirectories(path);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    return Collections.emptyList();
+                }
+            }
+            final List<Backup> backups = new ArrayList<>();
+            try {
+                Files.walk(path).filter(PlayerBackupProfile::isValidFile).forEach(file -> {
+                    try {
+                        final BasicFileAttributes
+                            basicFileAttributes = Files.readAttributes(file, BasicFileAttributes.class);
+                        backups.add(new Backup(this, basicFileAttributes.creationTime().toMillis(), file));
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                });
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            return backups;
+        });
+    }
+
+    public void destroy() throws IOException {
+        Files.delete(this.getBackupDirectory());
+    }
+
+    @NotNull public Path getBackupDirectory() {
+        return backupManager.getBackupPath().resolve(plot.getArea().getId())
+            .resolve(plot.getId().toCommaSeparatedString()).resolve(owner.toString());
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/backup/PlayerBackupProfile.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/PlayerBackupProfile.java
@@ -40,6 +40,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -95,6 +96,7 @@ public class PlayerBackupProfile implements BackupProfile {
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
+                backups.sort(Comparator.comparingLong(Backup::getCreationTime).reversed());
                 return (this.backupCache = backups);
             });
         }

--- a/Core/src/main/java/com/plotsquared/core/backup/SimpleBackupManager.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/SimpleBackupManager.java
@@ -56,7 +56,7 @@ import java.util.concurrent.CompletableFuture;
     }
 
     @Override @NotNull public BackupProfile getProfile(@NotNull final Plot plot) {
-        if (plot.hasOwner()) {
+        if (plot.hasOwner() && !plot.isMerged()) {
             return new PlayerBackupProfile(plot.getOwnerAbs(), plot, this);
         }
         return new NullBackupProfile();

--- a/Core/src/main/java/com/plotsquared/core/backup/SimpleBackupManager.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/SimpleBackupManager.java
@@ -1,0 +1,77 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.backup;
+
+import com.plotsquared.core.PlotSquared;
+import com.plotsquared.core.configuration.Settings;
+import com.plotsquared.core.plot.Plot;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * {@inheritDoc}
+ */
+@RequiredArgsConstructor public class SimpleBackupManager implements BackupManager {
+
+    @Getter private final Path backupPath;
+    private final boolean automaticBackup;
+    @Getter private final int backupLimit;
+
+    public SimpleBackupManager() throws Exception {
+        this.backupPath = Objects.requireNonNull(PlotSquared.imp()).getDirectory().toPath().resolve("backups");
+        if (!Files.exists(backupPath)) {
+            Files.createDirectory(backupPath);
+        }
+        this.automaticBackup = Settings.Backup.AUTOMATIC_BACKUPS;
+        this.backupLimit = Settings.Backup.BACKUP_LIMIT;
+    }
+
+    @Override @NotNull public BackupProfile getProfile(@NotNull final Plot plot) {
+        if (plot.hasOwner()) {
+            return new PlayerBackupProfile(plot.getOwnerAbs(), plot, this);
+        }
+        return new NullBackupProfile();
+    }
+
+    @Override @NotNull public CompletableFuture<?> automaticBackup(@NotNull final Plot plot) {
+        final BackupProfile profile;
+        if (!this.shouldAutomaticallyBackup() || (profile = getProfile(plot)) instanceof NullBackupProfile) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return profile.createBackup();
+    }
+
+    @Override public boolean shouldAutomaticallyBackup() {
+        return this.automaticBackup;
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/backup/SimpleBackupManager.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/SimpleBackupManager.java
@@ -118,13 +118,13 @@ import java.util.concurrent.TimeUnit;
                 return false;
             }
             final PlotCacheKey that = (PlotCacheKey) o;
-            return com.google.common.base.Objects.equal(plot.getArea(), that.plot.getArea())
-                && com.google.common.base.Objects.equal(plot.getId(), that.plot.getId())
-                && com.google.common.base.Objects.equal(plot.getOwnerAbs(), that.plot.getOwnerAbs());
+            return Objects.equals(plot.getArea(), that.plot.getArea())
+                && Objects.equals(plot.getId(), that.plot.getId())
+                && Objects.equals(plot.getOwnerAbs(), that.plot.getOwnerAbs());
         }
 
         @Override public int hashCode() {
-            return com.google.common.base.Objects.hashCode(plot.getArea(), plot.getId(), plot.getOwnerAbs());
+            return Objects.hash(plot.getArea(), plot.getId(), plot.getOwnerAbs());
         }
     }
 

--- a/Core/src/main/java/com/plotsquared/core/command/Backup.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Backup.java
@@ -27,10 +27,12 @@ package com.plotsquared.core.command;
 
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.backup.BackupProfile;
+import com.plotsquared.core.backup.NullBackupProfile;
 import com.plotsquared.core.backup.PlayerBackupProfile;
 import com.plotsquared.core.configuration.Captions;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
+import com.plotsquared.core.util.Permissions;
 import com.plotsquared.core.util.task.RunnableVal2;
 import com.plotsquared.core.util.task.RunnableVal3;
 
@@ -109,6 +111,29 @@ public final class Backup extends Command {
     public void save(final Command command, final PlotPlayer player, final String[] args,
         final RunnableVal3<Command, Runnable, Runnable> confirm,
         final RunnableVal2<Command, CommandResult> whenDone) {
+        final Plot plot = player.getCurrentPlot();
+        if (plot == null) {
+            sendMessage(player, Captions.NOT_IN_PLOT);
+        } else if (!plot.hasOwner()) {
+            sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "unowned");
+        } else if (plot.isMerged()) {
+            sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "merged");
+        } else if (!plot.isOwner(player.getUUID()) && !Permissions.hasPermission(player, Captions.PERMISSION_ADMIN_BACKUP_OTHER)) {
+            sendMessage(player, Captions.NO_PERMISSION, Captions.PERMISSION_ADMIN_BACKUP_OTHER);
+        } else {
+            final BackupProfile backupProfile = Objects.requireNonNull(PlotSquared.imp()).getBackupManager().getProfile(plot);
+            if (backupProfile instanceof NullBackupProfile) {
+                sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "other");
+            } else {
+                backupProfile.createBackup().whenComplete((backup, throwable) -> {
+                    if (throwable != null) {
+                        sendMessage(player, Captions.BACKUP_FAILED, throwable.getMessage());
+                    } else {
+                        sendMessage(player, Captions.BACKUP_SAVED);
+                    }
+                });
+            }
+        }
     }
 
     @CommandDeclaration(command = "list",
@@ -120,6 +145,25 @@ public final class Backup extends Command {
     public void list(final Command command, final PlotPlayer player, final String[] args,
         final RunnableVal3<Command, Runnable, Runnable> confirm,
         final RunnableVal2<Command, CommandResult> whenDone) {
+            final Plot plot = player.getCurrentPlot();
+            if (plot == null) {
+                sendMessage(player, Captions.NOT_IN_PLOT);
+            } else if (!plot.hasOwner()) {
+                sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "unowned");
+            } else if (plot.isMerged()) {
+                sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "merged");
+            } else if (!plot.isOwner(player.getUUID()) && !Permissions.hasPermission(player, Captions.PERMISSION_ADMIN_BACKUP_OTHER)) {
+                sendMessage(player, Captions.NO_PERMISSION, Captions.PERMISSION_ADMIN_BACKUP_OTHER);
+            } else {
+                final BackupProfile backupProfile = Objects.requireNonNull(PlotSquared.imp()).getBackupManager().getProfile(plot);
+                if (backupProfile instanceof NullBackupProfile) {
+                    sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "other");
+                } else {
+                    backupProfile.listBackups().whenComplete((backups, throwable) -> {
+                        // TODO: List backups
+                    });
+                }
+            }
     }
 
     @CommandDeclaration(command = "load",
@@ -131,6 +175,34 @@ public final class Backup extends Command {
     public void load(final Command command, final PlotPlayer player, final String[] args,
         final RunnableVal3<Command, Runnable, Runnable> confirm,
         final RunnableVal2<Command, CommandResult> whenDone) {
+        final Plot plot = player.getCurrentPlot();
+        if (plot == null) {
+            sendMessage(player, Captions.NOT_IN_PLOT);
+        } else if (!plot.hasOwner()) {
+            sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "unowned");
+        } else if (plot.isMerged()) {
+            sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "merged");
+        } else if (!plot.isOwner(player.getUUID()) && !Permissions.hasPermission(player, Captions.PERMISSION_ADMIN_BACKUP_OTHER)) {
+            sendMessage(player, Captions.NO_PERMISSION, Captions.PERMISSION_ADMIN_BACKUP_OTHER);
+        } else if (args.length == 0) {
+            sendMessage(player, Captions.BACKUP_LOAD_USAGE);
+        } else {
+            final int number;
+            try {
+                number = Integer.parseInt(args[0]);
+            } catch (final Exception e) {
+                sendMessage(player, Captions.NOT_A_NUMBER, args[0]);
+                return;
+            }
+            final BackupProfile backupProfile = Objects.requireNonNull(PlotSquared.imp()).getBackupManager().getProfile(plot);
+            if (backupProfile instanceof NullBackupProfile) {
+                sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "other");
+            } else {
+                backupProfile.listBackups().whenComplete((backups, throwable) -> {
+                    // TODO: Load backups
+                });
+            }
+        }
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/command/Backup.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Backup.java
@@ -115,15 +115,15 @@ public final class Backup extends Command {
         if (plot == null) {
             sendMessage(player, Captions.NOT_IN_PLOT);
         } else if (!plot.hasOwner()) {
-            sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "unowned");
+            sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_UNOWNED);
         } else if (plot.isMerged()) {
-            sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "merged");
+            sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_MERGED.getTranslated());
         } else if (!plot.isOwner(player.getUUID()) && !Permissions.hasPermission(player, Captions.PERMISSION_ADMIN_BACKUP_OTHER)) {
             sendMessage(player, Captions.NO_PERMISSION, Captions.PERMISSION_ADMIN_BACKUP_OTHER);
         } else {
             final BackupProfile backupProfile = Objects.requireNonNull(PlotSquared.imp()).getBackupManager().getProfile(plot);
             if (backupProfile instanceof NullBackupProfile) {
-                sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "other");
+                sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_OTHER.getTranslated());
             } else {
                 backupProfile.createBackup().whenComplete((backup, throwable) -> {
                     if (throwable != null) {
@@ -149,15 +149,15 @@ public final class Backup extends Command {
             if (plot == null) {
                 sendMessage(player, Captions.NOT_IN_PLOT);
             } else if (!plot.hasOwner()) {
-                sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "unowned");
+                sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_UNOWNED);
             } else if (plot.isMerged()) {
-                sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "merged");
+                sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_MERGED.getTranslated());
             } else if (!plot.isOwner(player.getUUID()) && !Permissions.hasPermission(player, Captions.PERMISSION_ADMIN_BACKUP_OTHER)) {
                 sendMessage(player, Captions.NO_PERMISSION, Captions.PERMISSION_ADMIN_BACKUP_OTHER);
             } else {
                 final BackupProfile backupProfile = Objects.requireNonNull(PlotSquared.imp()).getBackupManager().getProfile(plot);
                 if (backupProfile instanceof NullBackupProfile) {
-                    sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "other");
+                    sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_OTHER.getTranslated());
                 } else {
                     backupProfile.listBackups().whenComplete((backups, throwable) -> {
                         // TODO: List backups
@@ -179,8 +179,9 @@ public final class Backup extends Command {
         if (plot == null) {
             sendMessage(player, Captions.NOT_IN_PLOT);
         } else if (!plot.hasOwner()) {
-            sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "unowned");
+            sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_UNOWNED);
         } else if (plot.isMerged()) {
+            sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_MERGED.getTranslated());
             sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "merged");
         } else if (!plot.isOwner(player.getUUID()) && !Permissions.hasPermission(player, Captions.PERMISSION_ADMIN_BACKUP_OTHER)) {
             sendMessage(player, Captions.NO_PERMISSION, Captions.PERMISSION_ADMIN_BACKUP_OTHER);
@@ -196,7 +197,7 @@ public final class Backup extends Command {
             }
             final BackupProfile backupProfile = Objects.requireNonNull(PlotSquared.imp()).getBackupManager().getProfile(plot);
             if (backupProfile instanceof NullBackupProfile) {
-                sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "other");
+                sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_OTHER.getTranslated());
             } else {
                 backupProfile.listBackups().whenComplete((backups, throwable) -> {
                     // TODO: Load backups

--- a/Core/src/main/java/com/plotsquared/core/command/Backup.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Backup.java
@@ -1,0 +1,136 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.command;
+
+import com.plotsquared.core.PlotSquared;
+import com.plotsquared.core.backup.BackupProfile;
+import com.plotsquared.core.backup.PlayerBackupProfile;
+import com.plotsquared.core.configuration.Captions;
+import com.plotsquared.core.player.PlotPlayer;
+import com.plotsquared.core.plot.Plot;
+import com.plotsquared.core.util.task.RunnableVal2;
+import com.plotsquared.core.util.task.RunnableVal3;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+@CommandDeclaration(command = "backup",
+usage = "/plot backup <save|list|load>",
+description = "Manage plot backups",
+category = CommandCategory.SETTINGS,
+requiredType = RequiredType.PLAYER,
+permission = "plots.backup")
+public final class Backup extends Command {
+
+    public Backup() {
+        super(MainCommand.getInstance(), true);
+    }
+
+    private static boolean sendMessage(PlotPlayer player, Captions message, Object... args) {
+        message.send(player, args);
+        return true;
+    }
+
+    @Override public CompletableFuture<Boolean> execute(PlotPlayer player, String[] args,
+        RunnableVal3<Command, Runnable, Runnable> confirm,
+        RunnableVal2<Command, CommandResult> whenDone) throws CommandException {
+        if (args.length == 0 || !Arrays.asList("save", "list", "load")
+            .contains(args[0].toLowerCase(Locale.ENGLISH))) {
+            return CompletableFuture.completedFuture(sendMessage(player, Captions.BACKUP_USAGE));
+        }
+        return super.execute(player, args, confirm, whenDone);
+    }
+
+    @Override public Collection<Command> tab(PlotPlayer player, String[] args, boolean space) {
+        if (args.length == 1) {
+            return Stream.of("save", "list", "save")
+                          .filter(value -> value.startsWith(args[0].toLowerCase(Locale.ENGLISH)))
+                          .map(value -> new Command(null, false, value, "", RequiredType.NONE, null) {})
+                          .collect(Collectors.toList());
+        } else if (args[0].equalsIgnoreCase("load") && args.length == 2) {
+
+            final Plot plot = player.getCurrentPlot();
+            if (plot != null) {
+                final BackupProfile backupProfile = Objects.requireNonNull(PlotSquared.imp()).getBackupManager().getProfile(plot);
+                if (!(backupProfile instanceof PlayerBackupProfile)) {
+                    final CompletableFuture<List<com.plotsquared.core.backup.Backup>> backupList = backupProfile.listBackups();
+                    if (backupList.isDone()) {
+                        final List<com.plotsquared.core.backup.Backup> backups = backupList.getNow(new ArrayList<>());
+                        if (backups.isEmpty()) {
+                            return new ArrayList<>();
+                        }
+                        return IntStream.range(1, 1 + backups.size()).mapToObj(i -> new Command(null, false, Integer.toString(i),
+                            "", RequiredType.NONE, null) {}).collect(Collectors.toList());
+
+                    }
+                }
+            }
+        }
+        return tabOf(player, args, space);
+    }
+
+    @CommandDeclaration(command = "save",
+    usage = "/plot backup save",
+    description = "Create a plot backup",
+    category = CommandCategory.SETTINGS,
+    requiredType = RequiredType.PLAYER,
+    permission = "plots.backup.save")
+    public void save(final Command command, final PlotPlayer player, final String[] args,
+        final RunnableVal3<Command, Runnable, Runnable> confirm,
+        final RunnableVal2<Command, CommandResult> whenDone) {
+    }
+
+    @CommandDeclaration(command = "list",
+        usage = "/plot backup list",
+        description = "List available plot backups",
+        category = CommandCategory.SETTINGS,
+        requiredType = RequiredType.PLAYER,
+        permission = "plots.backup.list")
+    public void list(final Command command, final PlotPlayer player, final String[] args,
+        final RunnableVal3<Command, Runnable, Runnable> confirm,
+        final RunnableVal2<Command, CommandResult> whenDone) {
+    }
+
+    @CommandDeclaration(command = "load",
+        usage = "/plot backup load <#>",
+        description = "Restore a plot backup",
+        category = CommandCategory.SETTINGS,
+        requiredType = RequiredType.PLAYER,
+        permission = "plots.backup.load")
+    public void load(final Command command, final PlotPlayer player, final String[] args,
+        final RunnableVal3<Command, Runnable, Runnable> confirm,
+        final RunnableVal2<Command, CommandResult> whenDone) {
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/command/Backup.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Backup.java
@@ -115,7 +115,7 @@ public final class Backup extends Command {
         if (plot == null) {
             sendMessage(player, Captions.NOT_IN_PLOT);
         } else if (!plot.hasOwner()) {
-            sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_UNOWNED);
+            sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_UNOWNED.getTranslated());
         } else if (plot.isMerged()) {
             sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_MERGED.getTranslated());
         } else if (!plot.isOwner(player.getUUID()) && !Permissions.hasPermission(player, Captions.PERMISSION_ADMIN_BACKUP_OTHER)) {
@@ -149,7 +149,7 @@ public final class Backup extends Command {
             if (plot == null) {
                 sendMessage(player, Captions.NOT_IN_PLOT);
             } else if (!plot.hasOwner()) {
-                sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_UNOWNED);
+                sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_UNOWNED.getTranslated());
             } else if (plot.isMerged()) {
                 sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_MERGED.getTranslated());
             } else if (!plot.isOwner(player.getUUID()) && !Permissions.hasPermission(player, Captions.PERMISSION_ADMIN_BACKUP_OTHER)) {
@@ -179,7 +179,7 @@ public final class Backup extends Command {
         if (plot == null) {
             sendMessage(player, Captions.NOT_IN_PLOT);
         } else if (!plot.hasOwner()) {
-            sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_UNOWNED);
+            sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_UNOWNED.getTranslated());
         } else if (plot.isMerged()) {
             sendMessage(player, Captions.BACKUP_IMPOSSIBLE, Captions.GENERIC_MERGED.getTranslated());
             sendMessage(player, Captions.BACKUP_IMPOSSIBLE, "merged");

--- a/Core/src/main/java/com/plotsquared/core/command/Backup.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Backup.java
@@ -90,7 +90,7 @@ public final class Backup extends Command {
             final Plot plot = player.getCurrentPlot();
             if (plot != null) {
                 final BackupProfile backupProfile = Objects.requireNonNull(PlotSquared.imp()).getBackupManager().getProfile(plot);
-                if (!(backupProfile instanceof PlayerBackupProfile)) {
+                if (backupProfile instanceof PlayerBackupProfile) {
                     final CompletableFuture<List<com.plotsquared.core.backup.Backup>> backupList = backupProfile.listBackups();
                     if (backupList.isDone()) {
                         final List<com.plotsquared.core.backup.Backup> backups = backupList.getNow(new ArrayList<>());

--- a/Core/src/main/java/com/plotsquared/core/command/MainCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/MainCommand.java
@@ -127,6 +127,7 @@ public class MainCommand extends Command {
             new SetHome();
             new Cluster();
             new DebugImportWorlds();
+            new Backup();
 
             if (Settings.Ratings.USE_LIKES) {
                 new Like();

--- a/Core/src/main/java/com/plotsquared/core/command/Save.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Save.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.UUID;
 
 @CommandDeclaration(command = "save",
-    aliases = {"backup"},
     description = "Save your plot",
     category = CommandCategory.SCHEMATIC,
     requiredType = RequiredType.NONE,

--- a/Core/src/main/java/com/plotsquared/core/command/Set.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Set.java
@@ -25,6 +25,7 @@
  */
 package com.plotsquared.core.command;
 
+import com.plotsquared.core.backup.BackupManager;
 import com.plotsquared.core.configuration.CaptionUtility;
 import com.plotsquared.core.configuration.Captions;
 import com.plotsquared.core.player.PlotPlayer;
@@ -91,12 +92,15 @@ public class Set extends SubCommand {
                             MainUtil.sendMessage(player, Captions.WAIT_FOR_TIMER);
                             return false;
                         }
-                        plot.addRunning();
-                        for (Plot current : plot.getConnectedPlots()) {
-                            current.setComponent(component, pattern);
-                        }
-                        MainUtil.sendMessage(player, Captions.GENERATING_COMPONENT);
-                        GlobalBlockQueue.IMP.addEmptyTask(plot::removeRunning);
+
+                        BackupManager.backup(player, plot, () -> {
+                            plot.addRunning();
+                            for (Plot current : plot.getConnectedPlots()) {
+                                current.setComponent(component, pattern);
+                            }
+                            MainUtil.sendMessage(player, Captions.GENERATING_COMPONENT);
+                            GlobalBlockQueue.IMP.addEmptyTask(plot::removeRunning);
+                        });
                         return true;
                     }
                 }

--- a/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
@@ -184,6 +184,11 @@ public enum Captions implements Caption {
     PERMISSION_ALIAS_SET("plots.alias.set", "static.permissions"),
     PERMISSION_ALIAS_REMOVE("plots.alias.remove", "static.permissions"),
     PERMISSION_ADMIN_CHAT_BYPASS("plots.admin.chat.bypass", "static.permissions"),
+    PERMISSION_BACKUP("plots.backup", "static.permissions"),
+    PERMISSION_BACKUP_SAVE("plots.backup.save", "static.permissions"),
+    PERMISSION_BACUP_LIST("plots.backup.list", "static.permissions"),
+    PERMISSION_BACKUP_LOAD("plots.backup.load", "static.permissions"),
+    PERMISSION_ADMIN_BACKUP_OTHER("plots.admin.backup.other", "static.permissions"),
     //</editor-fold>
     //<editor-fold desc="Static Console">
     CONSOLE_JAVA_OUTDATED(
@@ -759,6 +764,10 @@ public enum Captions implements Caption {
 
     //<editor-fold desc="Backups">
     BACKUP_USAGE("$1Usage: $2/plot backup save/list/load", "Backups"),
+    BACKUP_IMPOSSIBLE("$2Backups are not enabled for this plot: %s", "Backups"),
+    BACKUP_SAVED("$1The backup was created successfully", "Backups"),
+    BACKUP_FAILED("$2The backup could not be created: %s", "Backups"),
+    BACKUP_LOAD_USAGE("$1Usage: $2/plot backup load [#]", "Backups"),
     //</editor-fold>
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
@@ -186,7 +186,7 @@ public enum Captions implements Caption {
     PERMISSION_ADMIN_CHAT_BYPASS("plots.admin.chat.bypass", "static.permissions"),
     PERMISSION_BACKUP("plots.backup", "static.permissions"),
     PERMISSION_BACKUP_SAVE("plots.backup.save", "static.permissions"),
-    PERMISSION_BAKCUP_LIST("plots.backup.list", "static.permissions"),
+    PERMISSION_BACKUP_LIST("plots.backup.list", "static.permissions"),
     PERMISSION_BACKUP_LOAD("plots.backup.load", "static.permissions"),
     PERMISSION_ADMIN_BACKUP_OTHER("plots.admin.backup.other", "static.permissions"),
     //</editor-fold>

--- a/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
@@ -757,6 +757,10 @@ public enum Captions implements Caption {
         false, "Info"),
     //</editor-fold>
 
+    //<editor-fold desc="Backups">
+    BACKUP_USAGE("$1Usage: $2/plot backup save/list/load", "Backups"),
+    //</editor-fold>
+
     /**
      * Legacy Configuration Conversion
      */

--- a/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
@@ -751,6 +751,29 @@ public enum Captions implements Caption {
         false, "Info"),
     //</editor-fold>
 
+    //<editor-fold desc="Backups">
+    BACKUP_USAGE("$1Usage: $2/plot backup save/list/load", "Backups"),
+    BACKUP_IMPOSSIBLE("$2Backups are not enabled for this plot: %s", "Backups"),
+    BACKUP_SAVE_SUCCESS("$1The backup was created successfully", "Backups"),
+    BACKUP_SAVE_FAILED("$2The backup could not be created: %s", "Backups"),
+    BACKUP_LOAD_SUCCESS("$1The backup was restored successfully", "Backups"),
+    BACKUP_LOAD_FAILURE("$2The backup could not be restored: %s", "Backups"),
+    BACKUP_LOAD_USAGE("$1Usage: $2/plot backup load [#]", "Backups"),
+    BACKUP_LIST_HEADER("$1Available backups for plot $2%s", "Backups"),
+    BACKUP_LIST_ENTRY("$3- $1#%s0 $2%s1", "Backups"),
+    BACKUP_LIST_FAILED("$2Backup listing failed: %s", "Backups"),
+    BACKUP_AUTOMATIC_STARTED("$1Backing up the plot...", "Backups"),
+    BACKUP_AUTOMATIC_FINISHED("$1The automatic backup process finished successfully!", "Backups"),
+    BACKUP_AUTOMATIC_FAILURE("$2The automatic backup process failed. Your pending action has been canceled. Reason: %s", "Backups"),
+    //</editor-fold>
+
+    //<editor-fold desc="Generic">
+    GENERIC_OTHER("other", "Generic"),
+    GENERIC_MERGED("merged", "Generic"),
+    GENERIC_UNOWNED("unowned", "Generic"),
+    GENERIC_INVALID_CHOICE("invalid choice", "Generic"),
+    //</editor-fold>
+
     /**
      * Legacy Configuration Conversion
      */

--- a/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
@@ -756,6 +756,9 @@ public enum Captions implements Caption {
     BACKUP_LOAD_SUCCESS("$1The backup was restored successfully", "Backups"),
     BACKUP_LOAD_FAILURE("$2The backup could not be restored: %s", "Backups"),
     BACKUP_LOAD_USAGE("$1Usage: $2/plot backup load [#]", "Backups"),
+    BACKUP_LIST_HEADER("$1Available backups for plot $2%s", "Backups"),
+    BACKUP_LIST_ENTRY("$3- $1#%s0 $2%s1", "Backups"),
+    BACKUP_LIST_FAILED("$2Backup listing failed: %s", "Backups"),
     //</editor-fold>
 
     //<editor-fold desc="Generic">

--- a/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
@@ -765,8 +765,10 @@ public enum Captions implements Caption {
     //<editor-fold desc="Backups">
     BACKUP_USAGE("$1Usage: $2/plot backup save/list/load", "Backups"),
     BACKUP_IMPOSSIBLE("$2Backups are not enabled for this plot: %s", "Backups"),
-    BACKUP_SAVED("$1The backup was created successfully", "Backups"),
-    BACKUP_FAILED("$2The backup could not be created: %s", "Backups"),
+    BACKUP_SAVE_SUCCESS("$1The backup was created successfully", "Backups"),
+    BACKUP_SAVE_FAILED("$2The backup could not be created: %s", "Backups"),
+    BACKUP_LOAD_SUCCESS("$1The backup was restored successfully", "Backups"),
+    BACKUP_LOAD_FAILURE("$2The backup could not be restored: %s", "Backups"),
     BACKUP_LOAD_USAGE("$1Usage: $2/plot backup load [#]", "Backups"),
     //</editor-fold>
 
@@ -774,6 +776,7 @@ public enum Captions implements Caption {
     GENERIC_OTHER("other", "Generic"),
     GENERIC_MERGED("merged", "Generic"),
     GENERIC_UNOWNED("unowned", "Generic"),
+    GENERIC_INVALID_CHOICE("invalid choice", "Generic"),
     //</editor-fold>
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
@@ -770,6 +770,12 @@ public enum Captions implements Caption {
     BACKUP_LOAD_USAGE("$1Usage: $2/plot backup load [#]", "Backups"),
     //</editor-fold>
 
+    //<editor-fold desc="Generic">
+    GENERIC_OTHER("other", "Generic"),
+    GENERIC_MERGED("merged", "Generic"),
+    GENERIC_UNOWNED("unowned", "Generic"),
+    //</editor-fold>
+
     /**
      * Legacy Configuration Conversion
      */

--- a/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
@@ -186,7 +186,7 @@ public enum Captions implements Caption {
     PERMISSION_ADMIN_CHAT_BYPASS("plots.admin.chat.bypass", "static.permissions"),
     PERMISSION_BACKUP("plots.backup", "static.permissions"),
     PERMISSION_BACKUP_SAVE("plots.backup.save", "static.permissions"),
-    PERMISSION_BACUP_LIST("plots.backup.list", "static.permissions"),
+    PERMISSION_BAKCUP_LIST("plots.backup.list", "static.permissions"),
     PERMISSION_BACKUP_LOAD("plots.backup.load", "static.permissions"),
     PERMISSION_ADMIN_BACKUP_OTHER("plots.admin.backup.other", "static.permissions"),
     //</editor-fold>

--- a/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
@@ -759,6 +759,9 @@ public enum Captions implements Caption {
     BACKUP_LIST_HEADER("$1Available backups for plot $2%s", "Backups"),
     BACKUP_LIST_ENTRY("$3- $1#%s0 $2%s1", "Backups"),
     BACKUP_LIST_FAILED("$2Backup listing failed: %s", "Backups"),
+    BACKUP_AUTOMATIC_STARTED("$1Backing up the plot...", "Backups"),
+    BACKUP_AUTOMATIC_FINISHED("$1The automatic backup process finished successfully!", "Backups"),
+    BACKUP_AUTOMATIC_FAILURE("$2The automatic backup process failed. Your pending action has been canceled. Reason: %s", "Backups"),
     //</editor-fold>
 
     //<editor-fold desc="Generic">

--- a/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
@@ -413,4 +413,13 @@ public class Settings extends Config {
         @Comment("Try to guess plot owners from sign data. This may decrease server performance")
         public static boolean GUESS_PLOT_OWNER = false;
     }
+
+    @Comment("Backup related settings")
+    public static final class Backup {
+        @Comment("Automatically backup plots when destructive commands are performed")
+        public static boolean AUTOMATIC_BACKUPS = true;
+        @Comment("Maximum amount of backups associated with a plot")
+        public static int BACKUP_LIMIT = 3;
+    }
+
 }

--- a/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
@@ -420,6 +420,8 @@ public class Settings extends Config {
         public static boolean AUTOMATIC_BACKUPS = true;
         @Comment("Maximum amount of backups associated with a plot")
         public static int BACKUP_LIMIT = 3;
+        @Comment("Whether or not backups should be deleted when the plot is unclaimed")
+        public static boolean DELETE_ON_UNCLAIM = true;
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -1360,9 +1360,10 @@ public class Plot {
                 PlotListener.plotExit(pp, current);
             }
 
-            // Destroy all backups when the plot is unclaimed
-            Objects.requireNonNull(PlotSquared.imp()).getBackupManager()
-                .getProfile(current).destroy();
+            if (Settings.Backup.DELETE_ON_UNCLAIM) {
+                // Destroy all backups when the plot is unclaimed
+                Objects.requireNonNull(PlotSquared.imp()).getBackupManager().getProfile(current).destroy();
+            }
 
             getArea().removePlot(getId());
             DBFunc.delete(current);

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -93,6 +93,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -1358,6 +1359,11 @@ public class Plot {
             for (PlotPlayer pp : players) {
                 PlotListener.plotExit(pp, current);
             }
+
+            // Destroy all backups when the plot is unclaimed
+            Objects.requireNonNull(PlotSquared.imp()).getBackupManager()
+                .getProfile(current).destroy();
+
             getArea().removePlot(getId());
             DBFunc.delete(current);
             current.setOwnerAbs(null);

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotId.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotId.java
@@ -198,6 +198,9 @@ public class PlotId {
         return this.x + "," + this.y;
     }
 
+    public String toDashSeparatedString() {
+        return this.x + "-" + this.y;
+    }
 
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotId.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotId.java
@@ -202,7 +202,6 @@ public class PlotId {
         return this.x + "-" + this.y;
     }
 
-
     /**
      * The PlotId object caches the hashcode for faster mapping/fetching/sorting<br>
      * - Recalculation is required if the x/y values change


### PR DESCRIPTION
Implements: https://github.com/IntellectualSites/PlotSquaredSuggestions/issues/86
This has been suggested before, because people keep clearing their plots and then regretting (how?? why??)

This pull request will add a new command (`/plot backup save/list/load`) and also optional (enabled by default) automatic backups when performing potentially destructive commands. 

There is a configurable backup limit per plot.

New permission nodes:
- `plots.backup`: Use the `/plot backup` command
- `plots.backup.save`: Create backups of your own plot
- `plots.backup.list`: List available backups
- `plots.backup.load`: Restore from a plot backup
- `plots.admin.backup.other`: Perform backy-uppy actions in plots that you do not own.

The system also comes with a feature complete and well documented API that can be used to do... things.

Wiki Page: https://wiki.intellectualsites.com/en/plotsquared/backups

**This does not work for merged plots!**