### PR TITLE
Fix problem with config creation

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/PlotSquared.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotSquared.java
@@ -1735,10 +1735,11 @@ public class PlotSquared {
 
             if (this.worlds.contains("worlds")) {
                 if (!this.worlds.contains("configuration_version") || (
-                    !this.worlds.getString("configuration_version")
-                        .equalsIgnoreCase(LegacyConverter.CONFIGURATION_VERSION) && !this.worlds
-                        .getString("configuration_version").equalsIgnoreCase("v5"))) {
-                    // Conversion needed
+                    !this.worlds.getString("configuration_version").equalsIgnoreCase(LegacyConverter.CONFIGURATION_VERSION) &&
+                    !this.worlds.getString("configuration_version").equalsIgnoreCase("v5"))) {
+                    // This means that the server is updating from version 3 to version 5. For this to be possible,
+                    // it must first go through v3->v4 (post_flattening), then on next restart
+                    // it must do v4 (post_flattening) -> v5
                     log(Captions.LEGACY_CONFIG_FOUND.getTranslated());
                     try {
                         com.google.common.io.Files
@@ -1760,7 +1761,9 @@ public class PlotSquared {
                     return false;
                 }
             } else {
-                this.worlds.set("configuration_version", LegacyConverter.CONFIGURATION_VERSION);
+                // If the server does not have a worlds section in their
+                // worlds.yml, we assume they generated their database using v5
+                this.setConfigurationVersion("v5");
             }
         } catch (IOException ignored) {
             PlotSquared.log("Failed to save settings.yml");


### PR DESCRIPTION
This fixes an issue where PlotSquared would try to convert databases created in v5 from v4 to v5, which obviously fails, because they never used v4.

This is a quite major issue and I hope this fix resolves it. Although, it should be tested with migration from v4 to v5 and then a fresh v5 server.