### PR TITLE
Fixed feedback recipient for notify flags

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
+++ b/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
@@ -175,7 +175,7 @@ public class PlotListener {
                     for (UUID uuid : plot.getOwners()) {
                         final PlotPlayer<?> owner = PlotSquared.platform().playerManager().getPlayerIfExists(uuid);
                         if (owner != null && !owner.getUUID().equals(player.getUUID()) && owner.canSee(player)) {
-                            player.sendMessage(
+                            owner.sendMessage(
                                     TranslatableCaption.of("notification.notify_enter"),
                                     Template.of("player", player.getName()),
                                     Template.of("plot", plot.getId().toString())
@@ -383,7 +383,7 @@ public class PlotListener {
                         for (UUID uuid : plot.getOwners()) {
                             final PlotPlayer<?> owner = PlotSquared.platform().playerManager().getPlayerIfExists(uuid);
                             if ((owner != null) && !owner.getUUID().equals(player.getUUID()) && owner.canSee(player)) {
-                                player.sendMessage(
+                                owner.sendMessage(
                                         TranslatableCaption.of("notification.notify_leave"),
                                         Template.of("player", player.getName()),
                                         Template.of("plot", plot.getId().toString())


### PR DESCRIPTION
The entering or leaving player receives the feedback instead of the actual owner of the plot.

This affects both the ``notify-enter`` and the ``notify-leave`` flag.

[Related issue](https://github.com/IntellectualSites/PlotSquared/issues/3010)