### PR TITLE
Synchronization utilities + Managed meta data access

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/player/BukkitPlayer.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/player/BukkitPlayer.java
@@ -69,12 +69,12 @@ import static com.sk89q.worldedit.world.gamemode.GameModes.SURVIVAL;
 public class BukkitPlayer extends PlotPlayer<Player> {
 
     private static boolean CHECK_EFFECTIVE = true;
-
-    private final EconHandler econHandler;
     public final Player player;
+    private final EconHandler econHandler;
     private boolean offline;
     private String name;
-
+    private String lastMessage = "";
+    private long lastMessageTime = 0L;
 
     /**
      * <p>Please do not use this method. Instead use
@@ -234,10 +234,10 @@ public class BukkitPlayer extends PlotPlayer<Player> {
 
     @Override public void sendMessage(String message) {
         message = message.replace('\u2010', '%').replace('\u2020', '&').replace('\u2030', '&');
-        if (!StringMan.isEqual(this.getMeta("lastMessage"), message) || (
-            System.currentTimeMillis() - this.<Long>getMeta("lastMessageTime") > 5000)) {
-            setMeta("lastMessage", message);
-            setMeta("lastMessageTime", System.currentTimeMillis());
+        if (!StringMan.isEqual(this.lastMessage, message) || (
+            System.currentTimeMillis() - this.lastMessageTime > 5000)) {
+            this.lastMessage = message;
+            this.lastMessageTime = System.currentTimeMillis();
             this.player.sendMessage(message);
         }
     }

--- a/Core/src/main/java/com/plotsquared/core/command/Auto.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Auto.java
@@ -94,7 +94,7 @@ public class Auto extends SubCommand {
         if (diff - sizeX * sizeZ < 0) {
             try (final MetaDataAccess<Integer> metaDataAccess = player.accessPersistentMetaData(
                 PlayerMetaDataKeys.PERSISTENT_GRANTED_PLOTS)) {
-                if (metaDataAccess.has()) {
+                if (metaDataAccess.isPresent()) {
                     int grantedPlots = metaDataAccess.get().orElse(0);
                     if (diff < 0 && grantedPlots < sizeX * sizeZ) {
                         MainUtil.sendMessage(player, Captions.CANT_CLAIM_MORE_PLOTS);

--- a/Core/src/main/java/com/plotsquared/core/command/Claim.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Claim.java
@@ -92,7 +92,7 @@ public class Claim extends SubCommand {
         try (final MetaDataAccess<Integer> metaDataAccess = player.accessPersistentMetaData(PlayerMetaDataKeys.PERSISTENT_GRANTED_PLOTS)) {
             int grants = 0;
             if (currentPlots >= player.getAllowedPlots() && !force) {
-                if (metaDataAccess.has()) {
+                if (metaDataAccess.isPresent()) {
                     grants = metaDataAccess.get().orElse(0);
                     if (grants <= 0) {
                         metaDataAccess.remove();

--- a/Core/src/main/java/com/plotsquared/core/command/Claim.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Claim.java
@@ -25,7 +25,6 @@
  */
 package com.plotsquared.core.command;
 
-import com.google.common.primitives.Ints;
 import com.google.inject.Inject;
 import com.plotsquared.core.configuration.CaptionUtility;
 import com.plotsquared.core.configuration.Captions;
@@ -36,6 +35,8 @@ import com.plotsquared.core.events.PlotMergeEvent;
 import com.plotsquared.core.events.Result;
 import com.plotsquared.core.location.Direction;
 import com.plotsquared.core.location.Location;
+import com.plotsquared.core.player.MetaDataAccess;
+import com.plotsquared.core.player.PlayerMetaDataKeys;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
@@ -85,54 +86,57 @@ public class Claim extends SubCommand {
         int currentPlots = Settings.Limit.GLOBAL ?
             player.getPlotCount() :
             player.getPlotCount(location.getWorldName());
-        int grants = 0;
-        if (currentPlots >= player.getAllowedPlots() && !force) {
-            if (player.hasPersistentMeta("grantedPlots")) {
-                grants = Ints.fromByteArray(player.getPersistentMeta("grantedPlots"));
-                if (grants <= 0) {
-                    player.removePersistentMeta("grantedPlots");
+
+        final PlotArea area = plot.getArea();
+
+        try (final MetaDataAccess<Integer> metaDataAccess = player.accessPersistentMetaData(PlayerMetaDataKeys.GRANTED_PLOTS)) {
+            int grants = 0;
+            if (currentPlots >= player.getAllowedPlots() && !force) {
+                if (metaDataAccess.has()) {
+                    grants = metaDataAccess.get().orElse(0);
+                    if (grants <= 0) {
+                        metaDataAccess.remove();
+                        return sendMessage(player, Captions.CANT_CLAIM_MORE_PLOTS);
+                    }
+                } else {
                     return sendMessage(player, Captions.CANT_CLAIM_MORE_PLOTS);
                 }
-            } else {
-                return sendMessage(player, Captions.CANT_CLAIM_MORE_PLOTS);
             }
-        }
-        if (!plot.canClaim(player)) {
-            return sendMessage(player, Captions.PLOT_IS_CLAIMED);
-        }
-        final PlotArea area = plot.getArea();
-        if (schematic != null && !schematic.isEmpty()) {
-            if (area.isSchematicClaimSpecify()) {
-                if (!area.hasSchematic(schematic)) {
-                    return sendMessage(player, Captions.SCHEMATIC_INVALID,
-                        "non-existent: " + schematic);
-                }
-                if (!Permissions.hasPermission(player, CaptionUtility
-                    .format(player, Captions.PERMISSION_CLAIM_SCHEMATIC.getTranslated(), schematic))
-                    && !Permissions
-                    .hasPermission(player, Captions.PERMISSION_ADMIN_COMMAND_SCHEMATIC) && !force) {
-                    return sendMessage(player, Captions.NO_SCHEMATIC_PERMISSION, schematic);
+
+            if (!plot.canClaim(player)) {
+                return sendMessage(player, Captions.PLOT_IS_CLAIMED);
+            }
+            if (schematic != null && !schematic.isEmpty()) {
+                if (area.isSchematicClaimSpecify()) {
+                    if (!area.hasSchematic(schematic)) {
+                        return sendMessage(player, Captions.SCHEMATIC_INVALID, "non-existent: " + schematic);
+                    }
+                    if (!Permissions.hasPermission(player, CaptionUtility.format(player, Captions.PERMISSION_CLAIM_SCHEMATIC.getTranslated(),
+                        schematic)) && !Permissions.hasPermission(player, Captions.PERMISSION_ADMIN_COMMAND_SCHEMATIC)
+                        && !force) {
+                        return sendMessage(player, Captions.NO_SCHEMATIC_PERMISSION, schematic);
+                    }
                 }
             }
-        }
-        if ((this.econHandler != null) && area.useEconomy() && !force) {
-            Expression<Double> costExr = area.getPrices().get("claim");
-            double cost = costExr.evaluate((double) currentPlots);
-            if (cost > 0d) {
-                if (this.econHandler.getMoney(player) < cost) {
-                    return sendMessage(player, Captions.CANNOT_AFFORD_PLOT, "" + cost);
+            if ((this.econHandler != null) && area.useEconomy() && !force) {
+                Expression<Double> costExr = area.getPrices().get("claim");
+                double cost = costExr.evaluate((double) currentPlots);
+                if (cost > 0d) {
+                    if (this.econHandler.getMoney(player) < cost) {
+                        return sendMessage(player, Captions.CANNOT_AFFORD_PLOT, "" + cost);
+                    }
+                    this.econHandler.withdrawMoney(player, cost);
+                    sendMessage(player, Captions.REMOVED_BALANCE, cost + "");
                 }
-                this.econHandler.withdrawMoney(player, cost);
-                sendMessage(player, Captions.REMOVED_BALANCE, cost + "");
             }
-        }
-        if (grants > 0) {
-            if (grants == 1) {
-                player.removePersistentMeta("grantedPlots");
-            } else {
-                player.setPersistentMeta("grantedPlots", Ints.toByteArray(grants - 1));
+            if (grants > 0) {
+                if (grants == 1) {
+                    metaDataAccess.remove();
+                } else {
+                    metaDataAccess.set(grants - 1);
+                }
+                sendMessage(player, Captions.REMOVED_GRANTED_PLOT, "1", (grants - 1));
             }
-            sendMessage(player, Captions.REMOVED_GRANTED_PLOT, "1", (grants - 1));
         }
         int border = area.getBorder();
         if (border != Integer.MAX_VALUE && plot.getDistanceFromOrigin() > border && !force) {

--- a/Core/src/main/java/com/plotsquared/core/command/Claim.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Claim.java
@@ -89,7 +89,7 @@ public class Claim extends SubCommand {
 
         final PlotArea area = plot.getArea();
 
-        try (final MetaDataAccess<Integer> metaDataAccess = player.accessPersistentMetaData(PlayerMetaDataKeys.GRANTED_PLOTS)) {
+        try (final MetaDataAccess<Integer> metaDataAccess = player.accessPersistentMetaData(PlayerMetaDataKeys.PERSISTENT_GRANTED_PLOTS)) {
             int grants = 0;
             if (currentPlots >= player.getAllowedPlots() && !force) {
                 if (metaDataAccess.has()) {

--- a/Core/src/main/java/com/plotsquared/core/command/CmdConfirm.java
+++ b/Core/src/main/java/com/plotsquared/core/command/CmdConfirm.java
@@ -26,19 +26,29 @@
 package com.plotsquared.core.command;
 
 import com.plotsquared.core.configuration.Captions;
+import com.plotsquared.core.player.MetaDataAccess;
+import com.plotsquared.core.player.PlayerMetaDataKeys;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.util.MainUtil;
 import com.plotsquared.core.util.task.TaskManager;
 import com.plotsquared.core.util.task.TaskTime;
 
+import javax.annotation.Nullable;
+
 public class CmdConfirm {
 
-    public static CmdInstance getPending(PlotPlayer<?> player) {
-        return player.getMeta("cmdConfirm");
+    @Nullable public static CmdInstance getPending(PlotPlayer<?> player) {
+        try (final MetaDataAccess<CmdInstance> metaDataAccess = player.accessTemporaryMetaData(
+            PlayerMetaDataKeys.TEMPORARY_CONFIRM)) {
+            return metaDataAccess.get().orElse(null);
+        }
     }
 
     public static void removePending(PlotPlayer<?> player) {
-        player.deleteMeta("cmdConfirm");
+        try (final MetaDataAccess<CmdInstance> metaDataAccess = player.accessTemporaryMetaData(
+            PlayerMetaDataKeys.TEMPORARY_CONFIRM)) {
+            metaDataAccess.remove();
+        }
     }
 
     public static void addPending(final PlotPlayer<?> player, String commandStr,
@@ -49,7 +59,10 @@ public class CmdConfirm {
         }
         TaskManager.runTaskLater(() -> {
             CmdInstance cmd = new CmdInstance(runnable);
-            player.setMeta("cmdConfirm", cmd);
+            try (final MetaDataAccess<CmdInstance> metaDataAccess = player.accessTemporaryMetaData(
+                PlayerMetaDataKeys.TEMPORARY_CONFIRM)) {
+                metaDataAccess.set(cmd);
+            }
         }, TaskTime.ticks(1L));
     }
 }

--- a/Core/src/main/java/com/plotsquared/core/command/DebugExec.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DebugExec.java
@@ -409,46 +409,6 @@ public class DebugExec extends SubCommand {
                             }
                         }, "/plot debugexec list-scripts", "List of scripts");
                     return true;
-                case "allcmd":
-                    if (args.length < 3) {
-                        Captions.COMMAND_SYNTAX
-                            .send(player, "/plot debugexec allcmd <condition> <command>");
-                        return false;
-                    }
-                    long start = System.currentTimeMillis();
-                    Command cmd = MainCommand.getInstance().getCommand(args[3]);
-                    String[] params = Arrays.copyOfRange(args, 4, args.length);
-                    if ("true".equals(args[1])) {
-                        Location location = player.getMeta(PlotPlayer.META_LOCATION);
-                        Plot plot = player.getMeta(PlotPlayer.META_LAST_PLOT);
-                        for (Plot current : PlotSquared.get().getBasePlots()) {
-                            player.setMeta(PlotPlayer.META_LOCATION, current.getBottomAbs());
-                            player.setMeta(PlotPlayer.META_LAST_PLOT, current);
-                            cmd.execute(player, params, null, null);
-                        }
-                        if (location == null) {
-                            player.deleteMeta(PlotPlayer.META_LOCATION);
-                        } else {
-                            player.setMeta(PlotPlayer.META_LOCATION, location);
-                        }
-                        if (plot == null) {
-                            player.deleteMeta(PlotPlayer.META_LAST_PLOT);
-                        } else {
-                            player.setMeta(PlotPlayer.META_LAST_PLOT, plot);
-                        }
-                        player.sendMessage("&c> " + (System.currentTimeMillis() - start));
-                        return true;
-                    }
-                    init();
-                    this.scope.put("_2", params);
-                    this.scope.put("_3", cmd);
-                    script =
-                        "_1=PS.getBasePlots().iterator();while(_1.hasNext()){plot=_1.next();if("
-                            + args[1]
-                            + "){PlotPlayer.setMeta(\"location\",plot.getBottomAbs());PlotPlayer.setMeta(\"lastplot\",plot);_3.onCommand"
-                            + "(PlotPlayer,_2)}}";
-
-                    break;
                 case "all":
                     if (args.length < 3) {
                         Captions.COMMAND_SYNTAX

--- a/Core/src/main/java/com/plotsquared/core/command/Grant.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Grant.java
@@ -84,7 +84,7 @@ public class Grant extends Command {
                         PlotPlayer<?> pp = PlotSquared.platform().getPlayerManager().getPlayerIfExists(uuid);
                         if (pp != null) {
                             try (final MetaDataAccess<Integer> access = pp.accessPersistentMetaData(
-                                PlayerMetaDataKeys.GRANTED_PLOTS)) {
+                                PlayerMetaDataKeys.PERSISTENT_GRANTED_PLOTS)) {
                                 if (args[0].equalsIgnoreCase("check")) {
                                     Captions.GRANTED_PLOTS.send(player, access.get().orElse(0));
                                 } else {

--- a/Core/src/main/java/com/plotsquared/core/command/Grant.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Grant.java
@@ -83,7 +83,7 @@ public class Grant extends Command {
                         final UUID uuid = uuids.toArray(new UUID[0])[0];
                         PlotPlayer<?> pp = PlotSquared.platform().getPlayerManager().getPlayerIfExists(uuid);
                         if (pp != null) {
-                            try (final MetaDataAccess<Integer> access = player.accessPersistentMetaData(
+                            try (final MetaDataAccess<Integer> access = pp.accessPersistentMetaData(
                                 PlayerMetaDataKeys.GRANTED_PLOTS)) {
                                 if (args[0].equalsIgnoreCase("check")) {
                                     Captions.GRANTED_PLOTS.send(player, access.get().orElse(0));

--- a/Core/src/main/java/com/plotsquared/core/command/Inbox.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Inbox.java
@@ -25,7 +25,9 @@
  */
 package com.plotsquared.core.command;
 
+import com.google.inject.TypeLiteral;
 import com.plotsquared.core.configuration.Captions;
+import com.plotsquared.core.player.MetaDataAccess;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.comment.CommentInbox;
@@ -34,6 +36,7 @@ import com.plotsquared.core.plot.comment.PlotComment;
 import com.plotsquared.core.util.MainUtil;
 import com.plotsquared.core.util.StringMan;
 import com.plotsquared.core.util.task.RunnableVal;
+import com.plotsquared.core.player.MetaDataKey;
 
 import java.util.List;
 
@@ -140,7 +143,10 @@ public class Inbox extends SubCommand {
                 StringMan.join(CommentManager.inboxes.keySet(), ", "));
             return false;
         }
-        player.setMeta("inbox:" + inbox.toString(), System.currentTimeMillis());
+        final MetaDataKey<Long> metaDataKey = MetaDataKey.of(String.format("inbox:%s", inbox.toString()), new TypeLiteral<Long>() {});
+        try (final MetaDataAccess<Long> metaDataAccess = player.accessTemporaryMetaData(metaDataKey)) {
+            metaDataAccess.set(System.currentTimeMillis());
+        }
         final int page;
         if (args.length > 1) {
             switch (args[1].toLowerCase()) {

--- a/Core/src/main/java/com/plotsquared/core/command/MainCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/MainCommand.java
@@ -31,6 +31,8 @@ import com.plotsquared.core.configuration.Captions;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.location.Location;
 import com.plotsquared.core.player.ConsolePlayer;
+import com.plotsquared.core.player.MetaDataAccess;
+import com.plotsquared.core.player.PlayerMetaDataKeys;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
@@ -43,6 +45,7 @@ import com.plotsquared.core.util.task.RunnableVal3;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -231,7 +234,11 @@ public class MainCommand extends Command {
         RunnableVal3<Command, Runnable, Runnable> confirm,
         RunnableVal2<Command, CommandResult> whenDone) {
         // Clear perm caching //
-        player.deleteMeta("perm");
+        try (final MetaDataAccess<Map<String, Boolean>> permAccess = player.accessTemporaryMetaData(
+            PlayerMetaDataKeys.TEMPORARY_PERMISSIONS)) {
+            permAccess.remove();
+        }
+
         // Optional command scope //
         Location location = null;
         Plot plot = null;
@@ -246,12 +253,17 @@ public class MainCommand extends Command {
                 Location newLoc = newPlot.getCenterSynchronous();
                 if (player.canTeleport(newLoc)) {
                     // Save meta
-                    location = player.getMeta(PlotPlayer.META_LOCATION);
-                    plot = player.getMeta(PlotPlayer.META_LAST_PLOT);
+                    try (final MetaDataAccess<Location> locationMetaDataAccess
+                        = player.accessTemporaryMetaData(PlayerMetaDataKeys.TEMPORARY_LOCATION)) {
+                        location = locationMetaDataAccess.get().orElse(null);
+                        locationMetaDataAccess.set(newLoc);
+                    }
+                    try (final MetaDataAccess<Plot> plotMetaDataAccess
+                        = player.accessTemporaryMetaData(PlayerMetaDataKeys.TEMPORARY_LAST_PLOT)) {
+                        plot = plotMetaDataAccess.get().orElse(null);
+                        plotMetaDataAccess.set(newPlot);
+                    }
                     tp = true;
-                    // Set loc
-                    player.setMeta(PlotPlayer.META_LOCATION, newLoc);
-                    player.setMeta(PlotPlayer.META_LAST_PLOT, newPlot);
                 } else {
                     Captions.BORDER.send(player);
                 }
@@ -304,15 +316,21 @@ public class MainCommand extends Command {
         }
         // Reset command scope //
         if (tp && !(player instanceof ConsolePlayer)) {
-            if (location == null) {
-                player.deleteMeta(PlotPlayer.META_LOCATION);
-            } else {
-                player.setMeta(PlotPlayer.META_LOCATION, location);
+            try (final MetaDataAccess<Location> locationMetaDataAccess
+                = player.accessTemporaryMetaData(PlayerMetaDataKeys.TEMPORARY_LOCATION)) {
+                if (location == null) {
+                    locationMetaDataAccess.remove();
+                } else {
+                    locationMetaDataAccess.set(location);
+                }
             }
-            if (plot == null) {
-                player.deleteMeta(PlotPlayer.META_LAST_PLOT);
-            } else {
-                player.setMeta(PlotPlayer.META_LAST_PLOT, plot);
+            try (final MetaDataAccess<Plot> plotMetaDataAccess
+                = player.accessTemporaryMetaData(PlayerMetaDataKeys.TEMPORARY_LAST_PLOT)) {
+                if (plot == null) {
+                    plotMetaDataAccess.remove();
+                } else {
+                    plotMetaDataAccess.set(plot);
+                }
             }
         }
         return CompletableFuture.completedFuture(true);

--- a/Core/src/main/java/com/plotsquared/core/command/Save.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Save.java
@@ -28,6 +28,8 @@ package com.plotsquared.core.command;
 import com.google.inject.Inject;
 import com.plotsquared.core.configuration.Captions;
 import com.plotsquared.core.location.Location;
+import com.plotsquared.core.player.MetaDataAccess;
+import com.plotsquared.core.player.PlayerMetaDataKeys;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotId;
@@ -104,9 +106,9 @@ public class Save extends SubCommand {
                                 return;
                             }
                             MainUtil.sendMessage(player, Captions.SAVE_SUCCESS);
-                            List<String> schematics = player.getMeta("plot_schematics");
-                            if (schematics != null) {
-                                schematics.add(file + ".schem");
+                            try (final MetaDataAccess<List<String>> schematicAccess =
+                                player.accessTemporaryMetaData(PlayerMetaDataKeys.TEMPORARY_SCHEMATICS)) {
+                                schematicAccess.get().ifPresent(schematics -> schematics.add(file + ".schem"));
                             }
                         }
                     });

--- a/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
+++ b/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
@@ -32,6 +32,7 @@ import com.plotsquared.core.events.PlotFlagRemoveEvent;
 import com.plotsquared.core.events.Result;
 import com.plotsquared.core.location.Location;
 import com.plotsquared.core.player.MetaDataAccess;
+import com.plotsquared.core.player.MetaDataKey;
 import com.plotsquared.core.player.PlayerMetaDataKeys;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
@@ -136,14 +137,16 @@ public class PlotListener {
             .hasPermission(player, "plots.admin.entry.denied")) {
             return false;
         }
-        Plot last = player.getMeta(PlotPlayer.META_LAST_PLOT);
-        if ((last != null) && !last.getId().equals(plot.getId())) {
-            plotExit(player, last);
+        try (final MetaDataAccess<Plot> lastPlot = player.accessTemporaryMetaData(PlayerMetaDataKeys.TEMPORARY_LAST_PLOT)) {
+            Plot last = lastPlot.get().orElse(null);
+            if ((last != null) && !last.getId().equals(plot.getId())) {
+                plotExit(player, last);
+            }
+            if (ExpireManager.IMP != null) {
+                ExpireManager.IMP.handleEntry(player, plot);
+            }
+            lastPlot.set(plot);
         }
-        if (ExpireManager.IMP != null) {
-            ExpireManager.IMP.handleEntry(player, plot);
-        }
-        player.setMeta(PlotPlayer.META_LAST_PLOT, plot);
         this.eventDispatcher.callEntry(player, plot);
         if (plot.hasOwner()) {
             // This will inherit values from PlotArea
@@ -230,39 +233,47 @@ public class PlotListener {
             player.setWeather(plot.getFlag(WeatherFlag.class));
 
             ItemType musicFlag = plot.getFlag(MusicFlag.class);
-            if (musicFlag != null) {
-                final String rawId = musicFlag.getId();
-                if (rawId.contains("disc") || musicFlag == ItemTypes.AIR) {
-                    Location location = player.getLocation();
-                    Location lastLocation = player.getMeta("music");
-                    if (lastLocation != null) {
-                        player.playMusic(lastLocation, musicFlag);
-                        if (musicFlag == ItemTypes.AIR) {
-                            player.deleteMeta("music");
+
+            try (final MetaDataAccess<Location> musicMeta =
+                player.accessTemporaryMetaData(PlayerMetaDataKeys.TEMPORARY_MUSIC)) {
+                if (musicFlag != null) {
+                    final String rawId = musicFlag.getId();
+                    if (rawId.contains("disc") || musicFlag == ItemTypes.AIR) {
+                        Location location = player.getLocation();
+                        Location lastLocation = musicMeta.get().orElse(null);
+                        if (lastLocation != null) {
+                            player.playMusic(lastLocation, musicFlag);
+                            if (musicFlag == ItemTypes.AIR) {
+                                musicMeta.remove();
+                            }
+                        }
+                        if (musicFlag != ItemTypes.AIR) {
+                            try {
+                                musicMeta.set(location);
+                                player.playMusic(location, musicFlag);
+                            } catch (Exception ignored) {
+                            }
                         }
                     }
-                    if (musicFlag != ItemTypes.AIR) {
-                        try {
-                            player.setMeta("music", location);
-                            player.playMusic(location, musicFlag);
-                        } catch (Exception ignored) {
-                        }
-                    }
-                }
-            } else {
-                Location lastLoc = player.getMeta("music");
-                if (lastLoc != null) {
-                    player.deleteMeta("music");
-                    player.playMusic(lastLoc, ItemTypes.AIR);
+                } else {
+                    musicMeta.get().ifPresent(lastLoc -> {
+                        musicMeta.remove();
+                        player.playMusic(lastLoc, ItemTypes.AIR);
+                    });
                 }
             }
+
             CommentManager.sendTitle(player, plot);
 
             if (titles && !player.getAttribute("disabletitles")) {
                 if (!Captions.TITLE_ENTERED_PLOT.getTranslated().isEmpty()
                     || !Captions.TITLE_ENTERED_PLOT_SUB.getTranslated().isEmpty()) {
                     TaskManager.runTaskLaterAsync(() -> {
-                        Plot lastPlot = player.getMeta(PlotPlayer.META_LAST_PLOT);
+                        Plot lastPlot = null;
+                        try (final MetaDataAccess<Plot> lastPlotAccess =
+                            player.accessTemporaryMetaData(PlayerMetaDataKeys.TEMPORARY_LAST_PLOT)) {
+                            lastPlot = lastPlotAccess.get().orElse(null);
+                        }
                         if ((lastPlot != null) && plot.getId().equals(lastPlot.getId())) {
                             Map<String, String> replacements = new HashMap<>();
                             replacements.put("%x%", String.valueOf(lastPlot.getId().getX()));
@@ -299,89 +310,96 @@ public class PlotListener {
     }
 
     public boolean plotExit(final PlotPlayer<?> player, Plot plot) {
-        Object previous = player.deleteMeta(PlotPlayer.META_LAST_PLOT);
-        this.eventDispatcher.callLeave(player, plot);
-        if (plot.hasOwner()) {
-            PlotArea pw = plot.getArea();
-            if (pw == null) {
-                return true;
-            }
-            if (plot.getFlag(DenyExitFlag.class) && !Permissions
-                .hasPermission(player, Captions.PERMISSION_ADMIN_EXIT_DENIED) && !player
-                .getMeta("kick", false)) {
-                if (previous != null) {
-                    player.setMeta(PlotPlayer.META_LAST_PLOT, previous);
+        try (final MetaDataAccess<Plot> lastPlot = player.accessTemporaryMetaData(PlayerMetaDataKeys.TEMPORARY_LAST_PLOT)) {
+            final Plot previous = lastPlot.remove();
+            this.eventDispatcher.callLeave(player, plot);
+            if (plot.hasOwner()) {
+                PlotArea pw = plot.getArea();
+                if (pw == null) {
+                    return true;
                 }
-                return false;
-            }
-            if (!plot.getFlag(GamemodeFlag.class).equals(GamemodeFlag.DEFAULT) || !plot
-                .getFlag(GuestGamemodeFlag.class).equals(GamemodeFlag.DEFAULT)) {
-                if (player.getGameMode() != pw.getGameMode()) {
-                    if (!Permissions.hasPermission(player, "plots.gamemode.bypass")) {
-                        player.setGameMode(pw.getGameMode());
-                    } else {
-                        MainUtil.sendMessage(player, StringMan
-                            .replaceAll(Captions.GAMEMODE_WAS_BYPASSED.getTranslated(), "{plot}",
-                                plot.toString(), "{gamemode}",
-                                pw.getGameMode().getName().toLowerCase()));
+                try (final MetaDataAccess<Boolean> kickAccess =
+                    player.accessTemporaryMetaData(PlayerMetaDataKeys.TEMPORARY_KICK)) {
+                    if (plot.getFlag(DenyExitFlag.class) && !Permissions
+                        .hasPermission(player, Captions.PERMISSION_ADMIN_EXIT_DENIED) &&
+                        !kickAccess.get().orElse(false)) {
+                        if (previous != null) {
+                            lastPlot.set(previous);
+                        }
+                        return false;
                     }
                 }
-            }
-
-            final String farewell = plot.getFlag(FarewellFlag.class);
-            if (!farewell.isEmpty()) {
-                plot.format(Captions.PREFIX_FAREWELL.getTranslated() + farewell, player, false)
-                    .thenAcceptAsync(player::sendMessage);
-            }
-
-            if (plot.getFlag(NotifyLeaveFlag.class)) {
-                if (!Permissions.hasPermission(player, "plots.flag.notify-enter.bypass")) {
-                    for (UUID uuid : plot.getOwners()) {
-                        final PlotPlayer owner = PlotSquared.platform().getPlayerManager().getPlayerIfExists(uuid);
-                        if ((owner != null) && !owner.getUUID().equals(player.getUUID())) {
-                            MainUtil.sendMessage(owner, Captions.NOTIFY_LEAVE.getTranslated()
-                                .replace("%player", player.getName())
-                                .replace("%plot", plot.getId().toString()));
+                if (!plot.getFlag(GamemodeFlag.class).equals(GamemodeFlag.DEFAULT) || !plot
+                    .getFlag(GuestGamemodeFlag.class).equals(GamemodeFlag.DEFAULT)) {
+                    if (player.getGameMode() != pw.getGameMode()) {
+                        if (!Permissions.hasPermission(player, "plots.gamemode.bypass")) {
+                            player.setGameMode(pw.getGameMode());
+                        } else {
+                            MainUtil.sendMessage(player, StringMan
+                                .replaceAll(Captions.GAMEMODE_WAS_BYPASSED.getTranslated(), "{plot}",
+                                    plot.toString(), "{gamemode}",
+                                    pw.getGameMode().getName().toLowerCase()));
                         }
                     }
                 }
-            }
 
-            final FlyFlag.FlyStatus flyStatus = plot.getFlag(FlyFlag.class);
-            if (flyStatus != FlyFlag.FlyStatus.DEFAULT) {
-                try (final MetaDataAccess<Boolean> metaDataAccess = player.accessPersistentMetaData(PlayerMetaDataKeys.PERSISTENT_FLIGHT)) {
-                    final Optional<Boolean> value = metaDataAccess.get();
-                    if (value.isPresent()) {
-                        player.setFlight(value.get());
-                        metaDataAccess.remove();
-                    } else {
-                        GameMode gameMode = player.getGameMode();
-                        if (gameMode == GameModes.SURVIVAL || gameMode == GameModes.ADVENTURE) {
-                            player.setFlight(false);
-                        } else if (!player.getFlight()) {
-                            player.setFlight(true);
+                final String farewell = plot.getFlag(FarewellFlag.class);
+                if (!farewell.isEmpty()) {
+                    plot.format(Captions.PREFIX_FAREWELL.getTranslated() + farewell, player, false)
+                        .thenAcceptAsync(player::sendMessage);
+                }
+
+                if (plot.getFlag(NotifyLeaveFlag.class)) {
+                    if (!Permissions.hasPermission(player, "plots.flag.notify-enter.bypass")) {
+                        for (UUID uuid : plot.getOwners()) {
+                            final PlotPlayer owner = PlotSquared.platform().getPlayerManager().getPlayerIfExists(uuid);
+                            if ((owner != null) && !owner.getUUID().equals(player.getUUID())) {
+                                MainUtil.sendMessage(owner, Captions.NOTIFY_LEAVE.getTranslated()
+                                    .replace("%player", player.getName())
+                                    .replace("%plot", plot.getId().toString()));
+                            }
                         }
                     }
                 }
-            }
 
-            if (plot.getFlag(TimeFlag.class) != TimeFlag.TIME_DISABLED.getValue().longValue()) {
-                player.setTime(Long.MAX_VALUE);
-            }
+                final FlyFlag.FlyStatus flyStatus = plot.getFlag(FlyFlag.class);
+                if (flyStatus != FlyFlag.FlyStatus.DEFAULT) {
+                    try (final MetaDataAccess<Boolean> metaDataAccess = player.accessPersistentMetaData(PlayerMetaDataKeys.PERSISTENT_FLIGHT)) {
+                        final Optional<Boolean> value = metaDataAccess.get();
+                        if (value.isPresent()) {
+                            player.setFlight(value.get());
+                            metaDataAccess.remove();
+                        } else {
+                            GameMode gameMode = player.getGameMode();
+                            if (gameMode == GameModes.SURVIVAL || gameMode == GameModes.ADVENTURE) {
+                                player.setFlight(false);
+                            } else if (!player.getFlight()) {
+                                player.setFlight(true);
+                            }
+                        }
+                    }
+                }
 
-            final PlotWeather plotWeather = plot.getFlag(WeatherFlag.class);
-            if (plotWeather != PlotWeather.CLEAR) {
-                player.setWeather(PlotWeather.RESET);
-            }
+                if (plot.getFlag(TimeFlag.class) != TimeFlag.TIME_DISABLED.getValue().longValue()) {
+                    player.setTime(Long.MAX_VALUE);
+                }
 
-            Location lastLoc = player.getMeta("music");
-            if (lastLoc != null) {
-                player.deleteMeta("music");
-                player.playMusic(lastLoc, ItemTypes.AIR);
-            }
+                final PlotWeather plotWeather = plot.getFlag(WeatherFlag.class);
+                if (plotWeather != PlotWeather.CLEAR) {
+                    player.setWeather(PlotWeather.RESET);
+                }
 
-            feedRunnable.remove(player.getUUID());
-            healRunnable.remove(player.getUUID());
+                try (final MetaDataAccess<Location> musicAccess =
+                    player.accessTemporaryMetaData(PlayerMetaDataKeys.TEMPORARY_MUSIC)) {
+                    musicAccess.get().ifPresent(lastLoc -> {
+                        musicAccess.remove();
+                        player.playMusic(lastLoc, ItemTypes.AIR);
+                    });
+                }
+
+                feedRunnable.remove(player.getUUID());
+                healRunnable.remove(player.getUUID());
+            }
         }
         return true;
     }

--- a/Core/src/main/java/com/plotsquared/core/player/ConsolePlayer.java
+++ b/Core/src/main/java/com/plotsquared/core/player/ConsolePlayer.java
@@ -32,6 +32,7 @@ import com.plotsquared.core.database.DBFunc;
 import com.plotsquared.core.events.TeleportCause;
 import com.plotsquared.core.inject.annotations.ConsoleActor;
 import com.plotsquared.core.location.Location;
+import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.plot.PlotWeather;
 import com.plotsquared.core.plot.world.PlotAreaManager;
@@ -134,8 +135,16 @@ public class ConsolePlayer extends PlotPlayer<Actor> {
     }
 
     @Override public void teleport(Location location, TeleportCause cause) {
-        setMeta(META_LAST_PLOT, location.getPlot());
-        setMeta(META_LOCATION, location);
+        try (final MetaDataAccess<Plot> lastPlot = accessTemporaryMetaData(PlayerMetaDataKeys.TEMPORARY_LAST_PLOT)) {
+            if (location.getPlot() == null) {
+                lastPlot.remove();
+            } else {
+                lastPlot.set(location.getPlot());
+            }
+        }
+        try (final MetaDataAccess<Location> locationMetaDataAccess = accessPersistentMetaData(PlayerMetaDataKeys.TEMPORARY_LOCATION)) {
+            locationMetaDataAccess.set(location);
+        }
     }
 
     @Override public boolean isOnline() {

--- a/Core/src/main/java/com/plotsquared/core/player/MetaDataAccess.java
+++ b/Core/src/main/java/com/plotsquared/core/player/MetaDataAccess.java
@@ -28,6 +28,7 @@ package com.plotsquared.core.player;
 import com.plotsquared.core.synchronization.LockRepository;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Optional;
 
 /**
@@ -59,8 +60,10 @@ public abstract class MetaDataAccess<T> implements AutoCloseable {
 
     /**
      * Remove the stored value meta data
+     *
+     * @return Old value, or {@link null}
      */
-    public abstract void remove();
+    @Nullable public abstract T remove();
 
     /**
      * Set the meta data value

--- a/Core/src/main/java/com/plotsquared/core/player/MetaDataAccess.java
+++ b/Core/src/main/java/com/plotsquared/core/player/MetaDataAccess.java
@@ -1,0 +1,101 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.player;
+
+import com.plotsquared.core.synchronization.LockRepository;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+
+/**
+ * Access to player meta data
+ *
+ * @param <P> Player type
+ * @param <T> Meta data type
+ */
+public abstract class MetaDataAccess<T> implements AutoCloseable {
+
+    private final PlotPlayer<?> player;
+    private final MetaDataKey<T> metaDataKey;
+    private final LockRepository.LockAccess lockAccess;
+
+    MetaDataAccess(@Nonnull final PlotPlayer<?> player, @Nonnull final MetaDataKey<T> metaDataKey,
+        @Nonnull final LockRepository.LockAccess lockAccess) {
+        this.player = player;
+        this.metaDataKey = metaDataKey;
+        this.lockAccess = lockAccess;
+    }
+
+    /**
+     * Check if the player has meta data stored with the given key
+     *
+     * @return {@code true} if player has meta data with this key, or
+     * {@code false}
+     */
+    public abstract boolean has();
+
+    /**
+     * Remove the stored value meta data
+     */
+    public abstract void remove();
+
+    /**
+     * Set the meta data value
+     *
+     * @param value New value
+     */
+    public abstract void set(@Nonnull final T value);
+
+    /**
+     * Get the stored meta data value
+     *
+     * @return Stored value, or {@link Optional#empty()}
+     */
+    @Nonnull public abstract Optional<T> get();
+
+    @Override public final void close() {
+        this.lockAccess.close();
+    }
+
+    /**
+     * Get the owner of the meta data
+     *
+     * @return Player
+     */
+    @Nonnull public PlotPlayer<?> getPlayer() {
+        return this.player;
+    }
+
+    /**
+     * Get the meta data key
+     *
+     * @return Meta data key
+     */
+    @Nonnull public MetaDataKey<T> getMetaDataKey() {
+        return this.metaDataKey;
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/player/MetaDataKey.java
+++ b/Core/src/main/java/com/plotsquared/core/player/MetaDataKey.java
@@ -27,6 +27,7 @@ package com.plotsquared.core.player;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import com.google.inject.TypeLiteral;
 import com.plotsquared.core.synchronization.LockKey;
 
 import javax.annotation.Nonnull;
@@ -44,10 +45,10 @@ public final class MetaDataKey<T> {
     private static final Object keyMetaData = new Object();
 
     private final String key;
-    private final Class<T> type;
+    private final TypeLiteral<T> type;
     private final LockKey lockKey;
 
-    private MetaDataKey(@Nonnull final String key, @Nonnull final Class<T> type) {
+    private MetaDataKey(@Nonnull final String key, @Nonnull final TypeLiteral<T> type) {
         this.key = Preconditions.checkNotNull(key, "Key may not be null");
         this.type = Preconditions.checkNotNull(type, "Type may not be null");
         this.lockKey = LockKey.of(this.key);
@@ -60,7 +61,7 @@ public final class MetaDataKey<T> {
      * @param <T> Type
      * @return MetaData key instance
      */
-    @Nonnull public static <T> MetaDataKey<T> of(@Nonnull final String key, @Nonnull final Class<T> type) {
+    @Nonnull public static <T> MetaDataKey<T> of(@Nonnull final String key, @Nonnull final TypeLiteral<T> type) {
         synchronized (keyMetaData) {
             return (MetaDataKey<T>)
                 keyMap.computeIfAbsent(key, missingKey -> new MetaDataKey<>(missingKey, type));
@@ -100,7 +101,7 @@ public final class MetaDataKey<T> {
      *
      * @return Meta data type
      */
-    @Nonnull public Class<T> getType() {
+    @Nonnull public TypeLiteral<T> getType() {
         return this.type;
     }
 

--- a/Core/src/main/java/com/plotsquared/core/player/MetaDataKey.java
+++ b/Core/src/main/java/com/plotsquared/core/player/MetaDataKey.java
@@ -1,0 +1,107 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.player;
+
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import com.plotsquared.core.synchronization.LockKey;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Key used to access meta data
+ *
+ * @param <T> Meta data type
+ */
+public final class MetaDataKey<T> {
+
+    private static final Map<String, MetaDataKey> keyMap = new HashMap<>();
+    private static final Object keyMetaData = new Object();
+
+    private final String key;
+    private final Class<T> type;
+    private final LockKey lockKey;
+
+    private MetaDataKey(@Nonnull final String key, @Nonnull final Class<T> type) {
+        this.key = Preconditions.checkNotNull(key, "Key may not be null");
+        this.type = Preconditions.checkNotNull(type, "Type may not be null");
+        this.lockKey = LockKey.of(this.key);
+    }
+
+    /**
+     * Get a new named lock key
+     *
+     * @param key Key name
+     * @param <T> Type
+     * @return MetaData key instance
+     */
+    @Nonnull public static <T> MetaDataKey<T> of(@Nonnull final String key, @Nonnull final Class<T> type) {
+        synchronized (keyMetaData) {
+            return (MetaDataKey<T>)
+                keyMap.computeIfAbsent(key, missingKey -> new MetaDataKey<>(missingKey, type));
+        }
+    }
+
+    @Override public String toString() {
+        return this.key;
+    }
+
+    @Override public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final MetaDataKey lockKey = (MetaDataKey) o;
+        return Objects.equal(this.key, lockKey.key);
+    }
+
+    @Override public int hashCode() {
+        return Objects.hashCode(this.key);
+    }
+
+    /**
+     * Get the {@link LockKey} associated with this key
+     *
+     * @return Lock key
+     */
+    @Nonnull public LockKey getLockKey() {
+        return this.lockKey;
+    }
+
+    /**
+     * Get the meta data type
+     *
+     * @return Meta data type
+     */
+    @Nonnull public Class<T> getType() {
+        return this.type;
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/player/PersistentMetaDataAccess.java
+++ b/Core/src/main/java/com/plotsquared/core/player/PersistentMetaDataAccess.java
@@ -39,11 +39,13 @@ final class PersistentMetaDataAccess<T> extends MetaDataAccess<T> {
         super(player, metaDataKey, lockAccess);
     }
 
-    @Override public boolean has() {
+    @Override public boolean isPresent() {
+        this.checkClosed();
         return this.getPlayer().hasPersistentMeta(getMetaDataKey().toString());
     }
 
     @Override @Nullable public T remove() {
+        this.checkClosed();
         final Object old = this.getPlayer().removePersistentMeta(this.getMetaDataKey().toString());
         if (old == null) {
             return null;
@@ -52,10 +54,12 @@ final class PersistentMetaDataAccess<T> extends MetaDataAccess<T> {
     }
 
     @Override public void set(@Nonnull T value) {
+        this.checkClosed();
         this.getPlayer().setPersistentMeta(this.getMetaDataKey(), value);
     }
 
     @Nonnull @Override public Optional<T> get() {
+        this.checkClosed();
         return Optional.ofNullable(this.getPlayer().getPersistentMeta(this.getMetaDataKey()));
     }
 

--- a/Core/src/main/java/com/plotsquared/core/player/PersistentMetaDataAccess.java
+++ b/Core/src/main/java/com/plotsquared/core/player/PersistentMetaDataAccess.java
@@ -1,0 +1,57 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.player;
+
+import com.plotsquared.core.synchronization.LockRepository;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+
+public final class PersistentMetaDataAccess<T> extends MetaDataAccess<T> {
+
+    PersistentMetaDataAccess(@Nonnull final PlotPlayer<?> player,
+                             @Nonnull final MetaDataKey<T> metaDataKey,
+                             @Nonnull final LockRepository.LockAccess lockAccess) {
+        super(player, metaDataKey, lockAccess);
+    }
+
+    @Override public boolean has() {
+        return this.getPlayer().hasPersistentMeta(getMetaDataKey().toString());
+    }
+
+    @Override public void remove() {
+        this.getPlayer().removePersistentMeta(this.getMetaDataKey().toString());
+    }
+
+    @Override public void set(@Nonnull T value) {
+        this.getPlayer().setPersistentMeta(this.getMetaDataKey(), value);
+    }
+
+    @Nonnull @Override public Optional<T> get() {
+        return Optional.ofNullable(this.getPlayer().getPersistentMeta(this.getMetaDataKey()));
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/player/PlayerMetaDataKeys.java
+++ b/Core/src/main/java/com/plotsquared/core/player/PlayerMetaDataKeys.java
@@ -25,10 +25,36 @@
  */
 package com.plotsquared.core.player;
 
+import com.google.inject.TypeLiteral;
+import com.plotsquared.core.command.Auto;
+import com.plotsquared.core.command.CmdInstance;
+import com.plotsquared.core.location.Location;
+import com.plotsquared.core.plot.Plot;
+import com.plotsquared.core.plot.PlotInventory;
+import com.plotsquared.core.setup.SetupProcess;
+
+import java.util.List;
+import java.util.Map;
+
 public final class PlayerMetaDataKeys {
 
-    public static final MetaDataKey<Boolean> PERSISTENT_FLIGHT = MetaDataKey.of("flight", Boolean.class);
-    public static final MetaDataKey<Integer> GRANTED_PLOTS = MetaDataKey.of("grantedPlots", Integer.class);
+    //@formatter:off
+    public static final MetaDataKey<Boolean> PERSISTENT_FLIGHT = MetaDataKey.of("flight", new TypeLiteral<Boolean>() {});
+    public static final MetaDataKey<Integer> PERSISTENT_GRANTED_PLOTS = MetaDataKey.of("grantedPlots", new TypeLiteral<Integer>() {});
+
+    public static final MetaDataKey<Plot> TEMPORARY_LAST_PLOT = MetaDataKey.of("lastplot", new TypeLiteral<Plot>() {});
+    public static final MetaDataKey<Location> TEMPORARY_MUSIC = MetaDataKey.of("music", new TypeLiteral<Location>() {});
+    public static final MetaDataKey<Boolean> TEMPORARY_KICK = MetaDataKey.of("kick", new TypeLiteral<Boolean>() {});
+    public static final MetaDataKey<SetupProcess> TEMPORARY_SETUP = MetaDataKey.of("setup", new TypeLiteral<SetupProcess>() {});
+    public static final MetaDataKey<PlotInventory> TEMPORARY_INVENTORY = MetaDataKey.of("inventory", new TypeLiteral<PlotInventory>() {});
+    public static final MetaDataKey<Boolean> TEMPORARY_IGNORE_EXPIRE_TASK = MetaDataKey.of("ignoreExpireTask", new TypeLiteral<Boolean>() {});
+    public static final MetaDataKey<Plot> TEMPORARY_WORLD_EDIT_REGION_PLOT = MetaDataKey.of("WorldEditRegionPlot", new TypeLiteral<Plot>() {});
+    public static final MetaDataKey<Boolean> TEMPORARY_AUTO = MetaDataKey.of(Auto.class.getName(), new TypeLiteral<Boolean>() {});
+    public static final MetaDataKey<Map<String, Boolean>> TEMPORARY_PERMISSIONS = MetaDataKey.of("permissions", new TypeLiteral<Map<String, Boolean>>() {});
+    public static final MetaDataKey<List<String>> TEMPORARY_SCHEMATICS = MetaDataKey.of("plot_schematics", new TypeLiteral<List<String>>() {});
+    public static final MetaDataKey<Location> TEMPORARY_LOCATION = MetaDataKey.of("location", new TypeLiteral<Location>() {});
+    public static final MetaDataKey<CmdInstance> TEMPORARY_CONFIRM = MetaDataKey.of("cmdConfirm", new TypeLiteral<CmdInstance>() {});
+    //@formatter:on
 
     private PlayerMetaDataKeys() {
     }

--- a/Core/src/main/java/com/plotsquared/core/player/PlayerMetaDataKeys.java
+++ b/Core/src/main/java/com/plotsquared/core/player/PlayerMetaDataKeys.java
@@ -1,0 +1,36 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.player;
+
+public final class PlayerMetaDataKeys {
+
+    public static final MetaDataKey<Boolean> PERSISTENT_FLIGHT = MetaDataKey.of("flight", Boolean.class);
+    public static final MetaDataKey<Integer> GRANTED_PLOTS = MetaDataKey.of("grantedPlots", Integer.class);
+
+    private PlayerMetaDataKeys() {
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
+++ b/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
@@ -758,10 +758,11 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer 
 
     <T> void setPersistentMeta(@Nonnull final MetaDataKey<T> key,
                                @Nonnull final T value) {
+        final Object rawValue = value;
         if (key.getType().equals(Integer.class)) {
-            this.setPersistentMeta(key.toString(), Ints.toByteArray((int) value));
+            this.setPersistentMeta(key.toString(), Ints.toByteArray((int) rawValue));
         } else if (key.getType().equals(Boolean.class)) {
-            this.setPersistentMeta(key.toString(), ByteArrayUtilities.booleanToBytes((boolean) value));
+            this.setPersistentMeta(key.toString(), ByteArrayUtilities.booleanToBytes((boolean) rawValue));
         } else {
             throw new IllegalArgumentException(String.format("Unknown meta data type '%s'", key.getType().getSimpleName()));
         }

--- a/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
+++ b/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
@@ -836,6 +836,15 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer 
         }
     }
 
+    /**
+     * Get this player's {@link LockRepository}
+     *
+     * @return Lock repository instance
+     */
+    @Nonnull public LockRepository getLockRepository() {
+        return this.lockRepository;
+    }
+
     @FunctionalInterface
     public interface PlotPlayerConverter<BaseObject> {
         PlotPlayer<?> convert(BaseObject object);

--- a/Core/src/main/java/com/plotsquared/core/player/TemporaryMetaDataAccess.java
+++ b/Core/src/main/java/com/plotsquared/core/player/TemporaryMetaDataAccess.java
@@ -31,20 +31,20 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Optional;
 
-final class PersistentMetaDataAccess<T> extends MetaDataAccess<T> {
+final class TemporaryMetaDataAccess<T> extends MetaDataAccess<T> {
 
-    PersistentMetaDataAccess(@Nonnull final PlotPlayer<?> player,
-                             @Nonnull final MetaDataKey<T> metaDataKey,
-                             @Nonnull final LockRepository.LockAccess lockAccess) {
+    TemporaryMetaDataAccess(@Nonnull final PlotPlayer<?> player,
+                            @Nonnull final MetaDataKey<T> metaDataKey,
+                            @Nonnull final LockRepository.LockAccess lockAccess) {
         super(player, metaDataKey, lockAccess);
     }
 
     @Override public boolean has() {
-        return this.getPlayer().hasPersistentMeta(getMetaDataKey().toString());
+        return this.getPlayer().getMeta(this.getMetaDataKey().toString()) != null;
     }
 
     @Override @Nullable public T remove() {
-        final Object old = this.getPlayer().removePersistentMeta(this.getMetaDataKey().toString());
+        final Object old = getPlayer().deleteMeta(this.getMetaDataKey().toString());
         if (old == null) {
             return null;
         }
@@ -52,11 +52,11 @@ final class PersistentMetaDataAccess<T> extends MetaDataAccess<T> {
     }
 
     @Override public void set(@Nonnull T value) {
-        this.getPlayer().setPersistentMeta(this.getMetaDataKey(), value);
+        this.getPlayer().setMeta(this.getMetaDataKey().toString(), null);
     }
 
     @Nonnull @Override public Optional<T> get() {
-        return Optional.ofNullable(this.getPlayer().getPersistentMeta(this.getMetaDataKey()));
+        return Optional.ofNullable(this.getPlayer().getMeta(this.getMetaDataKey().toString()));
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/player/TemporaryMetaDataAccess.java
+++ b/Core/src/main/java/com/plotsquared/core/player/TemporaryMetaDataAccess.java
@@ -39,11 +39,13 @@ final class TemporaryMetaDataAccess<T> extends MetaDataAccess<T> {
         super(player, metaDataKey, lockAccess);
     }
 
-    @Override public boolean has() {
+    @Override public boolean isPresent() {
+        this.checkClosed();
         return this.getPlayer().getMeta(this.getMetaDataKey().toString()) != null;
     }
 
     @Override @Nullable public T remove() {
+        this.checkClosed();
         final Object old = getPlayer().deleteMeta(this.getMetaDataKey().toString());
         if (old == null) {
             return null;
@@ -52,10 +54,12 @@ final class TemporaryMetaDataAccess<T> extends MetaDataAccess<T> {
     }
 
     @Override public void set(@Nonnull T value) {
+        this.checkClosed();
         this.getPlayer().setMeta(this.getMetaDataKey().toString(), null);
     }
 
     @Nonnull @Override public Optional<T> get() {
+        this.checkClosed();
         return Optional.ofNullable(this.getPlayer().getMeta(this.getMetaDataKey().toString()));
     }
 

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
@@ -42,6 +42,8 @@ import com.plotsquared.core.inject.annotations.WorldConfig;
 import com.plotsquared.core.location.Direction;
 import com.plotsquared.core.location.Location;
 import com.plotsquared.core.location.PlotLoc;
+import com.plotsquared.core.player.MetaDataAccess;
+import com.plotsquared.core.player.PlayerMetaDataKeys;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.flag.FlagContainer;
 import com.plotsquared.core.plot.flag.FlagParseException;
@@ -787,8 +789,11 @@ public abstract class PlotArea {
     }
 
     public boolean addPlot(@Nonnull final Plot plot) {
-        for (PlotPlayer pp : plot.getPlayersInPlot()) {
-            pp.setMeta(PlotPlayer.META_LAST_PLOT, plot);
+        for (final PlotPlayer<?> pp : plot.getPlayersInPlot()) {
+            try (final MetaDataAccess<Plot> metaDataAccess = pp.accessTemporaryMetaData(
+                PlayerMetaDataKeys.TEMPORARY_LAST_PLOT)) {
+                metaDataAccess.set(plot);
+            }
         }
         return this.plots.put(plot.getId(), plot) == null;
     }
@@ -826,8 +831,11 @@ public abstract class PlotArea {
 
     public boolean addPlotIfAbsent(@Nonnull final Plot plot) {
         if (this.plots.putIfAbsent(plot.getId(), plot) == null) {
-            for (PlotPlayer pp : plot.getPlayersInPlot()) {
-                pp.setMeta(PlotPlayer.META_LAST_PLOT, plot);
+            for (PlotPlayer<?> pp : plot.getPlayersInPlot()) {
+                try (final MetaDataAccess<Plot> metaDataAccess = pp.accessTemporaryMetaData(
+                    PlayerMetaDataKeys.TEMPORARY_LAST_PLOT)) {
+                    metaDataAccess.set(plot);
+                }
             }
             return true;
         }

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotInventory.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotInventory.java
@@ -25,18 +25,19 @@
  */
 package com.plotsquared.core.plot;
 
+import com.plotsquared.core.player.MetaDataAccess;
+import com.plotsquared.core.player.PlayerMetaDataKeys;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.util.InventoryUtil;
-
-import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
 
 public class PlotInventory {
 
     private static final Logger logger = LoggerFactory.getLogger("P2/" + PlotInventory.class.getSimpleName());
 
-    private static final String META_KEY = "inventory";
     public final PlotPlayer<?> player;
     public final int size;
     private final PlotItemStack[] items;
@@ -58,16 +59,25 @@ public class PlotInventory {
     }
 
     public static PlotInventory getOpenPlotInventory(@Nonnull final PlotPlayer<?> plotPlayer) {
-        return plotPlayer.getMeta(META_KEY, null);
+        try (final MetaDataAccess<PlotInventory> inventoryAccess = plotPlayer.accessTemporaryMetaData(
+            PlayerMetaDataKeys.TEMPORARY_INVENTORY)) {
+            return inventoryAccess.get().orElse(null);
+        }
     }
 
     public static void setPlotInventoryOpen(@Nonnull final PlotPlayer<?> plotPlayer,
         @Nonnull final PlotInventory plotInventory) {
-        plotPlayer.setMeta(META_KEY, plotInventory);
+        try (final MetaDataAccess<PlotInventory> inventoryAccess = plotPlayer.accessTemporaryMetaData(
+            PlayerMetaDataKeys.TEMPORARY_INVENTORY)) {
+            inventoryAccess.set(plotInventory);
+        }
     }
 
     public static void removePlotInventoryOpen(@Nonnull final PlotPlayer<?>plotPlayer) {
-        plotPlayer.deleteMeta(META_KEY);
+        try (final MetaDataAccess<PlotInventory> inventoryAccess = plotPlayer.accessTemporaryMetaData(
+            PlayerMetaDataKeys.TEMPORARY_INVENTORY)) {
+            inventoryAccess.remove();
+        }
     }
 
     public boolean onClick(int index) {

--- a/Core/src/main/java/com/plotsquared/core/plot/comment/CommentManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/comment/CommentManager.java
@@ -26,8 +26,11 @@
 package com.plotsquared.core.plot.comment;
 
 import com.google.common.annotations.Beta;
+import com.google.inject.TypeLiteral;
 import com.plotsquared.core.configuration.Captions;
 import com.plotsquared.core.configuration.Settings;
+import com.plotsquared.core.player.MetaDataAccess;
+import com.plotsquared.core.player.MetaDataKey;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.util.task.RunnableVal;
@@ -77,7 +80,10 @@ import java.util.concurrent.atomic.AtomicInteger;
     }
 
     public static long getTimestamp(PlotPlayer<?> player, String inbox) {
-        return player.getMeta("inbox:" + inbox, player.getLastPlayed());
+        final MetaDataKey<Long> inboxKey = MetaDataKey.of(String.format("inbox:%s", inbox), new TypeLiteral<Long>() {});
+        try (final MetaDataAccess<Long> inboxAccess = player.accessTemporaryMetaData(inboxKey)) {
+            return inboxAccess.get().orElse(player.getLastPlayed());
+        }
     }
 
     public static void addInbox(CommentInbox inbox) {

--- a/Core/src/main/java/com/plotsquared/core/plot/expiration/ExpireManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/expiration/ExpireManager.java
@@ -142,7 +142,7 @@ public class ExpireManager {
     public void confirmExpiry(final PlotPlayer<?> pp) {
         try (final MetaDataAccess<Boolean> metaDataAccess = pp.accessTemporaryMetaData(
             PlayerMetaDataKeys.TEMPORARY_IGNORE_EXPIRE_TASK)) {
-            if (metaDataAccess.has()) {
+            if (metaDataAccess.isPresent()) {
                 return;
             }
             if (plotsToDelete != null && !plotsToDelete.isEmpty() && pp.hasPermission("plots.admin.command.autoclear")) {

--- a/Core/src/main/java/com/plotsquared/core/setup/CommonSetupSteps.java
+++ b/Core/src/main/java/com/plotsquared/core/setup/CommonSetupSteps.java
@@ -30,6 +30,8 @@ import com.plotsquared.core.configuration.Caption;
 import com.plotsquared.core.configuration.Captions;
 import com.plotsquared.core.events.TeleportCause;
 import com.plotsquared.core.generator.GeneratorWrapper;
+import com.plotsquared.core.player.MetaDataAccess;
+import com.plotsquared.core.player.PlayerMetaDataKeys;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.plot.PlotAreaTerrainType;
@@ -221,7 +223,10 @@ public enum CommonSetupSteps implements SetupStep {
                 MainUtil.sendMessage(plotPlayer, Captions.SETUP_WORLD_APPLY_PLOTSQUARED);
             }
             builder.worldName(argument);
-            plotPlayer.deleteMeta("setup");
+            try (final MetaDataAccess<SetupProcess> setupAccess = plotPlayer.accessTemporaryMetaData(
+                PlayerMetaDataKeys.TEMPORARY_SETUP)) {
+                setupAccess.remove();
+            }
             String world;
             if (builder.setupManager() == null) {
                 world = PlotSquared.platform().getInjector().getInstance(SetupUtils.class).setupWorld(builder);

--- a/Core/src/main/java/com/plotsquared/core/synchronization/LockKey.java
+++ b/Core/src/main/java/com/plotsquared/core/synchronization/LockKey.java
@@ -1,0 +1,92 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.synchronization;
+
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Key used to access {@link java.util.concurrent.locks.Lock locks}
+ * from a {@link LockRepository}
+ */
+public final class LockKey {
+
+    private static final Map<String, LockKey> keyMap = new HashMap<>();
+    private static final Object keyLock = new Object();
+
+    private final String key;
+
+    private LockKey(@Nonnull final String key) {
+        this.key = Preconditions.checkNotNull(key, "Key may not be null");
+    }
+
+    /**
+     * Get a new named lock key
+     *
+     * @param key Key name
+     * @return Lock key instance
+     */
+    @Nonnull public static LockKey of(@Nonnull final String key) {
+        synchronized (keyLock) {
+            return keyMap.computeIfAbsent(key, LockKey::new);
+        }
+    }
+
+    /**
+     * Get all currently recognized lock keys
+     *
+     * @return Currently recognized lock keys
+     */
+    @Nonnull static Collection<LockKey> recognizedKeys() {
+        return Collections.unmodifiableCollection(keyMap.values());
+    }
+
+    @Override public String toString() {
+        return "LockKey{" + "key='" + key + '\'' + '}';
+    }
+
+    @Override public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final LockKey lockKey = (LockKey) o;
+        return Objects.equal(this.key, lockKey.key);
+    }
+
+    @Override public int hashCode() {
+        return Objects.hashCode(this.key);
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/synchronization/LockRepository.java
+++ b/Core/src/main/java/com/plotsquared/core/synchronization/LockRepository.java
@@ -1,0 +1,116 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.synchronization;
+
+import com.google.common.util.concurrent.Striped;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.locks.Lock;
+import java.util.function.Consumer;
+
+/**
+ * A repository for keyed {@link java.util.concurrent.locks.Lock locks}
+ */
+public final class LockRepository {
+
+    private final Striped<Lock> striped;
+
+    public LockRepository() {
+        this.striped = Striped.lock(LockKey.recognizedKeys().size());
+    }
+
+    /**
+     * Get the lock corresponding to the given lock key
+     *
+     * @param key Lock key
+     * @return Lock
+     */
+    @Nonnull public Lock getLock(@Nonnull final LockKey key) {
+        return this.striped.get(key);
+    }
+
+    /**
+     * Consume a lock
+     *
+     * @param key      Lock key
+     * @param consumer Lock consumer
+     */
+    public void useLock(@Nonnull final LockKey key, @Nonnull final Consumer<Lock> consumer) {
+        consumer.accept(this.getLock(key));
+    }
+
+    /**
+     * Wait for the lock to become available, and run
+     * the given runnable, then unlock the lock. This is
+     * a blocking method.
+     *
+     * @param key      Lock key
+     * @param runnable Action to run when the lock is available
+     */
+    public void useLock(@Nonnull final LockKey key, @Nonnull final Runnable runnable) {
+        this.useLock(key, lock -> {
+            lock.lock();
+            runnable.run();
+            lock.unlock();
+        });
+    }
+
+    /**
+     * Wait for a lock to be available, lock it and return
+     * an {@link AutoCloseable} instance that locks the key.
+     * <p>
+     * This is meant to be used with try-with-resources, like such:
+     * <pre>{@code
+     * try (final LockAccess lockAccess = lockRepository.lock(LockKey.of("your.key"))) {
+     *      // use lock
+     * }
+     * }</pre>
+     *
+     * @param key Lock key
+     * @return Lock access. Must be closed.
+     */
+    @Nonnull public LockAccess lock(@Nonnull final LockKey key) {
+        final Lock lock = this.getLock(key);
+        lock.lock();
+        return new LockAccess(lock);
+    }
+
+
+    public static class LockAccess implements AutoCloseable {
+
+        private final Lock lock;
+
+        private LockAccess(@Nonnull final Lock lock) {
+            this.lock = lock;
+        }
+
+        @Override public void close() {
+            this.lock.unlock();
+        }
+
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/util/ChunkUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/ChunkUtil.java
@@ -1,3 +1,28 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2020 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.plotsquared.core.util;
 
 import lombok.experimental.UtilityClass;

--- a/Core/src/main/java/com/plotsquared/core/util/WEManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/WEManager.java
@@ -28,6 +28,8 @@ package com.plotsquared.core.util;
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.location.Location;
+import com.plotsquared.core.player.MetaDataAccess;
+import com.plotsquared.core.player.PlayerMetaDataKeys;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
@@ -100,19 +102,22 @@ public class WEManager {
         }
         boolean allowMember = player.hasPermission("plots.worldedit.member");
         Plot plot = player.getCurrentPlot();
-        if (plot == null) {
-            plot = player.getMeta("WorldEditRegionPlot");
-        }
-        if (plot != null && (!Settings.Done.RESTRICT_BUILDING || !DoneFlag.isDone(plot)) && (
-            (allowMember && plot.isAdded(uuid)) || (!allowMember && (plot.isOwner(uuid)) || plot
-                .getTrusted().contains(uuid))) && !plot.getFlag(NoWorldeditFlag.class)) {
-            for (CuboidRegion region : plot.getRegions()) {
-                BlockVector3 pos1 = region.getMinimumPoint().withY(area.getMinBuildHeight());
-                BlockVector3 pos2 = region.getMaximumPoint().withY(area.getMaxBuildHeight());
-                CuboidRegion copy = new CuboidRegion(pos1, pos2);
-                regions.add(copy);
+        try (final MetaDataAccess<Plot> metaDataAccess =
+            player.accessTemporaryMetaData(PlayerMetaDataKeys.TEMPORARY_WORLD_EDIT_REGION_PLOT)) {
+            if (plot == null) {
+                plot = metaDataAccess.get().orElse(null);
             }
-            player.setMeta("WorldEditRegionPlot", plot);
+            if (plot != null && (!Settings.Done.RESTRICT_BUILDING || !DoneFlag.isDone(plot)) && (
+                (allowMember && plot.isAdded(uuid)) || (!allowMember && (plot.isOwner(uuid)) || plot
+                    .getTrusted().contains(uuid))) && !plot.getFlag(NoWorldeditFlag.class)) {
+                for (CuboidRegion region : plot.getRegions()) {
+                    BlockVector3 pos1 = region.getMinimumPoint().withY(area.getMinBuildHeight());
+                    BlockVector3 pos2 = region.getMaximumPoint().withY(area.getMaxBuildHeight());
+                    CuboidRegion copy = new CuboidRegion(pos1, pos2);
+                    regions.add(copy);
+                }
+                metaDataAccess.set(plot);
+            }
         }
         return regions;
     }

--- a/Core/src/main/java/com/plotsquared/core/util/task/AutoClaimFinishTask.java
+++ b/Core/src/main/java/com/plotsquared/core/util/task/AutoClaimFinishTask.java
@@ -30,6 +30,8 @@ import com.plotsquared.core.configuration.Captions;
 import com.plotsquared.core.events.PlotMergeEvent;
 import com.plotsquared.core.events.Result;
 import com.plotsquared.core.location.Direction;
+import com.plotsquared.core.player.MetaDataAccess;
+import com.plotsquared.core.player.PlayerMetaDataKeys;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
@@ -50,7 +52,10 @@ public final class AutoClaimFinishTask implements Callable<Boolean> {
     private final EventDispatcher eventDispatcher;
 
     @Override public Boolean call() {
-        player.deleteMeta(Auto.class.getName());
+        try (final MetaDataAccess<Boolean> autoAccess
+            = player.accessTemporaryMetaData(PlayerMetaDataKeys.TEMPORARY_AUTO)) {
+            autoAccess.remove();
+        }
         if (plot == null) {
             sendMessage(player, Captions.NO_FREE_PLOTS);
             return false;


### PR DESCRIPTION
This PR introduces a new per-object lock repository system, which is then used in PlotPlayer to provide managed access to persistent and temporary meta data.

This allows for thread safe access to meta data through a MetaDataAccess class, which manages a lock. No two classes can access the same meta data for the same player, at once.

What is left to do (in a separate PR) is to improve the persistent meta data serialization, because the types are currently hardcoded in the get/set methods in PlotPlayer. This will be done in a separate PR, to keep the diff more relevant to the topic.

Addendum: This now also fixes an issue where `/plot grant` would use the calling player's grant count, instead of the target's grant count, when adding new grants.