### PR TITLE
Get biome data from correct schematic for intersections (Fixes PS-50)

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
@@ -335,7 +335,7 @@ public class HybridPlotWorld extends ClassicPlotWorld {
                             (short) (z - shift), id, false, h2);
                     }
                 }
-                BiomeType biome = blockArrayClipboard1
+                BiomeType biome = blockArrayClipboard2
                     .getBiome(BlockVector2.at(x + min.getBlockX(), z + min.getBlockZ()));
                 addOverlayBiome((short) (x - shift), (short) (z - shift), biome);
             }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets

If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://github.com/IntellectualSites/PlotSquared/issues/new/choose
-->

**Fixes https://issues.intellectualsites.com/issue/PS-50**

## Description
Copy-paste from issue tracker:
> When attempting to use custom road schematics, I ran into an issue where the roads generated with /p createroadschematic were all ocean biome. I was able to fix this for the road by creating the schematic using WorldEdit and including the proper biome in the schematic using //copy -b, however when I followed the same steps for the intersection, the intersections still generate with the biome as ocean. As you can see in the attached screenshot, the roads are properly showing as plains compared to the dark forest biome set for the plots, however the intersections are generating as ocean.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v5/CONTRIBUTING.md)
