### PR TITLE
Improve piston interaction with plot and area borders

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEvents.java
@@ -1509,10 +1509,18 @@ public class PlayerEvents extends PlotListener implements Listener {
                 return;
             }
             for (Block block1 : event.getBlocks()) {
-                if (BukkitUtil.getLocation(block1.getLocation().add(relative)).isPlotArea()) {
+                Location bloc = BukkitUtil.getLocation(block1.getLocation());
+                if (bloc.isPlotArea() || bloc.add(relative.getBlockX(),
+                    relative.getBlockY(), relative.getBlockZ()).isPlotArea()) {
                     event.setCancelled(true);
                     return;
                 }
+            }
+            if (location.add(relative.getBlockX(), relative.getBlockY(), relative.getBlockZ())
+                .isPlotArea()) {
+                // Prevent pistons from extending if they are: bordering a plot
+                // area, facing inside plot area, and not pushing any blocks
+                event.setCancelled(true);
             }
             return;
         }
@@ -1555,7 +1563,9 @@ public class PlayerEvents extends PlotListener implements Listener {
                 return;
             }
             for (Block block1 : event.getBlocks()) {
-                if (BukkitUtil.getLocation(block1.getLocation().add(relative)).isPlotArea()) {
+                Location bloc = BukkitUtil.getLocation(block1.getLocation());
+                if (bloc.isPlotArea() || bloc.add(relative.getBlockX(),
+                    relative.getBlockY(), relative.getBlockZ()).isPlotArea()) {
                     event.setCancelled(true);
                     return;
                 }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEvents.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEvents.java
@@ -230,7 +230,6 @@ public class PlayerEvents extends PlotListener implements Listener {
     public static final com.sk89q.worldedit.world.entity.EntityType FAKE_ENTITY_TYPE =
         new com.sk89q.worldedit.world.entity.EntityType("plotsquared:fake");
 
-    private boolean pistonBlocks = true;
     private float lastRadius;
     // To prevent recursion
     private boolean tmpTeleport = true;
@@ -1535,35 +1534,28 @@ public class PlayerEvents extends PlotListener implements Listener {
                 return;
             }
         }
+        if (!plot.equals(area.getOwnedPlot(location.add(
+            relative.getBlockX(), relative.getBlockY(), relative.getBlockZ())))) {
+            // This branch is only necessary to prevent pistons from extending
+            // if they are: on a plot edge, facing outside the plot, and not
+            // pushing any blocks
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBlockPistonRetract(BlockPistonRetractEvent event) {
         Block block = event.getBlock();
         Location location = BukkitUtil.getLocation(block.getLocation());
+        BlockFace face = event.getDirection();
+        Vector relative = new Vector(face.getModX(), face.getModY(), face.getModZ());
         PlotArea area = location.getPlotArea();
         if (area == null) {
             if (!PlotSquared.get().hasPlotArea(location.getWorld())) {
                 return;
             }
-            if (this.pistonBlocks) {
-                try {
-                    for (Block pulled : event.getBlocks()) {
-                        location = BukkitUtil.getLocation(pulled.getLocation());
-                        if (location.isPlotArea()) {
-                            event.setCancelled(true);
-                            return;
-                        }
-                    }
-                } catch (Throwable ignored) {
-                    this.pistonBlocks = false;
-                }
-            }
-            if (!this.pistonBlocks && !block.getType().toString().contains("PISTON")) {
-                BlockFace dir = event.getDirection();
-                location = BukkitUtil.getLocation(block.getLocation()
-                    .add(dir.getModX() * 2, dir.getModY() * 2, dir.getModZ() * 2));
-                if (location.isPlotArea()) {
+            for (Block block1 : event.getBlocks()) {
+                if (BukkitUtil.getLocation(block1.getLocation().add(relative)).isPlotArea()) {
                     event.setCancelled(true);
                     return;
                 }
@@ -1571,45 +1563,21 @@ public class PlayerEvents extends PlotListener implements Listener {
             return;
         }
         Plot plot = area.getOwnedPlot(location);
-        BlockFace dir = event.getDirection();
-        //        Location head = location.add(-dir.getModX(), -dir.getModY(), -dir.getModZ());
-        //
-        //        if (!Objects.equals(plot, area.getOwnedPlot(head))) {
-        //            // FIXME: cancelling the event doesn't work here. See issue #1484
-        //            event.setCancelled(true);
-        //            return;
-        //        }
-        if (this.pistonBlocks) {
-            try {
-                for (Block pulled : event.getBlocks()) {
-                    Location from = BukkitUtil.getLocation(
-                        pulled.getLocation().add(dir.getModX(), dir.getModY(), dir.getModZ()));
-                    Location to = BukkitUtil.getLocation(pulled.getLocation());
-                    if (!area.contains(to.getX(), to.getZ())) {
-                        event.setCancelled(true);
-                        return;
-                    }
-                    Plot fromPlot = area.getOwnedPlot(from);
-                    Plot toPlot = area.getOwnedPlot(to);
-                    if (!Objects.equals(fromPlot, toPlot)) {
-                        event.setCancelled(true);
-                        return;
-                    }
-                }
-            } catch (Throwable ignored) {
-                this.pistonBlocks = false;
-            }
+        if (plot == null) {
+            event.setCancelled(true);
+            return;
         }
-        if (!this.pistonBlocks && !block.getType().toString().contains("PISTON")) {
-            location = BukkitUtil.getLocation(
-                block.getLocation().add(dir.getModX() * 2, dir.getModY() * 2, dir.getModZ() * 2));
-            if (!area.contains(location)) {
+        for (Block block1 : event.getBlocks()) {
+            Location bloc = BukkitUtil.getLocation(block1.getLocation());
+            if (!area.contains(bloc.getX(), bloc.getZ()) || !area
+                .contains(bloc.getX() + relative.getBlockX(), bloc.getZ() + relative.getBlockZ())) {
                 event.setCancelled(true);
                 return;
             }
-            Plot newPlot = area.getOwnedPlot(location);
-            if (!Objects.equals(plot, newPlot)) {
+            if (!plot.equals(area.getOwnedPlot(bloc)) || !plot.equals(area.getOwnedPlot(
+                bloc.add(relative.getBlockX(), relative.getBlockY(), relative.getBlockZ())))) {
                 event.setCancelled(true);
+                return;
             }
         }
     }

--- a/Core/src/main/java/com/plotsquared/core/location/Location.java
+++ b/Core/src/main/java/com/plotsquared/core/location/Location.java
@@ -179,6 +179,7 @@ public class Location implements Cloneable, Comparable<Location> {
         this.x += x;
         this.y += y;
         this.z += z;
+        this.blockVector3 = BlockVector3.at(this.x, this.y, this.z);
         return this;
     }
 
@@ -220,6 +221,7 @@ public class Location implements Cloneable, Comparable<Location> {
         this.x -= x;
         this.y -= y;
         this.z -= z;
+        this.blockVector3 = BlockVector3.at(this.x, this.y, this.z);
         return this;
     }
 


### PR DESCRIPTION
## Overview
Improves the handling of moving blocks across plot and area borders.

**Fixes https://issues.intellectualsites.com/issue/PS-39** (and more)

## Description

First commit should explain well enough how this improves the situation for plot borders. I just copy pasted most of the piston extend listener code to the retract listener. It all seems to work fine now. Not sure why the retract listener was so different from the extend listener.

In the second commit I applied similar fixes to interaction with area borders. I encountered a bug in `Location`'s `add` and `subtract` methods while doing this, which I fixed in the third commit. That last fix may have effects on a lot of other parts of the code, which I didn't test.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v5/CONTRIBUTING.md)
