### PR TITLE
Separate the Vault Permission Handling from the Economy Handling

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitMain.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitMain.java
@@ -45,6 +45,7 @@ import com.plotsquared.bukkit.util.BukkitChatManager;
 import com.plotsquared.bukkit.util.BukkitChunkManager;
 import com.plotsquared.bukkit.util.BukkitEconHandler;
 import com.plotsquared.bukkit.util.BukkitInventoryUtil;
+import com.plotsquared.bukkit.util.BukkitPermHandler;
 import com.plotsquared.bukkit.util.BukkitRegionManager;
 import com.plotsquared.bukkit.util.BukkitSetupUtils;
 import com.plotsquared.bukkit.util.BukkitTaskManager;
@@ -94,6 +95,7 @@ import com.plotsquared.core.util.ConsoleColors;
 import com.plotsquared.core.util.EconHandler;
 import com.plotsquared.core.util.InventoryUtil;
 import com.plotsquared.core.util.MainUtil;
+import com.plotsquared.core.util.PermHandler;
 import com.plotsquared.core.util.PlatformWorldManager;
 import com.plotsquared.core.util.PlayerManager;
 import com.plotsquared.core.util.PremiumVerification;
@@ -179,6 +181,7 @@ public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain<
     @Getter private PlatformWorldManager<World> worldManager;
     private final BukkitPlayerManager playerManager = new BukkitPlayerManager();
     private EconHandler econ;
