### PR TITLE
Add default namespace when wrapping block categories by their ids

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/plot/flag/types/BlockTypeWrapper.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/types/BlockTypeWrapper.java
@@ -46,6 +46,8 @@ public class BlockTypeWrapper {
 
     private static final Map<BlockType, BlockTypeWrapper> blockTypes = new HashMap<>();
     private static final Map<String, BlockTypeWrapper> blockCategories = new HashMap<>();
+    private static final String minecraftNamespace = "minecraft";
+
     @Nullable @Getter private final BlockType blockType;
     @Nullable private final String blockCategoryId;
     @Nullable private BlockCategory blockCategory;
@@ -78,7 +80,14 @@ public class BlockTypeWrapper {
     }
 
     public static BlockTypeWrapper get(final String blockCategoryId) {
-        return blockCategories.computeIfAbsent(blockCategoryId, BlockTypeWrapper::new);
+        // use minecraft as default namespace
+        String id;
+        if (blockCategoryId.indexOf(':') == -1) {
+            id = minecraftNamespace + ":" + blockCategoryId;
+        } else {
+            id = blockCategoryId;
+        }
+        return blockCategories.computeIfAbsent(id, BlockTypeWrapper::new);
     }
 
     @Override public String toString() {


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets

If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://issues.intellectualsites.com/projects/ps
-->

**Fixes PS-131**

## Description
Previously, the block category cache would miss the entry when using get(BlockCategory) as the id used there is namespaced whereas get(String) would ignore whether the string is namespaced.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v5/CONTRIBUTING.md)
