### PR TITLE
Fixed bug where "plot.plots.*" isnt returning

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Claim.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Claim.java
@@ -118,6 +118,7 @@ public class Claim extends SubCommand {
                             TranslatableCaption.of("permission.cant_claim_more_plots"),
                             Template.of("amount", String.valueOf(grants))
                     );
+                    return false;
                 }
             }
 


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets --!>
It fixes the issue where you can claim more plots than your permission node allows you to. I used LuckPerms and had the "plot.plots.2" permission, but it allowed me to claim more than 2 plots, giving me the error I cannot own more than 2 plots, but still allowed me to claim it.

**Fixes {Link to issue}**
https://issues.intellectualsites.com/issue/HYPERVERSE-52
## Description
I added a return false to fix this issue.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I tested my changes and approved their functionality
- [X] I included all information required in the sections above
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v5/CONTRIBUTING.md)
