### PR TITLE
Log plot chat messages

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -657,6 +657,8 @@ public class PlayerEventListener extends PlotListener implements Listener {
                 player.sendMessage(spyMessage);
             }
         }
+        PlotSquared.log(Captions.PREFIX + full);
+
         PlotSquared.debug(full);
     }
 


### PR DESCRIPTION
## Overview
Plot chat messages should be logged for administrative purposes, just like any other chat message.

## Description
This PR logs the plot chat messages.  The format of the log entries is as follows:
![plotchat](https://user-images.githubusercontent.com/3617206/103462684-059ff680-4cf5-11eb-8b26-d479d20b8aea.png)

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v5/CONTRIBUTING.md)
