### PR TITLE
Begin working on a platform specific world management system

### DIFF
--- a/Bukkit/build.gradle
+++ b/Bukkit/build.gradle
@@ -11,6 +11,7 @@ repositories {
         name = "papermc"
         url = "https://papermc.io/repo/repository/maven-public/"
     }
+    maven { url = "https://mvn.intellectualsites.com/content/repositories/snapshots" }
     mavenLocal()
 }
 
@@ -29,6 +30,7 @@ dependencies {
         exclude(module: "bukkit")
     }
     implementation("me.clip:placeholderapi:2.10.4")
+    compile("se.hyperver.hyperverse:Core:0.6.0-SNAPSHOT")
 }
 
 sourceCompatibility = 1.8

--- a/Bukkit/pom.xml
+++ b/Bukkit/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.plotsquared</groupId>
       <artifactId>PlotSquared-Core</artifactId>
-      <version>5.11.1</version>
+      <version>5.11.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -53,6 +53,12 @@
           <groupId>*</groupId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>se.hyperver.hyperverse</groupId>
+      <artifactId>Core</artifactId>
+      <version>0.6.0-SNAPSHOT</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.sk89q.worldedit</groupId>

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitMain.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitMain.java
@@ -86,6 +86,7 @@ import com.plotsquared.core.util.ConsoleColors;
 import com.plotsquared.core.util.EconHandler;
 import com.plotsquared.core.util.InventoryUtil;
 import com.plotsquared.core.util.MainUtil;
+import com.plotsquared.core.util.PlatformWorldManager;
 import com.plotsquared.core.util.PremiumVerification;
 import com.plotsquared.core.util.ReflectionUtils;
 import com.plotsquared.core.util.RegionManager;
@@ -159,6 +160,7 @@ public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain 
     private boolean methodUnloadSetup = false;
     private boolean metricsStarted;
     @Getter private BackupManager backupManager;
