### PR TITLE
Added UseFlag check at Roads

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
+++ b/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
@@ -279,6 +279,12 @@ public class EventDispatcher {
                 return true;
             case INTERACT_BLOCK: {
                 if (plot == null) {
+                    final List<BlockTypeWrapper> use = area.getRoadFlag(UseFlag.class);
+                    for(final BlockTypeWrapper blockTypeWrapper : use) {
+                        if (blockTypeWrapper.accepts(BlockTypes.AIR) || blockTypeWrapper.accepts(blockType)) {
+                            return true;
+                        }
+                    }
                     return Permissions.hasPermission(player,
                         Captions.PERMISSION_ADMIN_INTERACT_ROAD.getTranslated(), notifyPerms);
                 }
@@ -301,6 +307,12 @@ public class EventDispatcher {
             }
             case TRIGGER_PHYSICAL: {
                 if (plot == null) {
+                    final List<BlockTypeWrapper> use = area.getRoadFlag(UseFlag.class);
+                    for(final BlockTypeWrapper blockTypeWrapper : use) {
+                        if (blockTypeWrapper.accepts(BlockTypes.AIR) || blockTypeWrapper.accepts(blockType)) {
+                            return true;
+                        }
+                    }
                     return Permissions.hasPermission(player,
                         Captions.PERMISSION_ADMIN_INTERACT_ROAD.getTranslated(), false);
                 }


### PR DESCRIPTION
## Overview
When configuring the "worlds.yml"-config, there is the option "worlds.<world_name>.road.flags".
According to the wiki it should represent the flags on the road, so that's what i implemented.

**Fixes https://issues.intellectualsites.com/issue/PS-95**

## Description

## Checklist
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v5/CONTRIBUTING.md)
