### PR TITLE
Add fawe integration to v6

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -186,6 +186,7 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
     private Method methodUnloadChunk0;
     private boolean methodUnloadSetup = false;
     private boolean metricsStarted;
+    private boolean faweHook = false;
     private EconHandler econ;
 
     private Injector injector;
@@ -317,11 +318,25 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
         // WorldEdit
         if (Settings.Enabled_Components.WORLDEDIT_RESTRICTIONS) {
             try {
-                LOGGER.info("{} hooked into WorldEdit", this.pluginName());
                 WorldEdit.getInstance().getEventBus().register(this.injector().getInstance(WESubscriber.class));
+                LOGGER.info("{} hooked into WorldEdit", this.pluginName());
             } catch (Throwable e) {
                 LOGGER.error(
                         "Incompatible version of WorldEdit, please upgrade: https://builds.enginehub.org/job/worldedit?branch=master");
+            }
+        }
+
+        // FAWE
+        if (Settings.FAWE_Components.FAWE_HOOK) {
+            Plugin fawe = getServer().getPluginManager().getPlugin("FastAsyncWorldEdit");
+            if (fawe != null) {
+                try {
+                    Class.forName("com.boydti.fawe.bukkit.regions.plotsquared.FaweQueueCoordinator");
+                    faweHook = true;
+                } catch (Exception ignored) {
+                    LOGGER.error("Incompatible version of FAWE to enable hook, please upgrade: https://ci.athion" +
+                            ".net/job/FastAsyncWorldEdit-P2-V6/");
+                }
             }
         }
 
@@ -1207,6 +1222,11 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
     @Override
     public String toLegacyPlatformString(final @NonNull Component component) {
         return LegacyComponentSerializer.legacyAmpersand().serialize(component);
+    }
+
+    @Override
+    public boolean isFaweHooking() {
+        return faweHook;
     }
 
 }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -258,6 +258,20 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
 
         final PlotSquared plotSquared = new PlotSquared(this, "Bukkit");
 
+        // FAWE
+        if (Settings.FAWE_Components.FAWE_HOOK) {
+            Plugin fawe = getServer().getPluginManager().getPlugin("FastAsyncWorldEdit");
+            if (fawe != null) {
+                try {
+                    Class.forName("com.boydti.fawe.bukkit.regions.plotsquared.FaweQueueCoordinator");
+                    faweHook = true;
+                } catch (Exception ignored) {
+                    LOGGER.error("Incompatible version of FAWE to enable hook, please upgrade: https://ci.athion" +
+                            ".net/job/FastAsyncWorldEdit-P2-V6/");
+                }
+            }
+        }
+
         // We create the injector after PlotSquared has been initialized, so that we have access
         // to generated instances and settings
         this.injector = Guice
@@ -323,20 +337,6 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
             } catch (Throwable e) {
                 LOGGER.error(
                         "Incompatible version of WorldEdit, please upgrade: https://builds.enginehub.org/job/worldedit?branch=master");
-            }
-        }
-
-        // FAWE
-        if (Settings.FAWE_Components.FAWE_HOOK) {
-            Plugin fawe = getServer().getPluginManager().getPlugin("FastAsyncWorldEdit");
-            if (fawe != null) {
-                try {
-                    Class.forName("com.boydti.fawe.bukkit.regions.plotsquared.FaweQueueCoordinator");
-                    faweHook = true;
-                } catch (Exception ignored) {
-                    LOGGER.error("Incompatible version of FAWE to enable hook, please upgrade: https://ci.athion" +
-                            ".net/job/FastAsyncWorldEdit-P2-V6/");
-                }
             }
         }
 

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/inject/BukkitModule.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/inject/BukkitModule.java
@@ -41,7 +41,10 @@ import com.plotsquared.bukkit.util.BukkitInventoryUtil;
 import com.plotsquared.bukkit.util.BukkitRegionManager;
 import com.plotsquared.bukkit.util.BukkitSetupUtils;
 import com.plotsquared.bukkit.util.BukkitUtil;
+import com.plotsquared.bukkit.util.fawe.FaweRegionManager;
+import com.plotsquared.bukkit.util.fawe.FaweSchematicHandler;
 import com.plotsquared.core.PlotPlatform;
+import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.generator.HybridGen;
 import com.plotsquared.core.generator.IndependentPlotGenerator;
