### PR TITLE
Add placeholder to get the value of a plot flag

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/placeholder/Placeholders.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/placeholder/Placeholders.java
@@ -72,20 +72,20 @@ public class Placeholders extends PlaceholderExpansion {
         }
 
         if (identifier.startsWith("has_plot_")) {
-            if (identifier.split("has_plot_").length != 2)
+            identifier = identifier.substring("has_plot_".length());
+            if (identifier.isEmpty())
                 return "";
 
-            identifier = identifier.split("has_plot_")[1];
             return pl.getPlotCount(identifier) > 0 ?
                 PlaceholderAPIPlugin.booleanTrue() :
                 PlaceholderAPIPlugin.booleanFalse();
         }
 
         if (identifier.startsWith("plot_count_")) {
-            if (identifier.split("plot_count_").length != 2)
+            identifier = identifier.substring("plot_count_".length());
+            if (identifier.isEmpty())
                 return "";
 
-            identifier = identifier.split("plot_count_")[1];
             return String.valueOf(pl.getPlotCount(identifier));
         }
 
@@ -184,12 +184,11 @@ public class Placeholders extends PlaceholderExpansion {
                 break;
         }
         if (identifier.startsWith("currentplot_localflag_")) {
-            final String[] splitValues = identifier.split("currentplot_localflag_");
-            return (splitValues.length >= 2) ? getFlagValue(plot, splitValues[1], false) : "";
+            return getFlagValue(plot, identifier.substring("currentplot_localflag_".length()),
+                false);
         }
         if (identifier.startsWith("currentplot_flag_")) {
-            final String[] splitValues = identifier.split("currentplot_flag_");
-            return (splitValues.length >= 2) ? getFlagValue(plot, splitValues[1], true) : "";
+            return getFlagValue(plot, identifier.substring("currentplot_flag_".length()), true);
         }
         return "";
     }
@@ -206,10 +205,11 @@ public class Placeholders extends PlaceholderExpansion {
      * @return The value of flag serialized in string
      */
     private String getFlagValue(final Plot plot, final String flagName, final boolean inherit) {
-        final PlotFlag<?, ?> flag = GlobalFlagContainer.getInstance().getFlagFromString(flagName);
-        if (flag == null) {
+        if (flagName.isEmpty())
             return "";
-        }
+        final PlotFlag<?, ?> flag = GlobalFlagContainer.getInstance().getFlagFromString(flagName);
+        if (flag == null)
+            return "";
 
         if (inherit) {
             return plot.getFlag(flag).toString();
@@ -217,6 +217,5 @@ public class Placeholders extends PlaceholderExpansion {
             final PlotFlag<?, ?> plotFlag = plot.getFlagContainer().queryLocal(flag.getClass());
             return (plotFlag != null) ? plotFlag.getValue().toString() : "";
         }
-
     }
 }


### PR DESCRIPTION
Hello :)

## Overview
For my server, I need to get the flags value of a plot (to build a gui with DeluxeMenus).
For this purpose, I have developed the feature I need. I first add this feature in Placeholder-Expansion but you told me it is legacy, so I come here to add it in PlotSquared V5. 

**Fixes #106** ([issue](https://github.com/IntellectualSites/PlotSquaredSuggestions/issues/106))

## Description
For this purpose, this PullRequest add the following feature :
- Add a new placeholder `%plotsquared_currentplot_flag_<flagName>%` to get the value of a flag when the player is on a plot

Behavior :
- If the flag is set on the current plot, it returns the flag value serialized in string
- If the flag is not set on the current plot, it returns the default value
- If the flag doesn't exist, it returns an empty string

## Checklist
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v5/CONTRIBUTING.md)

Thank you in advance for your feedback
Best regards,
EpiCanard