### PR TITLE
Move the caching and static accessors from EconHandler to PlotMain

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitMain.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitMain.java
@@ -178,6 +178,7 @@ public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain<
     @Getter private BackupManager backupManager;
     @Getter private PlatformWorldManager<World> worldManager;
     private final BukkitPlayerManager playerManager = new BukkitPlayerManager();
+    private EconHandler econ;
 
     @Override public int[] getServerVersion() {
         if (this.version == null) {
@@ -902,8 +903,16 @@ public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain<
     }
 
     @Override public EconHandler getEconomyHandler() {
+        if (econ != null) {
+            if (econ.init() /* is inited*/) {
+                return econ;
+            } else {
+                return null;
+            }
+        }
+
         try {
-            BukkitEconHandler econ = new BukkitEconHandler();
+            econ = new BukkitEconHandler();
             if (econ.init()) {
                 return econ;
             }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitEconHandler.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitEconHandler.java
@@ -40,6 +40,7 @@ public class BukkitEconHandler extends EconHandler {
     private Economy econ;
     private Permission perms;
 
+    @Override
     public boolean init() {
         if (this.econ == null || this.perms == null) {
             setupPermissions();

--- a/Core/src/main/java/com/plotsquared/core/IPlotMain.java
+++ b/Core/src/main/java/com/plotsquared/core/IPlotMain.java
@@ -174,11 +174,11 @@ public interface IPlotMain<P> extends ILogger {
     boolean initWorldEdit();
 
     /**
-     * Gets the economy provider.
+     * Gets the economy provider, if there is one
      *
      * @return the PlotSquared economy manager
      */
-    EconHandler getEconomyHandler();
+    @Nullable EconHandler getEconomyHandler();
 
     /**
      * Gets the {@link QueueProvider} class.

--- a/Core/src/main/java/com/plotsquared/core/util/EconHandler.java
+++ b/Core/src/main/java/com/plotsquared/core/util/EconHandler.java
@@ -35,18 +35,17 @@ import org.jetbrains.annotations.Nullable;
 public abstract class EconHandler {
 
     /**
-     * @deprecated This will be made private in the future
+     * @deprecated This will be removed in the future,
+     * call {@link IPlotMain#getEconomyHandler()} instead.
      */
-    @Deprecated public static EconHandler manager;
+    @Deprecated @Nullable public static EconHandler manager;
 
     /**
-     * Initialize the economy handler using
-     * {@link IPlotMain#getEconomyHandler()}
+     * Initialize the economy handler using {@link IPlotMain#getEconomyHandler()}
+     * @deprecated Call {@link #init} instead or use {@link IPlotMain#getEconomyHandler()}
+     * which does this already.
      */
-    public static void initializeEconHandler() {
-        if (manager != null) {
-            return;
-        }
+    @Deprecated public static void initializeEconHandler() {
         manager = PlotSquared.get().IMP.getEconomyHandler();
     }
 
@@ -54,10 +53,14 @@ public abstract class EconHandler {
      * Return the econ handler instance, if one exists
      *
      * @return Economy handler instance
+     * @deprecated Call {@link IPlotMain#getEconomyHandler()} instead
      */
-    @Nullable public static EconHandler getEconHandler() {
+    @Deprecated @Nullable public static EconHandler getEconHandler() {
+        manager = PlotSquared.get().IMP.getEconomyHandler();
         return manager;
     }
+
+    public abstract boolean init();
 
     public double getMoney(PlotPlayer<?> player) {
         if (player instanceof ConsolePlayer) {


### PR DESCRIPTION
## Overview
As discussed on Discord, I've moved the EconHandler creation into PlotMain as previously calling PlotMain#getEconomyHandler would've created a new instance of the econhandler which doesn't always correspond with EconHandler#getEconHandler's instance.

In any way the interface should't manage the static lifetime when we have a Main Class.
Note that I had to deprecate some stuff which should be removed in the future.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [ ] I tested my changes and approved their functionality
- [ ] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v5/CONTRIBUTING.md)

I didn't really test the changes, but it _should_ work and I was able to compile it sucessfully.

Edit: Actually one could also change all the other files to call into Main instead of EconHandler, but I guess for the sake of simplicity, that'd be another PR (maybe together with the NullEconHandler)