+    @Getter private PlatformWorldManager worldManager;
 
     @Override public int[] getServerVersion() {
         if (this.version == null) {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitMain.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitMain.java
@@ -33,6 +33,9 @@ import com.plotsquared.bukkit.listener.PaperListener;
 import com.plotsquared.bukkit.listener.PlayerEvents;
 import com.plotsquared.bukkit.listener.SingleWorldListener;
 import com.plotsquared.bukkit.listener.WorldEvents;
+import com.plotsquared.bukkit.managers.BukkitWorldManager;
+import com.plotsquared.bukkit.managers.HyperverseWorldManager;
+import com.plotsquared.bukkit.managers.MultiverseWorldManager;
 import com.plotsquared.bukkit.placeholder.PlaceholderFormatter;
 import com.plotsquared.bukkit.placeholder.Placeholders;
 import com.plotsquared.bukkit.queue.BukkitLocalQueue;
@@ -247,6 +250,17 @@ public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain 
             PlotSquared.log(Captions.PREFIX + "&6Backup features will be disabled");
             this.backupManager = new NullBackupManager();
         }
+
+        if (Bukkit.getPluginManager().getPlugin("Hyperverse") != null) {
+            this.worldManager = new HyperverseWorldManager();
+        } else if (Bukkit.getPluginManager().getPlugin("Multiverse-Core") != null) {
+            this.worldManager = new MultiverseWorldManager();
+        } else {
+            this.worldManager = new BukkitWorldManager();
+        }
+
+        PlotSquared.log(Captions.PREFIX.getTranslated() + "Using platform world manager: " +
+            this.worldManager.getName());
     }
 
     private void unload() {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/managers/BukkitWorldManager.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/managers/BukkitWorldManager.java
@@ -1,0 +1,79 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.bukkit.managers;
+
+import com.plotsquared.core.configuration.file.YamlConfiguration;
+import com.plotsquared.core.util.PlatformWorldManager;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.WorldCreator;
+import org.bukkit.WorldType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Default Bukkit world manager. It will handle world creation by
+ * registering the generator in bukkit.yml
+ */
+public class BukkitWorldManager implements PlatformWorldManager<World> {
+
+    @Override public void initialize() {
+    }
+
+    @Override @Nullable
+    public World handleWorldCreation(@NotNull String worldName, @Nullable String generator) {
+        this.setGenerator(worldName, generator);
+        final WorldCreator wc = new WorldCreator(worldName);
+        wc.environment(World.Environment.NORMAL);
+        if (generator != null) {
+            wc.generator(generator);
+            wc.type(WorldType.FLAT);
+        }
+        return Bukkit.createWorld(wc);
+    }
+
+    protected void setGenerator(@Nullable final String worldName, @Nullable final String generator) {
+        if (generator == null) {
+            return;
+        }
+        File file = new File("bukkit.yml").getAbsoluteFile();
+        YamlConfiguration yml = YamlConfiguration.loadConfiguration(file);
+        yml.set(String.format("worlds.%s.generator", worldName), generator);
+        try {
+            yml.save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override public String getName() {
+        return "bukkit";
+    }
+
+}

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/managers/HyperverseWorldManager.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/managers/HyperverseWorldManager.java
@@ -1,0 +1,66 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.bukkit.managers;
+
+import org.bukkit.World;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import se.hyperver.hyperverse.Hyperverse;
+import se.hyperver.hyperverse.world.WorldConfiguration;
+import se.hyperver.hyperverse.world.WorldConfigurationBuilder;
+import se.hyperver.hyperverse.world.WorldFeatures;
+import se.hyperver.hyperverse.world.WorldType;
+
+/**
+ * Hyperverse specific manager that creates worlds
+ * using Hyperverse's API
+ */
+public class HyperverseWorldManager extends BukkitWorldManager {
+
+    @Override @Nullable
+    public World handleWorldCreation(@NotNull String worldName, @Nullable String generator) {
+        // First let Bukkit register the world
+        this.setGenerator(worldName, generator);
+        // Create the world
+        final WorldConfigurationBuilder worldConfigurationBuilder = WorldConfiguration.builder()
+            .setName(worldName).setType(WorldType.OVER_WORLD);
+        if (generator != null) {
+            worldConfigurationBuilder.setGenerator(generator).setWorldFeatures(WorldFeatures.FLATLAND);
+        }
+        try {
+            return Hyperverse.getApi().createWorld(worldConfigurationBuilder.createWorldConfiguration())
+                .getBukkitWorld();
+        } catch (final Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    @Override public String getName() {
+        return "bukkit-hyperverse";
+    }
+
+}

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/managers/MultiverseWorldManager.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/managers/MultiverseWorldManager.java
@@ -1,0 +1,57 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.bukkit.managers;
+
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Multiverse specific manager that informs Multiverse of
+ * world creation by executing a console command
+ */
+public class MultiverseWorldManager extends BukkitWorldManager {
+
+    @Override @Nullable
+    public World handleWorldCreation(@NotNull final String worldName, @Nullable final String generator) {
+        // First let Bukkit register the world
+        this.setGenerator(worldName, generator);
+        // Then we send the console command
+        final StringBuilder commandBuilder = new StringBuilder("mv create ")
+            .append(worldName).append(" normal");
+        if (generator != null && !generator.isEmpty()) {
+            commandBuilder.append(" -g ").append(generator);
+        }
+        Bukkit.getServer().dispatchCommand(Bukkit.getServer().getConsoleSender(), commandBuilder.toString());
+        return Bukkit.getWorld(worldName);
+    }
+
+    @Override public String getName() {
+        return "bukkit-multiverse";
+    }
+
+}

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitSetupUtils.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitSetupUtils.java
@@ -29,7 +29,6 @@ import com.plotsquared.bukkit.generator.BukkitPlotGenerator;
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.ConfigurationNode;
 import com.plotsquared.core.configuration.ConfigurationSection;
-import com.plotsquared.core.configuration.file.YamlConfiguration;
 import com.plotsquared.core.generator.GeneratorWrapper;
 import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.plot.PlotAreaType;
@@ -39,14 +38,10 @@ import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.World;
-import org.bukkit.World.Environment;
-import org.bukkit.WorldCreator;
-import org.bukkit.WorldType;
 import org.bukkit.entity.Player;
 import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.plugin.Plugin;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map.Entry;
@@ -197,53 +192,21 @@ public class BukkitSetupUtils extends SetupUtils {
                 break;
             }
         }
+
         try {
             PlotSquared.get().worlds.save(PlotSquared.get().worldsFile);
         } catch (IOException e) {
             e.printStackTrace();
         }
-        Plugin plugin = Bukkit.getPluginManager().getPlugin("Multiverse-Core");
-        if (object.setupGenerator != null) {
-            if (plugin != null && plugin.isEnabled()) {
-                Bukkit.getServer().dispatchCommand(Bukkit.getServer().getConsoleSender(),
-                    "mv create " + world + " normal -g " + object.setupGenerator);
-                setGenerator(world, object.setupGenerator);
-                if (Bukkit.getWorld(world) != null) {
-                    return world;
-                }
-            }
-            WorldCreator wc = new WorldCreator(object.world);
-            wc.generator(object.setupGenerator);
-            wc.environment(Environment.NORMAL);
-            wc.type(WorldType.FLAT);
-            Bukkit.createWorld(wc);
-            setGenerator(world, object.setupGenerator);
-        } else {
-            if (plugin != null && plugin.isEnabled()) {
-                Bukkit.getServer().dispatchCommand(Bukkit.getServer().getConsoleSender(),
-                    "mv create " + world + " normal");
-                if (Bukkit.getWorld(world) != null) {
-                    return world;
-                }
-            }
-            World bw =
-                Bukkit.createWorld(new WorldCreator(object.world).environment(Environment.NORMAL));
-        }
-        return object.world;
-    }
 
-    public void setGenerator(String world, String generator) {
-        if (Bukkit.getWorlds().isEmpty() || !Bukkit.getWorlds().get(0).getName().equals(world)) {
-            return;
+        Objects.requireNonNull(PlotSquared.imp()).getWorldManager()
+            .handleWorldCreation(object.world, object.setupGenerator);
+
+        if (Bukkit.getWorld(world) != null) {
+            return world;
         }
-        File file = new File("bukkit.yml").getAbsoluteFile();
-        YamlConfiguration yml = YamlConfiguration.loadConfiguration(file);
-        yml.set("worlds." + world + ".generator", generator);
-        try {
-            yml.save(file);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+
+        return object.world;
     }
 
     @Override public String getGenerator(PlotArea plotArea) {

--- a/Core/src/main/java/com/plotsquared/core/IPlotMain.java
+++ b/Core/src/main/java/com/plotsquared/core/IPlotMain.java
@@ -35,6 +35,7 @@ import com.plotsquared.core.util.ChatManager;
 import com.plotsquared.core.util.ChunkManager;
 import com.plotsquared.core.util.EconHandler;
 import com.plotsquared.core.util.InventoryUtil;
+import com.plotsquared.core.util.PlatformWorldManager;
 import com.plotsquared.core.util.RegionManager;
 import com.plotsquared.core.util.SchematicHandler;
 import com.plotsquared.core.util.SetupUtils;
@@ -277,6 +278,13 @@ public interface IPlotMain extends ILogger {
      *
      * @return Backup manager
      */
-    BackupManager getBackupManager();
+    @NotNull BackupManager getBackupManager();
+
+    /**
+     * Get the platform specific world manager
+     *
+     * @return World manager
+     */
+    @NotNull PlatformWorldManager getWorldManager();
 
 }

--- a/Core/src/main/java/com/plotsquared/core/util/PlatformWorldManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/PlatformWorldManager.java
@@ -1,0 +1,65 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.util;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This class should be implemented by each platform to allow PlotSquared to interact
+ * with the world management solution used on the server.
+ * <p>
+ * Special support for world management plugins such as Multiverse and
+ * Hyperverse can be added by extending the platform specific class. This
+ * way PlotSquared can hook into different APIs and provide better support for that
+ * particular plugin
+ */
+public interface PlatformWorldManager<T> {
+
+    /**
+     * Initialize the platform world manager
+     */
+    void initialize();
+
+    /**
+     * Inform the manager that PlotSquared has created a new world, using
+     * a specified generator.
+     *
+     * @param worldName World name
+     * @param generator World generator
+     * @return Created world
+     */
+    @Nullable T handleWorldCreation(@NotNull final String worldName,
+        @Nullable final String generator);
+
+    /**
+     * Get the implementation name
+     *
+     * @return implementation name
+     */
+    String getName();
+
+}


### PR DESCRIPTION
This should make world management a fair bit cleaner

This has been tested with Hyperverse and Bukkit, with both normal plot worlds and augmented worlds.

A side effect is that PlotSquared will now register itself in bukkit.yml for every world that loads with a normal square plot generator on setup, as the world creation methods are loaded that way.

The idea is to then add more plugin specific features to these world managers, where needed.