### PR TITLE
More dispense blocking on roads

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEvents.java
@@ -1618,6 +1618,35 @@ public class PlayerEvents extends PlotListener implements Listener {
     public void onBlockDispense(BlockDispenseEvent event) {
         Material type = event.getItem().getType();
         switch (type) {
+            case SHULKER_BOX:
+            case WHITE_SHULKER_BOX:
+            case ORANGE_SHULKER_BOX:
+            case MAGENTA_SHULKER_BOX:
+            case LIGHT_BLUE_SHULKER_BOX:
+            case YELLOW_SHULKER_BOX:
+            case LIME_SHULKER_BOX:
+            case PINK_SHULKER_BOX:
+            case GRAY_SHULKER_BOX:
+            case LIGHT_GRAY_SHULKER_BOX:
+            case CYAN_SHULKER_BOX:
+            case PURPLE_SHULKER_BOX:
+            case BLUE_SHULKER_BOX:
+            case BROWN_SHULKER_BOX:
+            case GREEN_SHULKER_BOX:
+            case RED_SHULKER_BOX:
+            case BLACK_SHULKER_BOX:
+            case CARVED_PUMPKIN:
+            case WITHER_SKELETON_SKULL:
+            case FLINT_AND_STEEL:
+            case BONE_MEAL:
+            case SHEARS:
+            case GLASS_BOTTLE:
+            case GLOWSTONE:
+            case COD_BUCKET:
+            case PUFFERFISH_BUCKET:
+            case SALMON_BUCKET:
+            case TROPICAL_FISH_BUCKET:
+            case BUCKET:
             case WATER_BUCKET:
             case LAVA_BUCKET: {
                 if (event.getBlock().getType() == Material.DROPPER) {


### PR DESCRIPTION
## Overview
Currently PlotSquared prevents water buckets and lava buckets from being used by dispensers on the road (fired from e.g. inside a plot). This pull request aims to prevent any modification by dispensers to the road.

**Fixes https://issues.intellectualsites.com/issue/PS-69** (and more)

## Description

Blocks the following items from being used by dispensers on roads:

- Shulker boxes: placed by dispensers.
- Carved pumpkins: placed on iron blocks and snow blocks if they are in the shape of an iron golem or snow golem.
- Wither skeleton skulls: placed on soul sand if in the shape of a wither.
- Flint and steel: places fire. PlotSquared currently prevents fire from being created already, but the flint and steel has its usage decreased.
- Bone meal: creates plants. Although PlotSquared already prevents plants from growing on the road.
- Shears: harvests honey combs from bee nests and beehives.
- Glass bottle: harvests honey from bee nests and beehives.
- Glowstone: charges respawn anchor.
- Fish buckets: create water source block.
- Buckets: pick up water.

See also https://minecraft.gamepedia.com/Dispenser.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v5/CONTRIBUTING.md)