@@ -99,10 +102,15 @@ public class BukkitModule extends AbstractModule {
         install(new FactoryModuleBuilder()
                 .implement(ProgressSubscriber.class, DefaultProgressSubscriber.class)
                 .build(ProgressSubscriberFactory.class));
-        bind(GlobalBlockQueue.class).toInstance(new GlobalBlockQueue(QueueProvider.of(BukkitQueueCoordinator.class)));
         bind(ChunkManager.class).to(BukkitChunkManager.class);
-        bind(RegionManager.class).to(BukkitRegionManager.class);
-        bind(SchematicHandler.class).to(BukkitSchematicHandler.class);
+        if (PlotSquared.platform().isFaweHooking()) {
+            bind(SchematicHandler.class).to(FaweSchematicHandler.class);
+            bind(RegionManager.class).to(FaweRegionManager.class);
+        } else {
+            bind(SchematicHandler.class).to(BukkitSchematicHandler.class);
+            bind(RegionManager.class).to(BukkitRegionManager.class);
+        }
+        bind(GlobalBlockQueue.class).toInstance(new GlobalBlockQueue(QueueProvider.of(BukkitQueueCoordinator.class)));
         if (Settings.Enabled_Components.WORLDS) {
             bind(PlotAreaManager.class).to(SinglePlotAreaManager.class);
             try {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/fawe/FaweRegionManager.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/fawe/FaweRegionManager.java
@@ -8,7 +8,7 @@
  *                                    | |
  *                                    |_|
  *            PlotSquared plot management system for Minecraft
- *                  Copyright (C) ${year} IntellectualSites
+ *                  Copyright (C) 2021 IntellectualSites
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
@@ -21,9 +21,8 @@
  *     GNU General Public License for more details.
  *
  *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package com.plotsquared.bukkit.util.fawe;
 
 import com.boydti.fawe.bukkit.regions.plotsquared.FaweDelegateRegionManager;

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/fawe/FaweRegionManager.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/fawe/FaweRegionManager.java
@@ -1,0 +1,130 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) ${year} IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.plotsquared.bukkit.util.fawe;
+
+import com.boydti.fawe.bukkit.regions.plotsquared.FaweDelegateRegionManager;
+import com.google.inject.Inject;
+import com.plotsquared.bukkit.util.BukkitRegionManager;
+import com.plotsquared.core.configuration.Settings;
+import com.plotsquared.core.generator.HybridPlotManager;
+import com.plotsquared.core.inject.factory.ProgressSubscriberFactory;
+import com.plotsquared.core.location.Location;
+import com.plotsquared.core.player.PlotPlayer;
+import com.plotsquared.core.plot.Plot;
+import com.plotsquared.core.plot.PlotArea;
+import com.plotsquared.core.plot.PlotManager;
+import com.plotsquared.core.queue.GlobalBlockQueue;
+import com.plotsquared.core.queue.QueueCoordinator;
+import com.plotsquared.core.util.WorldUtil;
+import com.sk89q.worldedit.function.pattern.Pattern;
+import com.sk89q.worldedit.regions.CuboidRegion;
+import com.sk89q.worldedit.world.biome.BiomeType;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Set;
+
+public class FaweRegionManager extends BukkitRegionManager {
+
+    private final FaweDelegateRegionManager delegate = new FaweDelegateRegionManager();
+
+    @Inject
+    public FaweRegionManager(
+            @NonNull WorldUtil worldUtil, @NonNull GlobalBlockQueue blockQueue, @NonNull
+            ProgressSubscriberFactory subscriberFactory
+    ) {
+        super(worldUtil, blockQueue, subscriberFactory);
+    }
+
+    @Override
+    public boolean setCuboids(
+            final @NonNull PlotArea area,
+            final @NonNull Set<CuboidRegion> regions,
+            final @NonNull Pattern blocks,
+            int minY,
+            int maxY,
+            @org.checkerframework.checker.nullness.qual.Nullable PlotPlayer<?> actor,
+            @org.checkerframework.checker.nullness.qual.Nullable QueueCoordinator queue
+    ) {
+        return delegate.setCuboids(area, regions, blocks, minY, maxY);
+    }
+
+    @Override
+    public boolean notifyClear(PlotManager manager) {
+        if (!Settings.FAWE_Components.CLEAR || !(manager instanceof HybridPlotManager)) {
+            return false;
+        }
+        return delegate.notifyClear(manager);
+    }
+
+    @Override
+    public boolean handleClear(
+            @NotNull Plot plot,
+            @Nullable Runnable whenDone,
+            @NotNull PlotManager manager,
+            final @Nullable PlotPlayer<?> player
+    ) {
+        if (!Settings.FAWE_Components.CLEAR || !(manager instanceof HybridPlotManager)) {
+            return false;
+        }
+        return delegate.handleClear(plot, whenDone, manager);
+    }
+
+    @Override
+    public void swap(
+            Location pos1,
+            Location pos2,
+            Location swapPos,
+            final @Nullable PlotPlayer<?> player,
+            final Runnable whenDone
+    ) {
+        delegate.swap(pos1, pos2, swapPos, whenDone);
+    }
+
+    @Override
+    public void setBiome(CuboidRegion region, int extendBiome, BiomeType biome, String world, Runnable whenDone) {
+        delegate.setBiome(region, extendBiome, biome, world, whenDone);
+    }
+
+    @Override
+    public boolean copyRegion(
+            final @NonNull Location pos1,
+            final @NonNull Location pos2,
+            final @NonNull Location pos3,
+            final @Nullable PlotPlayer<?> player,
+            final @NonNull Runnable whenDone
+    ) {
+        return delegate.copyRegion(pos1, pos2, pos3, whenDone);
+    }
+
+    @Override
+    public boolean regenerateRegion(final Location pos1, final Location pos2, boolean ignore, final Runnable whenDone) {
+        return delegate.regenerateRegion(pos1, pos2, ignore, whenDone);
+    }
+
+}

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/fawe/FaweRegionManager.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/fawe/FaweRegionManager.java
@@ -67,10 +67,10 @@ public class FaweRegionManager extends BukkitRegionManager {
             final @NonNull Pattern blocks,
             int minY,
             int maxY,
-            @org.checkerframework.checker.nullness.qual.Nullable PlotPlayer<?> actor,
-            @org.checkerframework.checker.nullness.qual.Nullable QueueCoordinator queue
+            @Nullable PlotPlayer<?> actor,
+            @Nullable QueueCoordinator queue
     ) {
-        return delegate.setCuboids(area, regions, blocks, minY, maxY);
+        return delegate.setCuboids(area, regions, blocks, minY, maxY, queue.getCompleteTask());
     }
 
     @Override

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/fawe/FaweSchematicHandler.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/fawe/FaweSchematicHandler.java
@@ -1,0 +1,90 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) ${year} IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.plotsquared.bukkit.util.fawe;
+
+import com.boydti.fawe.bukkit.regions.plotsquared.FaweDelegateSchematicHandler;
+import com.google.inject.Inject;
+import com.plotsquared.core.inject.factory.ProgressSubscriberFactory;
+import com.plotsquared.core.player.PlotPlayer;
+import com.plotsquared.core.plot.Plot;
+import com.plotsquared.core.plot.schematic.Schematic;
+import com.plotsquared.core.queue.QueueCoordinator;
+import com.plotsquared.core.util.SchematicHandler;
+import com.plotsquared.core.util.WorldUtil;
+import com.plotsquared.core.util.task.RunnableVal;
+import com.sk89q.jnbt.CompoundTag;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.UUID;
+
+public class FaweSchematicHandler extends SchematicHandler {
+
+    private final FaweDelegateSchematicHandler delegate = new FaweDelegateSchematicHandler();
+
+    @Inject
+    public FaweSchematicHandler(@NotNull WorldUtil worldUtil, @NotNull ProgressSubscriberFactory subscriberFactory) {
+        super(worldUtil, subscriberFactory);
+    }
+
+    @Override
+    public boolean restoreTile(QueueCoordinator queue, CompoundTag tag, int x, int y, int z) {
+        return false;
+    }
+
+    @Override
+    public void paste(
+            final Schematic schematic,
+            final Plot plot,
+            final int xOffset,
+            final int yOffset,
+            final int zOffset,
+            final boolean autoHeight,
+            final PlotPlayer<?> actor,
+            final RunnableVal<Boolean> whenDone
+    ) {
+        delegate.paste(schematic, plot, xOffset, yOffset, zOffset, autoHeight, whenDone);
+    }
+
+    @Override
+    public boolean save(CompoundTag tag, String path) {
+        return delegate.save(tag, path);
+    }
+
+    @Override
+    public void upload(final CompoundTag tag, final UUID uuid, final String file, final RunnableVal<URL> whenDone) {
+        delegate.upload(tag, uuid, file, whenDone);
+    }
+
+    @Override
+    public Schematic getSchematic(@NotNull InputStream is) {
+        return delegate.getSchematic(is);
+    }
+
+}
+

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/fawe/FaweSchematicHandler.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/fawe/FaweSchematicHandler.java
@@ -8,7 +8,7 @@
  *                                    | |
  *                                    |_|
  *            PlotSquared plot management system for Minecraft
- *                  Copyright (C) ${year} IntellectualSites
+ *                  Copyright (C) 2021 IntellectualSites
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
@@ -21,9 +21,8 @@
  *     GNU General Public License for more details.
  *
  *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package com.plotsquared.bukkit.util.fawe;
 
 import com.boydti.fawe.bukkit.regions.plotsquared.FaweDelegateSchematicHandler;

--- a/Core/build.gradle.kts
+++ b/Core/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
         exclude(group = "dummypermscompat")
     }
     testImplementation(libs.worldeditCore)
