### PR TITLE
Fix off-by-one error in schematic pasting

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/util/SchematicHandler.java
+++ b/Core/src/main/java/com/plotsquared/core/util/SchematicHandler.java
@@ -365,7 +365,7 @@ public abstract class SchematicHandler {
                 if (yy > 255 || yy < 0) {
                     continue;
                 }
-                for (int rz = 0; rz <= blockArrayClipboard.getDimensions().getZ(); rz++) {
+                for (int rz = 0; rz < blockArrayClipboard.getDimensions().getZ(); rz++) {
                     for (int rx = 0; rx < blockArrayClipboard.getDimensions().getX(); rx++) {
                         int xx = p1x + rx;
                         int zz = p1z + rz;


### PR DESCRIPTION
## Overview
**Fixes https://github.com/IntellectualSites/PlotSquared/issues/3159**
**Fixes https://github.com/IntellectualSites/PlotSquared/issues/3131**

## Description

There's an off-by-one error in the schematic pasting code, which leads to the +Z plot border being deleted when loading a plot backup or pasting a plot schematic.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v5/CONTRIBUTING.md)
