### PR TITLE
Fix PaperLib relocation

### DIFF
--- a/Bukkit/build.gradle
+++ b/Bukkit/build.gradle
@@ -101,7 +101,7 @@ shadowJar {
         include(dependency("com.sk89q:squirrelid:1.0.0-SNAPSHOT"))
     }
     relocate('net.kyori.text', 'com.plotsquared.formatting.text')
-    relocate("io.papermc.lib", "com.plotsquared.bukkit.paperlib")
+    relocate("io.papermc.paperlib", "com.plotsquared.bukkit.paperlib")
     relocate("org.bstats", "com.plotsquared.metrics")
     relocate('com.sk89q.squirrelid', 'com.plotsquared.squirrelid')
     relocate('org.khelekore.prtree', 'com.plotsquared.prtree')


### PR DESCRIPTION
**Fixes {Link to issue}**
https://www.youtube.com/watch?v=dQw4w9WgXcQ

## Description
When starting the server it says PaperLib cannot be found. This is because there is a typo in the Gradle file that I have fixed.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v5/CONTRIBUTING.md)
