### PR TITLE
Fix chunk processing

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
@@ -33,6 +33,7 @@ import com.destroystokyo.paper.event.entity.SlimePathfindEvent;
 import com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent;
 import com.plotsquared.bukkit.util.BukkitUtil;
 import com.plotsquared.core.PlotSquared;
+import com.plotsquared.core.configuration.Captions;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.location.Location;
 import com.plotsquared.core.player.PlotPlayer;
@@ -41,6 +42,7 @@ import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.plot.flag.implementations.DoneFlag;
 import org.bukkit.Chunk;
 import org.bukkit.block.Block;
+import org.bukkit.block.TileState;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -48,7 +50,9 @@ import org.bukkit.entity.Projectile;
 import org.bukkit.entity.Slime;
 import org.bukkit.entity.ThrownPotion;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.projectiles.ProjectileSource;
 
@@ -249,6 +253,27 @@ public class PaperListener implements Listener {
                 event.setCancelled(true);
                 event.setShouldAbortSpawn(true);
             }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST) public void onBlockPlace(BlockPlaceEvent event) {
+        if (!Settings.Paper_Components.TILE_ENTITY_CHECK) {
+            return;
+        }
+        if (!(event.getBlock().getState(false) instanceof TileState)) {
+            return;
+        }
+        final Location location = BukkitUtil.getLocation(event.getBlock().getLocation());
+        final PlotArea plotArea = location.getPlotArea();
+        if (plotArea == null) {
+            return;
+        }
+        final int tileEntityCount = event.getBlock().getChunk().getTileEntities(false).length;
+        if (tileEntityCount >= Settings.Chunk_Processor.MAX_TILES) {
+            final PlotPlayer plotPlayer = BukkitUtil.getPlayer(event.getPlayer());
+            Captions.TILE_ENTITY_CAP_REACHED.send(plotPlayer, Settings.Chunk_Processor.MAX_TILES);
+            event.setCancelled(true);
+            event.setBuild(false);
         }
     }
 

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
@@ -257,7 +257,7 @@ public class PaperListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.HIGHEST) public void onBlockPlace(BlockPlaceEvent event) {
-        if (!Settings.Paper_Components.TILE_ENTITY_CHECK) {
+        if (!Settings.Paper_Components.TILE_ENTITY_CHECK || !Settings.Enabled_Components.CHUNK_PROCESSOR) {
             return;
         }
         if (!(event.getBlock().getState(false) instanceof TileState)) {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
@@ -653,7 +653,7 @@ public class BukkitUtil extends WorldUtil {
             tileEntityTypes.addAll(BlockCategories.FLOWER_POTS.getAll());
             // Individual Types
             // Add these from strings
-            Stream.of("barrel", "beacon", "beehive", "bell", "blast_furnace",
+            Stream.of("barrel", "beacon", "beehive", "bee_nest", "bell", "blast_furnace",
                 "brewing_stand", "campfire", "chest", "ender_chest", "trapped_chest",
                 "command_block", "end_gateway", "hopper", "jigsaw", "jubekox",
                 "lectern", "note_block", "black_shulker_box", "blue_shulker_box",
@@ -661,7 +661,7 @@ public class BukkitUtil extends WorldUtil {
                 "light_blue_shulker_box", "light_gray_shulker_box", "lime_shulker_box",
                 "magenta_shulker_box", "orange_shulker_box", "pink_shulker_box",
                 "purple_shulker_box", "red_shulker_box", "shulker_box", "white_shulker_box",
-                "yellow_shulker_box", "smoker", "structure")
+                "yellow_shulker_box", "smoker", "structure_block", "structure_void")
                 .map(BlockTypes::get)
                 .filter(Objects::nonNull)
                 .forEach(tileEntityTypes::add);

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
@@ -44,7 +44,10 @@ import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.BukkitWorld;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.world.biome.BiomeType;
+import com.sk89q.worldedit.world.block.BlockCategories;
 import com.sk89q.worldedit.world.block.BlockState;
+import com.sk89q.worldedit.world.block.BlockType;
+import com.sk89q.worldedit.world.block.BlockTypes;
 import io.papermc.lib.PaperLib;
 import lombok.NonNull;
 import org.bukkit.Bukkit;
@@ -95,10 +98,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
+import java.util.stream.Stream;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class BukkitUtil extends WorldUtil {
@@ -636,6 +641,32 @@ public class BukkitUtil extends WorldUtil {
             }
         }
         return types;
+    }
+
+    private final Collection<BlockType> tileEntityTypes = new HashSet<>();
+    @Override public Collection<BlockType> getTileEntityTypes() {
+        if (this.tileEntityTypes.isEmpty()) {
+            // Categories
+            tileEntityTypes.addAll(BlockCategories.BANNERS.getAll());
+            tileEntityTypes.addAll(BlockCategories.SIGNS.getAll());
+            tileEntityTypes.addAll(BlockCategories.BEDS.getAll());
+            tileEntityTypes.addAll(BlockCategories.FLOWER_POTS.getAll());
+            // Individual Types
+            // Add these from strings
+            Stream.of("barrel", "beacon", "beehive", "bell", "blast_furnace",
+                "brewing_stand", "campfire", "chest", "ender_chest", "trapped_chest",
+                "command_block", "end_gateway", "hopper", "jigsaw", "jubekox",
+                "lectern", "note_block", "black_shulker_box", "blue_shulker_box",
+                "brown_shulker_box", "cyan_shulker_box", "gray_shulker_box", "green_shulker_box",
+                "light_blue_shulker_box", "light_gray_shulker_box", "lime_shulker_box",
+                "magenta_shulker_box", "orange_shulker_box", "pink_shulker_box",
+                "purple_shulker_box", "red_shulker_box", "shulker_box", "white_shulker_box",
+                "yellow_shulker_box", "smoker", "structure")
+                .map(BlockTypes::get)
+                .filter(Objects::nonNull)
+                .forEach(tileEntityTypes::add);
+        }
+        return this.tileEntityTypes;
     }
 
     private static void ensureLoaded(final String world, final int x, final int z,

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
@@ -42,6 +42,7 @@ import com.plotsquared.core.util.task.TaskManager;
 import com.plotsquared.core.util.uuid.UUIDHandler;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.BukkitWorld;
+import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockCategories;
@@ -667,6 +668,12 @@ public class BukkitUtil extends WorldUtil {
                 .forEach(tileEntityTypes::add);
         }
         return this.tileEntityTypes;
+    }
+
+    @Override
+    public int getTileEntityCount(String world, BlockVector2 chunk) {
+        return Bukkit.getWorld(world).getChunkAt(chunk.getBlockX(), chunk.getBlockZ())
+            .getTileEntities().length;
     }
 
     private static void ensureLoaded(final String world, final int x, final int z,

--- a/Core/src/main/java/com/plotsquared/core/command/Set.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Set.java
@@ -96,7 +96,8 @@ public class Set extends SubCommand {
 
                             if (blockType.startsWith("##")) {
                                 try {
-                                    final BlockCategory category = BlockCategory.REGISTRY.get(blockType.substring(2).toLowerCase(Locale.ENGLISH));
+                                    final BlockCategory category = BlockCategory.REGISTRY.get(blockType.substring(2)
+                                        .replaceAll("[*^|]+", "").toLowerCase(Locale.ENGLISH));
                                     if (category == null || !category.contains(BlockTypes.get(forbiddenType))) {
                                         continue;
                                     }

--- a/Core/src/main/java/com/plotsquared/core/command/Set.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Set.java
@@ -37,8 +37,10 @@ import com.plotsquared.core.util.MainUtil;
 import com.plotsquared.core.util.PatternUtil;
 import com.plotsquared.core.util.Permissions;
 import com.plotsquared.core.util.StringMan;
+import com.plotsquared.core.util.WorldUtil;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.block.BlockCategory;
+import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
 
 import java.util.ArrayList;
@@ -80,7 +82,13 @@ public class Set extends SubCommand {
                 String material =
                     StringMan.join(Arrays.copyOfRange(args, 1, args.length), ",").trim();
 
-                final List<String> forbiddenTypes = Settings.General.INVALID_BLOCKS;
+                final List<String> forbiddenTypes = new ArrayList<>(Settings.General.INVALID_BLOCKS);
+
+                if (Settings.Enabled_Components.CHUNK_PROCESSOR) {
+                    forbiddenTypes.addAll(WorldUtil.IMP.getTileEntityTypes().stream().map(
+                        BlockType::getName).collect(Collectors.toList()));
+                }
+
                 if (!Permissions.hasPermission(player, Captions.PERMISSION_ADMIN_ALLOW_UNSAFE) &&
                     !forbiddenTypes.isEmpty()) {
                     for (String forbiddenType : forbiddenTypes) {

--- a/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Captions.java
@@ -446,6 +446,7 @@ public enum Captions implements Caption {
     NOT_VALID_PLOT_WORLD("$2That is not a valid plot area (case sensitive)", "Errors"),
     NO_PLOTS("$2You don't have any plots", "Errors"),
     WAIT_FOR_TIMER("$2A set block timer is bound to either the current plot or you. Please wait for it to finish", "Errors"),
+    TILE_ENTITY_CAP_REACHED("$2The total number of tile entities in this chunk may not exceed $1%s", "Errors"),
     //</editor-fold>
     DEBUG_REPORT_CREATED("$1Uploaded a full debug to: $1%url%", "Paste"),
     PURGE_SUCCESS("$4Successfully purged %s plots", "Purge"),

--- a/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
@@ -484,6 +484,8 @@ public class Settings extends Config {
         public static boolean SPAWNER_SPAWN = true;
         @Comment("Cancel entity spawns from tick spawn rates before they happen (performance buff)")
         public static boolean CREATURE_SPAWN = true;
+        @Comment("Check the tile entity limit on block placement")
+        public static boolean TILE_ENTITY_CHECK = false;
     }
 
 

--- a/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
@@ -485,7 +485,7 @@ public class Settings extends Config {
         @Comment("Cancel entity spawns from tick spawn rates before they happen (performance buff)")
         public static boolean CREATURE_SPAWN = true;
         @Comment("Check the tile entity limit on block placement")
-        public static boolean TILE_ENTITY_CHECK = false;
+        public static boolean TILE_ENTITY_CHECK = true;
     }
 
 

--- a/Core/src/main/java/com/plotsquared/core/listener/ProcessedWEExtent.java
+++ b/Core/src/main/java/com/plotsquared/core/listener/ProcessedWEExtent.java
@@ -89,95 +89,37 @@ public class ProcessedWEExtent extends AbstractDelegateExtent {
     @Override
     public <T extends BlockStateHolder<T>> boolean setBlock(BlockVector3 location, T block)
         throws WorldEditException {
-        String id = block.getBlockType().getId();
-        switch (id) {
-            case "54":
-            case "130":
-            case "142":
-            case "27":
-            case "137":
-            case "52":
-            case "154":
-            case "84":
-            case "25":
-            case "144":
-            case "138":
-            case "176":
-            case "177":
-            case "63":
-            case "68":
-            case "323":
-            case "117":
-            case "116":
-            case "28":
-            case "66":
-            case "157":
-            case "61":
-            case "62":
-            case "140":
-            case "146":
-            case "149":
-            case "150":
-            case "158":
-            case "23":
-            case "123":
-            case "124":
-            case "29":
-            case "33":
-            case "151":
-            case "178":
-                if (this.BSblocked) {
-                    return false;
-                }
-                this.BScount++;
-                if (this.BScount > Settings.Chunk_Processor.MAX_TILES) {
-                    this.BSblocked = true;
-                    PlotSquared.debug(
-                        Captions.PREFIX + "&cDetected unsafe WorldEdit: " + location.getX() + ","
-                            + location.getZ());
-                }
-                if (WEManager
-                    .maskContains(this.mask, location.getX(), location.getY(), location.getZ())) {
-                    if (this.count++ > this.max) {
-                        if (this.parent != null) {
-                            try {
-                                Field field =
-                                    AbstractDelegateExtent.class.getDeclaredField("extent");
-                                field.setAccessible(true);
-                                field.set(this.parent, new NullExtent());
-                            } catch (Exception e) {
-                                e.printStackTrace();
-                            }
-                            this.parent = null;
-                        }
-                        return false;
-                    }
-                    return super.setBlock(location, block);
-                }
-                break;
-            default:
-                if (WEManager
-                    .maskContains(this.mask, location.getX(), location.getY(), location.getZ())) {
-                    if (this.count++ > this.max) {
-                        if (this.parent != null) {
-                            try {
-                                Field field =
-                                    AbstractDelegateExtent.class.getDeclaredField("extent");
-                                field.setAccessible(true);
-                                field.set(this.parent, new NullExtent());
-                            } catch (Exception e) {
-                                e.printStackTrace();
-                            }
-                            this.parent = null;
-                        }
-                        return false;
-                    }
-                    super.setBlock(location, block);
-                }
-                return true;
 
+        final boolean isTile = block.toBaseBlock().getNbtData() != null;
+        if (isTile) {
+            if (this.BSblocked) {
+                return false;
+            }
+            if (++this.BScount > Settings.Chunk_Processor.MAX_TILES) {
+                this.BSblocked = true;
+                PlotSquared.debug(Captions.PREFIX + "&cDetected unsafe WorldEdit: " + location.getX() + ","
+                        + location.getZ());
+            }
         }
-        return false;
+        if (WEManager.maskContains(this.mask, location.getX(), location.getY(), location.getZ())) {
+            if (this.count++ > this.max) {
+                if (this.parent != null) {
+                    try {
+                        Field field =
+                            AbstractDelegateExtent.class.getDeclaredField("extent");
+                        field.setAccessible(true);
+                        field.set(this.parent, new NullExtent());
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                    this.parent = null;
+                }
+                return false;
+            }
+            return super.setBlock(location, block);
+        }
+
+        return !isTile;
     }
 
     @Override public Entity createEntity(Location location, BaseEntity entity) {

--- a/Core/src/main/java/com/plotsquared/core/listener/ProcessedWEExtent.java
+++ b/Core/src/main/java/com/plotsquared/core/listener/ProcessedWEExtent.java
@@ -46,6 +46,8 @@ import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 
 import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 public class ProcessedWEExtent extends AbstractDelegateExtent {
@@ -53,12 +55,11 @@ public class ProcessedWEExtent extends AbstractDelegateExtent {
     private final Set<CuboidRegion> mask;
     private final String world;
     private final int max;
-    int BScount = 0;
     int Ecount = 0;
-    boolean BSblocked = false;
     boolean Eblocked = false;
     private int count;
     private Extent parent;
+    private Map<Long, Integer[]> tileEntityCount = new HashMap<>();
 
     public ProcessedWEExtent(String world, Set<CuboidRegion> mask, int max, Extent child,
         Extent parent) {
@@ -93,13 +94,15 @@ public class ProcessedWEExtent extends AbstractDelegateExtent {
 
         final boolean isTile = WorldUtil.IMP.getTileEntityTypes().contains(block.getBlockType());
         if (isTile) {
-            if (this.BSblocked) {
+            final Integer[] tileEntityCount = this.tileEntityCount.computeIfAbsent(getChunkKey(location),
+                key -> new Integer[] {WorldUtil.IMP.getTileEntityCount(world,
+                    BlockVector2.at(location.getBlockX() >> 4, location.getBlockZ() >> 4))});
+            if (tileEntityCount[0] >= Settings.Chunk_Processor.MAX_TILES) {
                 return false;
-            }
-            if (++this.BScount >= Settings.Chunk_Processor.MAX_TILES) {
-                this.BSblocked = true;
+            } else {
+                tileEntityCount[0]++;
                 PlotSquared.debug(Captions.PREFIX + "&cDetected unsafe WorldEdit: " + location.getX() + ","
-                        + location.getZ());
+                    + location.getZ());
             }
         }
         if (WEManager.maskContains(this.mask, location.getX(), location.getY(), location.getZ())) {
@@ -145,4 +148,10 @@ public class ProcessedWEExtent extends AbstractDelegateExtent {
         return WEManager.maskContains(this.mask, position.getX(), position.getZ()) && super
             .setBiome(position, biome);
     }
+
+
+    private static long getChunkKey(final BlockVector3 location) {
+        return (long) (location.getBlockX() >> 4) & 4294967295L | ((long) (location.getBlockZ() >> 4) & 4294967295L) << 32;
+    }
+
 }

--- a/Core/src/main/java/com/plotsquared/core/listener/ProcessedWEExtent.java
+++ b/Core/src/main/java/com/plotsquared/core/listener/ProcessedWEExtent.java
@@ -29,6 +29,7 @@ import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.Captions;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.util.WEManager;
+import com.plotsquared.core.util.WorldUtil;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.entity.Entity;
@@ -90,12 +91,12 @@ public class ProcessedWEExtent extends AbstractDelegateExtent {
     public <T extends BlockStateHolder<T>> boolean setBlock(BlockVector3 location, T block)
         throws WorldEditException {
 
-        final boolean isTile = block.toBaseBlock().getNbtData() != null;
+        final boolean isTile = WorldUtil.IMP.getTileEntityTypes().contains(block.getBlockType());
         if (isTile) {
             if (this.BSblocked) {
                 return false;
             }
-            if (++this.BScount > Settings.Chunk_Processor.MAX_TILES) {
+            if (++this.BScount >= Settings.Chunk_Processor.MAX_TILES) {
                 this.BSblocked = true;
                 PlotSquared.debug(Captions.PREFIX + "&cDetected unsafe WorldEdit: " + location.getX() + ","
                         + location.getZ());

--- a/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
@@ -220,4 +220,6 @@ public abstract class WorldUtil {
 
     public abstract Collection<BlockType> getTileEntityTypes();
 
+    public abstract int getTileEntityCount(String world, BlockVector2 chunk);
+
 }

--- a/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
@@ -39,6 +39,7 @@ import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockState;
+import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.entity.EntityType;
 import org.jetbrains.annotations.NotNull;
 
@@ -48,6 +49,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -215,5 +217,7 @@ public abstract class WorldUtil {
     public abstract void setFoodLevel(PlotPlayer player, int foodLevel);
 
     public abstract Set<EntityType> getTypesInCategory(final String category);
+
+    public abstract Collection<BlockType> getTileEntityTypes();
 
 }


### PR DESCRIPTION
- Make the tile entity limit apply on block placements when using paper
- Make sure the chunk processor doesn't delete all entities and tile entities if they exceed the limit
- Update the WE extent and make the tile entity limit apply per chunk rather than per edit
- Make sure `/plot set <component>` doesn't let you override the tile entity limit