### PR TITLE
feat: re-add aggregated javadocs task

### DIFF
--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -101,3 +101,10 @@ tasks.named<ShadowJar>("shadowJar") {
 
     mergeServiceFiles()
 }
+
+tasks {
+    withType<Javadoc> {
+        val opt = options as StandardJavadocDocletOptions
+        opt.links("https://papermc.io/javadocs/paper/1.16")
+    }
+}

--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -105,6 +105,11 @@ tasks.named<ShadowJar>("shadowJar") {
 tasks {
     withType<Javadoc> {
         val opt = options as StandardJavadocDocletOptions
-        opt.links("https://papermc.io/javadocs/paper/1.16")
+        opt.links("https://papermc.io/javadocs/paper/1.16/")
+        opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-core/7.2.5/")
+        opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-bukkit/7.2.5/")
+        opt.links("https://jd.adventure.kyori.net/api/4.7.0/")
+        opt.links("https://google.github.io/guice/api-docs/5.0.1/javadoc/")
+        opt.links("https://checkerframework.org/api/")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,6 +76,7 @@ subprojects {
     }
 }
 
+val javadocDir = rootDir.resolve("docs").resolve("javadoc").resolve(project.name)
 allprojects {
     dependencies {
         // Tests
@@ -173,7 +174,6 @@ allprojects {
         }
     }
 
-    val javadocDir = rootDir.resolve("docs").resolve("javadoc").resolve(project.name)
     tasks {
         named<Delete>("clean") {
             doFirst {
@@ -214,6 +214,36 @@ allprojects {
 
         named("build") {
             dependsOn(named("shadowJar"))
+        }
+    }
+}
+
+tasks {
+    val aggregatedJavadocs = create<Javadoc>("aggregatedJavadocs") {
+        title = "${project.name} ${project.version} API"
+        setDestinationDir(javadocDir)
+        options.destinationDirectory = javadocDir
+
+        doFirst {
+            javadocDir.deleteRecursively()
+        }
+    }.also {
+        it.group = "Documentation"
+        it.description = "Generate javadocs from all child projects as if it was a single project"
+    }
+
+    subprojects.forEach { subProject ->
+        subProject.afterEvaluate {
+            subProject.tasks.withType<Javadoc>().forEach { task ->
+                aggregatedJavadocs.source += task.source
+                aggregatedJavadocs.classpath += task.classpath
+                aggregatedJavadocs.excludes += task.excludes
+                aggregatedJavadocs.includes += task.includes
+
+                val rootOptions = aggregatedJavadocs.options as StandardJavadocDocletOptions
+                val subOptions = task.options as StandardJavadocDocletOptions
+                rootOptions.links(*subOptions.links.orEmpty().minus(rootOptions.links.orEmpty()).toTypedArray())
+            }
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -246,4 +246,8 @@ tasks {
             }
         }
     }
+
+    build {
+        dependsOn(aggregatedJavadocs)
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-checker-qual = "3.13.0"
+checker-qual = "3.14.0"
 
 guava = "21.0"
 gson = "2.8.0"
@@ -32,7 +32,6 @@ paster = "1.0.2-SNAPSHOT"
 
 bstats = "2.2.1"
 
-# Remember to update Paper javadoc version in the bukkit module!
 paper = "1.16.5-R0.1-SNAPSHOT"
 paperlib = "1.0.6"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ paster = "1.0.2-SNAPSHOT"
 
 bstats = "2.2.1"
 
+# Remember to update Paper javadoc version in the bukkit module!
 paper = "1.16.5-R0.1-SNAPSHOT"
 paperlib = "1.0.6"
 


### PR DESCRIPTION
I only a week late.
This will generate the aggregated docs to `docs/javadoc/PlotSquared`, while per-project still go to `docs/javadoc/PlotSquared-${module}`.

---

This was removed by IntellectualSites/PlotSquared#2922.
Closes IntellectualSites/PlotSquared#3037.

Signed-off-by: Mariell Hoversholm <proximyst@proximyst.com>