+    private PermHandler perm;
 
     @Override public int[] getServerVersion() {
         if (this.version == null) {
@@ -904,7 +907,7 @@ public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain<
 
     @Override public EconHandler getEconomyHandler() {
         if (econ != null) {
-            if (econ.init() /* is inited*/) {
+            if (econ.init() /* is inited */) {
                 return econ;
             } else {
                 return null;
@@ -918,6 +921,26 @@ public final class BukkitMain extends JavaPlugin implements Listener, IPlotMain<
             }
         } catch (Throwable ignored) {
             PlotSquared.debug("No economy detected!");
+        }
+        return null;
+    }
+
+    @Override public PermHandler getPermissionHandler() {
+        if (perm != null) {
+            if (perm.init() /* is inited */) {
+                return perm;
+            } else {
+                return null;
+            }
+        }
+
+        try {
+            perm = new BukkitPermHandler();
+            if (perm.init()) {
+                return perm;
+            }
+        } catch (Throwable ignored) {
+            PlotSquared.debug("No permissions detected!");
         }
         return null;
     }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitEconHandler.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitEconHandler.java
@@ -27,34 +27,25 @@ package com.plotsquared.bukkit.util;
 
 import com.plotsquared.bukkit.player.BukkitOfflinePlayer;
 import com.plotsquared.bukkit.player.BukkitPlayer;
+import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.player.OfflinePlotPlayer;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.util.EconHandler;
+import com.plotsquared.core.util.PermHandler;
 import net.milkbowl.vault.economy.Economy;
-import net.milkbowl.vault.permission.Permission;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.RegisteredServiceProvider;
 
 public class BukkitEconHandler extends EconHandler {
 
     private Economy econ;
-    private Permission perms;
 
     @Override
     public boolean init() {
-        if (this.econ == null || this.perms == null) {
-            setupPermissions();
+        if (this.econ == null) {
             setupEconomy();
         }
-        return this.econ != null && this.perms != null;
-    }
-
-    private void setupPermissions() {
-        RegisteredServiceProvider<Permission> permissionProvider =
-            Bukkit.getServer().getServicesManager().getRegistration(Permission.class);
-        if (permissionProvider != null) {
-            this.perms = permissionProvider.getProvider();
-        }
+        return this.econ != null;
     }
 
     private void setupEconomy() {
@@ -88,20 +79,19 @@ public class BukkitEconHandler extends EconHandler {
         this.econ.depositPlayer(((BukkitOfflinePlayer) player).player, amount);
     }
 
-    @Override public boolean hasPermission(String world, String player, String perm) {
-        return this.perms.playerHas(world, Bukkit.getOfflinePlayer(player), perm);
+    /**
+     * @deprecated Use {@link PermHandler#hasPermission(String, String, String)} instead
+     */
+    @Deprecated @Override public boolean hasPermission(String world, String player, String perm) {
+        if (PlotSquared.imp().getPermissionHandler() != null) {
+            return PlotSquared.imp().getPermissionHandler().hasPermission(world, player, perm);
+        } else {
+            return false;
+        }
     }
 
     @Override public double getBalance(PlotPlayer<?> player) {
         return this.econ.getBalance(player.getName());
-    }
-
-    @Deprecated public void setPermission(String world, String player, String perm, boolean value) {
-        if (value) {
-            this.perms.playerAdd(world, player, perm);
-        } else {
-            this.perms.playerRemove(world, player, perm);
-        }
     }
 
 }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitPermHandler.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitPermHandler.java
@@ -1,0 +1,59 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.bukkit.util;
+
+import com.plotsquared.core.util.PermHandler;
+import net.milkbowl.vault.permission.Permission;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+public class BukkitPermHandler extends PermHandler {
+
+    private Permission perms;
+
+    @Override
+    public boolean init() {
+        if (this.perms == null) {
+            setupPermissions();
+        }
+        return this.perms != null;
+    }
+
+    private void setupPermissions() {
+        if (Bukkit.getServer().getPluginManager().getPlugin("Vault") == null) {
+            return;
+        }
+        RegisteredServiceProvider<Permission> permissionProvider =
+            Bukkit.getServer().getServicesManager().getRegistration(Permission.class);
+        if (permissionProvider != null) {
+            this.perms = permissionProvider.getProvider();
+        }
+    }
+
+    @Override public boolean hasPermission(String world, String player, String perm) {
+        return this.perms.playerHas(world, Bukkit.getOfflinePlayer(player), perm);
+    }
+}

--- a/Core/src/main/java/com/plotsquared/core/IPlotMain.java
+++ b/Core/src/main/java/com/plotsquared/core/IPlotMain.java
@@ -35,6 +35,7 @@ import com.plotsquared.core.util.ChatManager;
 import com.plotsquared.core.util.ChunkManager;
 import com.plotsquared.core.util.EconHandler;
 import com.plotsquared.core.util.InventoryUtil;
+import com.plotsquared.core.util.PermHandler;
 import com.plotsquared.core.util.PlatformWorldManager;
 import com.plotsquared.core.util.PlayerManager;
 import com.plotsquared.core.util.RegionManager;
@@ -179,6 +180,13 @@ public interface IPlotMain<P> extends ILogger {
      * @return the PlotSquared economy manager
      */
     @Nullable EconHandler getEconomyHandler();
+
+    /**
+     * Gets the permission provider, if there is one
+     *
+     * @return the PlotSquared permission manager
+     */
+    @Nullable PermHandler getPermissionHandler();
 
     /**
      * Gets the {@link QueueProvider} class.

--- a/Core/src/main/java/com/plotsquared/core/util/EconHandler.java
+++ b/Core/src/main/java/com/plotsquared/core/util/EconHandler.java
@@ -77,9 +77,15 @@ public abstract class EconHandler {
 
     public abstract void depositMoney(OfflinePlotPlayer player, double amount);
 
-    public abstract boolean hasPermission(String world, String player, String perm);
+    /**
+     * @deprecated Use {@link PermHandler#hasPermission(String, String, String)} instead
+     */
+    @Deprecated public abstract boolean hasPermission(String world, String player, String perm);
 
-    public boolean hasPermission(String player, String perm) {
+    /**
+     * @deprecated Use {@link PermHandler#hasPermission(String, String)} instead
+     */
+    @Deprecated public boolean hasPermission(String player, String perm) {
         return hasPermission(null, player, perm);
     }
 }

--- a/Core/src/main/java/com/plotsquared/core/util/PermHandler.java
+++ b/Core/src/main/java/com/plotsquared/core/util/PermHandler.java
@@ -1,0 +1,37 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.util;
+
+public abstract class PermHandler {
+
+    public abstract boolean init();
+
+    public abstract boolean hasPermission(String world, String player, String perm);
+
+    public boolean hasPermission(String player, String perm) {
+        return hasPermission(null, player, perm);
+    }
+}


### PR DESCRIPTION
## Overview
First: This is based on #2860, if that poses technical issues, just tell me and I'll rebase it once that is merged.
**Fixes PS-49**

## Description
As opposed to suggested on Discord, I could not move (Bukkit-specific) Permission Handling into Permission.java, which belongs to Core.
If the Auto-Import-Optimization is undesired, just tell me and I'll fix that.
I've taken the freedom to remove the already deprecated setPermissions as it was Bukkit only as well.


## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [ ] I tested my changes and approved their functionality
- [ ] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v5/CONTRIBUTING.md)

Specific testing has not been done, same as #2860 but it _should_ not break anything.