### PR TITLE
Fix paperlib shading

### DIFF
--- a/Bukkit/build.gradle
+++ b/Bukkit/build.gradle
@@ -36,7 +36,9 @@ dependencies {
     }
     implementation("me.clip:placeholderapi:2.10.6")
     implementation("net.luckperms:api:5.1")
-    implementation("net.ess3:EssentialsX:2.17.2")
+    implementation("net.ess3:EssentialsX:2.17.2") {
+        exclude(group: "io.papermc", module: "paperlib")
+    }
     implementation("net.alpenblock:BungeePerms:4.0-dev-106")
     compile("se.hyperver.hyperverse:Core:0.6.0-SNAPSHOT"){ transitive = false }
     compile('com.sk89q:squirrelid:1.0.0-SNAPSHOT'){ transitive = false }

--- a/Bukkit/pom.xml
+++ b/Bukkit/pom.xml
@@ -163,6 +163,12 @@
       <artifactId>EssentialsX</artifactId>
       <version>2.17.2</version>
       <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>paperlib</artifactId>
+          <groupId>io.papermc</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>net.alpenblock</groupId>


### PR DESCRIPTION
## Overview
Fixes https://issues.intellectualsites.com/issue/PS-65. See the commit comment for why shading fails. I'm not sure why shading works on some machines.

## Description

It may be useful to note that you can navigate to the 'Bukkit' directory and execute `gradle dependencyInsight --dependency io.papermc:paperlib`. On my machine this prints:

```
io.papermc:paperlib:1.0.4
   variant "compile" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-api
      org.gradle.libraryelements     = jar (compatible with: classes)
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.version         = 8
   ]
   Selection reasons:
      - By conflict resolution : between versions 1.0.4 and 1.0.2
```

This helped me discover the issue. With this commit, version 1.0.2 is selected instead of 1.0.4.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v5/CONTRIBUTING.md)
