### PR TITLE
[Bugfix] No chat message confirmation on /p add /p trust, etc.

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Deny.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Deny.java
@@ -35,11 +35,11 @@ import com.plotsquared.core.util.MainUtil;
 import com.plotsquared.core.util.Permissions;
 import com.plotsquared.core.util.TabCompletions;
 import com.plotsquared.core.util.WorldUtil;
+import com.plotsquared.core.uuid.UUIDMapping;
 import com.sk89q.worldedit.world.gamemode.GameModes;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
 @CommandDeclaration(command = "deny",
@@ -77,26 +77,26 @@ public class Deny extends SubCommand {
             } else if (throwable != null || uuids.isEmpty()) {
                 MainUtil.sendMessage(player, Captions.INVALID_PLAYER, args[0]);
             } else {
-                for (UUID uuid : uuids) {
-                    if (uuid == DBFunc.EVERYONE && !(
+                for (UUIDMapping uuidMapping : uuids) {
+                    if (uuidMapping.getUuid() == DBFunc.EVERYONE && !(
                         Permissions.hasPermission(player, Captions.PERMISSION_DENY_EVERYONE) || Permissions
                             .hasPermission(player, Captions.PERMISSION_ADMIN_COMMAND_DENY))) {
-                        MainUtil.sendMessage(player, Captions.INVALID_PLAYER, MainUtil.getName(uuid));
-                    } else if (plot.isOwner(uuid)) {
-                        MainUtil.sendMessage(player, Captions.CANT_REMOVE_OWNER, MainUtil.getName(uuid));
+                        MainUtil.sendMessage(player, Captions.INVALID_PLAYER, uuidMapping.getUsername());
+                    } else if (plot.isOwner(uuidMapping.getUuid())) {
+                        MainUtil.sendMessage(player, Captions.CANT_REMOVE_OWNER, uuidMapping.getUsername());
                         return;
-                    } else if (plot.getDenied().contains(uuid)) {
-                        MainUtil.sendMessage(player, Captions.ALREADY_ADDED, MainUtil.getName(uuid));
+                    } else if (plot.getDenied().contains(uuidMapping.getUuid())) {
+                        MainUtil.sendMessage(player, Captions.ALREADY_ADDED, uuidMapping.getUsername());
                         return;
                     } else {
-                        if (uuid != DBFunc.EVERYONE) {
-                            plot.removeMember(uuid);
-                            plot.removeTrusted(uuid);
+                        if (uuidMapping.getUuid() != DBFunc.EVERYONE) {
+                            plot.removeMember(uuidMapping.getUuid());
+                            plot.removeTrusted(uuidMapping.getUuid());
                         }
-                        plot.addDenied(uuid);
-                        PlotSquared.get().getEventDispatcher().callDenied(player, plot, uuid, true);
-                        if (!uuid.equals(DBFunc.EVERYONE)) {
-                            handleKick(PlotSquared.imp().getPlayerManager().getPlayerIfExists(uuid), plot);
+                        plot.addDenied(uuidMapping.getUuid());
+                        PlotSquared.get().getEventDispatcher().callDenied(player, plot, uuidMapping.getUuid(), true);
+                        if (!uuidMapping.equals(DBFunc.EVERYONE)) {
+                            handleKick(PlotSquared.imp().getPlayerManager().getPlayerIfExists(uuidMapping.getUuid()), plot);
                         } else {
                             for (PlotPlayer plotPlayer : plot.getPlayersInPlot()) {
                                 // Ignore plot-owners

--- a/Core/src/main/java/com/plotsquared/core/command/Kick.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Kick.java
@@ -35,12 +35,12 @@ import com.plotsquared.core.util.MainUtil;
 import com.plotsquared.core.util.Permissions;
 import com.plotsquared.core.util.TabCompletions;
 import com.plotsquared.core.util.WorldUtil;
+import com.plotsquared.core.uuid.UUIDMapping;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
 @CommandDeclaration(command = "kick",
@@ -75,8 +75,8 @@ public class Kick extends SubCommand {
                 MainUtil.sendMessage(player, Captions.INVALID_PLAYER, args[0]);
             } else {
                 Set<PlotPlayer<?>> players = new HashSet<>();
-                for (UUID uuid : uuids) {
-                    if (uuid == DBFunc.EVERYONE) {
+                for (UUIDMapping uuidMapping : uuids) {
+                    if (uuidMapping.getUuid() == DBFunc.EVERYONE) {
                         for (PlotPlayer<?> pp : plot.getPlayersInPlot()) {
                             if (pp == player || Permissions
                                 .hasPermission(pp, Captions.PERMISSION_ADMIN_ENTRY_DENIED)) {
@@ -86,7 +86,7 @@ public class Kick extends SubCommand {
                         }
                         continue;
                     }
-                    PlotPlayer<?> pp = PlotSquared.imp().getPlayerManager().getPlayerIfExists(uuid);
+                    PlotPlayer<?> pp = PlotSquared.imp().getPlayerManager().getPlayerIfExists(uuidMapping.getUuid());
                     if (pp != null) {
                         players.add(pp);
                     }

--- a/Core/src/main/java/com/plotsquared/core/command/Remove.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Remove.java
@@ -34,10 +34,10 @@ import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.util.MainUtil;
 import com.plotsquared.core.util.Permissions;
 import com.plotsquared.core.util.TabCompletions;
+import com.plotsquared.core.uuid.UUIDMapping;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
 @CommandDeclaration(command = "remove",
@@ -78,37 +78,37 @@ public class Remove extends SubCommand {
                 MainUtil.sendMessage(player, Captions.INVALID_PLAYER, args[0]);
                 return;
             } else if (!uuids.isEmpty()) {
-                for (UUID uuid : uuids) {
-                    if (plot.getTrusted().contains(uuid)) {
-                        if (plot.removeTrusted(uuid)) {
+                for (UUIDMapping uuidMapping : uuids) {
+                    if (plot.getTrusted().contains(uuidMapping.getUuid())) {
+                        if (plot.removeTrusted(uuidMapping.getUuid())) {
                             PlotSquared.get().getEventDispatcher()
-                                .callTrusted(player, plot, uuid, false);
+                                .callTrusted(player, plot, uuidMapping.getUuid(), false);
                             count++;
                         }
-                    } else if (plot.getMembers().contains(uuid)) {
-                        if (plot.removeMember(uuid)) {
+                    } else if (plot.getMembers().contains(uuidMapping.getUuid())) {
+                        if (plot.removeMember(uuidMapping.getUuid())) {
                             PlotSquared.get().getEventDispatcher()
-                                .callMember(player, plot, uuid, false);
+                                .callMember(player, plot, uuidMapping.getUuid(), false);
                             count++;
                         }
-                    } else if (plot.getDenied().contains(uuid)) {
-                        if (plot.removeDenied(uuid)) {
+                    } else if (plot.getDenied().contains(uuidMapping.getUuid())) {
+                        if (plot.removeDenied(uuidMapping.getUuid())) {
                             PlotSquared.get().getEventDispatcher()
-                                .callDenied(player, plot, uuid, false);
+                                .callDenied(player, plot, uuidMapping.getUuid(), false);
                             count++;
                         }
-                    } else if (uuid == DBFunc.EVERYONE) {
-                        if (plot.removeTrusted(uuid)) {
+                    } else if (uuidMapping.getUuid() == DBFunc.EVERYONE) {
+                        if (plot.removeTrusted(uuidMapping.getUuid())) {
                             PlotSquared.get().getEventDispatcher()
-                                .callTrusted(player, plot, uuid, false);
+                                .callTrusted(player, plot, uuidMapping.getUuid(), false);
                             count++;
-                        } else if (plot.removeMember(uuid)) {
+                        } else if (plot.removeMember(uuidMapping.getUuid())) {
                             PlotSquared.get().getEventDispatcher()
-                                .callMember(player, plot, uuid, false);
+                                .callMember(player, plot, uuidMapping.getUuid(), false);
                             count++;
-                        } else if (plot.removeDenied(uuid)) {
+                        } else if (plot.removeDenied(uuidMapping.getUuid())) {
                             PlotSquared.get().getEventDispatcher()
-                                .callDenied(player, plot, uuid, false);
+                                .callDenied(player, plot, uuidMapping.getUuid(), false);
                             count++;
                         }
                     }

--- a/Core/src/main/java/com/plotsquared/core/command/Trust.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Trust.java
@@ -35,11 +35,11 @@ import com.plotsquared.core.util.Permissions;
 import com.plotsquared.core.util.TabCompletions;
 import com.plotsquared.core.util.task.RunnableVal2;
 import com.plotsquared.core.util.task.RunnableVal3;
+import com.plotsquared.core.uuid.UUIDMapping;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
@@ -81,28 +81,28 @@ public class Trust extends Command {
                 return;
             } else {
                 checkTrue(!uuids.isEmpty(), Captions.INVALID_PLAYER, args[0]);
-                Iterator<UUID> iterator = uuids.iterator();
+                Iterator<UUIDMapping> iterator = uuids.iterator();
                 int size = currentPlot.getTrusted().size() + currentPlot.getMembers().size();
                 while (iterator.hasNext()) {
-                    UUID uuid = iterator.next();
-                    if (uuid == DBFunc.EVERYONE && !(
+                    UUIDMapping uuidMapping = iterator.next();
+                    if (uuidMapping.getUuid() == DBFunc.EVERYONE && !(
                         Permissions.hasPermission(player, Captions.PERMISSION_TRUST_EVERYONE) || Permissions
                             .hasPermission(player, Captions.PERMISSION_ADMIN_COMMAND_TRUST))) {
-                        MainUtil.sendMessage(player, Captions.INVALID_PLAYER, MainUtil.getName(uuid));
+                        MainUtil.sendMessage(player, Captions.INVALID_PLAYER, uuidMapping.getUsername());
                         iterator.remove();
                         continue;
                     }
-                    if (currentPlot.isOwner(uuid)) {
-                        MainUtil.sendMessage(player, Captions.ALREADY_ADDED, MainUtil.getName(uuid));
+                    if (currentPlot.isOwner(uuidMapping.getUuid())) {
+                        MainUtil.sendMessage(player, Captions.ALREADY_ADDED, uuidMapping.getUsername());
                         iterator.remove();
                         continue;
                     }
-                    if (currentPlot.getTrusted().contains(uuid)) {
-                        MainUtil.sendMessage(player, Captions.ALREADY_ADDED, MainUtil.getName(uuid));
+                    if (currentPlot.getTrusted().contains(uuidMapping.getUuid())) {
+                        MainUtil.sendMessage(player, Captions.ALREADY_ADDED, uuidMapping.getUsername());
                         iterator.remove();
                         continue;
                     }
-                    size += currentPlot.getMembers().contains(uuid) ? 0 : 1;
+                    size += currentPlot.getMembers().contains(uuidMapping.getUuid()) ? 0 : 1;
                 }
                 checkTrue(!uuids.isEmpty(), null);
                 checkTrue(size <= currentPlot.getArea().getMaxPlotMembers() || Permissions
@@ -110,16 +110,16 @@ public class Trust extends Command {
                     Captions.PLOT_MAX_MEMBERS);
                 // Success
                 confirm.run(this, () -> {
-                    for (UUID uuid : uuids) {
-                        if (uuid != DBFunc.EVERYONE) {
-                            if (!currentPlot.removeMember(uuid)) {
-                                if (currentPlot.getDenied().contains(uuid)) {
-                                    currentPlot.removeDenied(uuid);
+                    for (UUIDMapping uuidMapping : uuids) {
+                        if (uuidMapping.getUuid() != DBFunc.EVERYONE) {
+                            if (!currentPlot.removeMember(uuidMapping.getUuid())) {
+                                if (currentPlot.getDenied().contains(uuidMapping.getUuid())) {
+                                    currentPlot.removeDenied(uuidMapping.getUuid());
                                 }
                             }
                         }
-                        currentPlot.addTrusted(uuid);
-                        PlotSquared.get().getEventDispatcher().callTrusted(player, currentPlot, uuid, true);
+                        currentPlot.addTrusted(uuidMapping.getUuid());
+                        PlotSquared.get().getEventDispatcher().callTrusted(player, currentPlot, uuidMapping.getUuid(), true);
                         MainUtil.sendMessage(player, Captions.TRUSTED_ADDED);
                     }
                 }, null);

--- a/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
+++ b/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
@@ -279,6 +279,12 @@ public class EventDispatcher {
                 return true;
             case INTERACT_BLOCK: {
                 if (plot == null) {
+                    final List<BlockTypeWrapper> use = area.getRoadFlag(UseFlag.class);
+                    for(final BlockTypeWrapper blockTypeWrapper : use) {
+                        if (blockTypeWrapper.accepts(BlockTypes.AIR) || blockTypeWrapper.accepts(blockType)) {
+                            return true;
+                        }
+                    }
                     return Permissions.hasPermission(player,
                         Captions.PERMISSION_ADMIN_INTERACT_ROAD.getTranslated(), notifyPerms);
                 }
@@ -301,6 +307,12 @@ public class EventDispatcher {
             }
             case TRIGGER_PHYSICAL: {
                 if (plot == null) {
+                    final List<BlockTypeWrapper> use = area.getRoadFlag(UseFlag.class);
+                    for(final BlockTypeWrapper blockTypeWrapper : use) {
+                        if (blockTypeWrapper.accepts(BlockTypes.AIR) || blockTypeWrapper.accepts(blockType)) {
+                            return true;
+                        }
+                    }
                     return Permissions.hasPermission(player,
                         Captions.PERMISSION_ADMIN_INTERACT_ROAD.getTranslated(), false);
                 }


### PR DESCRIPTION
## Overview
When a player runs /p add, trust or similar methods, the plugin tries to call MainUtil#getName which throws an exception if called from the main thread. So i changed the Name -> UUID lookup mechanism to return not only the UUID, but also the Name.

**Fixes https://issues.intellectualsites.com/issue/PS-96**

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v5/CONTRIBUTING.md)