+    compileOnlyApi(libs.fastasyncworldeditBukkit)
+    testImplementation(libs.fastasyncworldeditBukkit)
 
     // Logging
     compileOnlyApi(libs.log4j) {

--- a/Core/src/main/java/com/plotsquared/core/PlotPlatform.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotPlatform.java
@@ -323,4 +323,13 @@ public interface PlotPlatform<P> extends LocaleHolder {
      */
     @NonNull String toLegacyPlatformString(@NonNull Component component);
 
+    /**
+     * Returns if the FAWE-P2 hook is active/enabled
+     *
+     * @return status of FAWE-P2 hook
+     */
+    default boolean isFaweHooking() {
+        return false;
+    }
+
 }

--- a/Core/src/main/java/com/plotsquared/core/command/DebugRoadRegen.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DebugRoadRegen.java
@@ -107,11 +107,7 @@ public class DebugRoadRegen extends SubCommand {
         } else {
             PlotManager manager = area.getPlotManager();
             QueueCoordinator queue = area.getQueue();
-            manager.createRoadEast(plot, queue);
-            manager.createRoadSouth(plot, queue);
-            manager.createRoadSouthEast(plot, queue);
             queue.setCompleteTask(() -> {
-                ;
                 player.sendMessage(
                         TranslatableCaption.of("debugroadregen.regen_done"),
                         Template.of("value", plot.getId().toString())
@@ -121,6 +117,9 @@ public class DebugRoadRegen extends SubCommand {
                         Template.of("value", "/plot regenallroads")
                 );
             });
+            manager.createRoadEast(plot, queue);
+            manager.createRoadSouth(plot, queue);
+            manager.createRoadSouthEast(plot, queue);
             queue.enqueue();
         }
         return true;

--- a/Core/src/main/java/com/plotsquared/core/command/Set.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Set.java
@@ -161,9 +161,6 @@ public class Set extends SubCommand {
                         BackupManager.backup(player, plot, () -> {
                             plot.addRunning();
                             QueueCoordinator queue = plotArea.getQueue();
-                            for (final Plot current : plot.getConnectedPlots()) {
-                                current.getPlotModificationManager().setComponent(component, pattern, player, queue);
-                            }
                             queue.setCompleteTask(() -> {
                                 plot.removeRunning();
                                 player.sendMessage(
@@ -178,6 +175,9 @@ public class Set extends SubCommand {
                                                 .injector()
                                                 .getInstance(ProgressSubscriberFactory.class)
                                                 .createWithActor(player));
+                            }
+                            for (final Plot current : plot.getConnectedPlots()) {
+                                current.getPlotModificationManager().setComponent(component, pattern, player, queue);
                             }
                             queue.enqueue();
                             player.sendMessage(TranslatableCaption.of("working.generating_component"));

--- a/Core/src/main/java/com/plotsquared/core/components/ComponentPresetManager.java
+++ b/Core/src/main/java/com/plotsquared/core/components/ComponentPresetManager.java
@@ -222,6 +222,7 @@ public class ComponentPresetManager {
                 BackupManager.backup(getPlayer(), plot, () -> {
                     plot.addRunning();
                     QueueCoordinator queue = plot.getArea().getQueue();
+                    queue.setCompleteTask(plot::removeRunning);
                     for (Plot current : plot.getConnectedPlots()) {
                         current.getPlotModificationManager().setComponent(
                                 componentPreset.getComponent().name(),
@@ -230,7 +231,6 @@ public class ComponentPresetManager {
                                 queue
                         );
                     }
-                    queue.setCompleteTask(plot::removeRunning);
                     queue.enqueue();
                     getPlayer().sendMessage(TranslatableCaption.of("working.generating_component"));
                 });

--- a/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
@@ -608,6 +608,17 @@ public class Settings extends Config {
 
     }
 
+    @Comment("Enable or disable all of or parts of the FAWE-P2 hook")
+    public static final class FAWE_Components {
+
+        @Comment("Use FAWE for queue handling.")
+        public static boolean FAWE_HOOK = true;
+        public static boolean CUBOIDS = true;
+        public static boolean CLEAR = true;
+        public static boolean COPY_AND_SWAP = true;
+        public static boolean SET_BIOME = true;
+
+    }
 
     @Comment("Enable or disable parts of the plugin specific to using Paper")
     public static final class Paper_Components {

--- a/Core/src/main/java/com/plotsquared/core/generator/HybridPlotManager.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridPlotManager.java
@@ -263,6 +263,12 @@ public class HybridPlotManager extends ClassicPlotManager {
             enqueue = true;
             queue = hybridPlotWorld.getQueue();
         }
+        if (actor != null && Settings.QUEUE.NOTIFY_PROGRESS) {
+            queue.addProgressSubscriber(subscriberFactory.createWithActor(actor));
+        }
+        if (whenDone != null) {
+            queue.setCompleteTask(whenDone);
+        }
         if (!canRegen) {
             queue.setCuboid(pos1.withY(0), pos2.withY(0), bedrock);
             // Each component has a different layer
@@ -274,12 +280,6 @@ public class HybridPlotManager extends ClassicPlotManager {
             queue.setRegenRegion(new CuboidRegion(pos1.getBlockVector3(), pos2.getBlockVector3()));
         }
         pastePlotSchematic(queue, pos1, pos2);
-        if (actor != null && Settings.QUEUE.NOTIFY_PROGRESS) {
-            queue.addProgressSubscriber(subscriberFactory.createWithActor(actor));
-        }
-        if (whenDone != null) {
-            queue.setCompleteTask(whenDone);
-        }
         return !enqueue || queue.enqueue();
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,11 @@ allprojects {
         }
 
         maven {
+            name = "IntellectualSites Releases Repository"
+            url = uri("https://mvn.intellectualsites.com/content/repositories/releases")
+        }
+
+        maven {
             name = "IntellectualSites Snapshots Repository"
             url = uri("https://mvn.intellectualsites.com/content/repositories/snapshots")
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ guice = "5.0.1"
 findbugs = "3.0.1"
 
 worldedit = "7.2.5"
+fawe = "p2v6-8"
 vault = "1.7"
 placeholderapi = "2.10.9"
 luckperms = "5.3"
@@ -63,6 +64,7 @@ findbugs = { group = "com.google.code.findbugs", name = "annotations", version.r
 # Plugins
 worldeditCore = { group = "com.sk89q.worldedit", name = "worldedit-core", version.ref = "worldedit" }
 worldeditBukkit = { group = "com.sk89q.worldedit", name = "worldedit-bukkit", version.ref = "worldedit" }
+fastasyncworldeditBukkit = { group = "com.intellectualsites.fawe", name = "FAWE-Bukkit", version.ref = "fawe" }
 vault = { group = "com.github.MilkBowl", name = "VaultAPI", version.ref = "vault" }
 placeholderapi = { group = "me.clip", name = "placeholderapi", version.ref = "placeholderapi" }
 luckperms = { group = "net.luckperms", name = "api", version.ref = "luckperms" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ guice = "5.0.1"
 findbugs = "3.0.1"
 
 worldedit = "7.2.5"
-fawe = "p2v6-8"
+fawe = "p2v6-9"
 vault = "1.7"
 placeholderapi = "2.10.9"
 luckperms = "5.3"


### PR DESCRIPTION
Using guice means integration with FAWE is harder. This is a pretty simple workaround and simply delegates to the FAWE classes, also avoiding the fact some of the methods used in FAWE do not exist in WE (e.g. Clipboard#paste)

Integration of FAWE into the actual queue process is much harder, as QueueCoordinator allows for several things FAWE does not (namely "chunk consumers") and should probably be targeted at a later version