### PR TITLE
Revert projectile hit on splash

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/ProjectileEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/ProjectileEventListener.java
@@ -63,6 +63,11 @@ public class ProjectileEventListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onLingeringPotionSplash(LingeringPotionSplashEvent event) {
+        onProjectileHit(event);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPotionSplash(PotionSplashEvent event) {
         ThrownPotion damager = event.getPotion();
         Location location = BukkitUtil.adapt(damager.getLocation());
@@ -78,6 +83,8 @@ public class ProjectileEventListener implements Listener {
         }
         if (count > 0 && count == event.getAffectedEntities().size()) {
             event.setCancelled(true);
+        } else {
+            onProjectileHit(event);
         }
     }
 

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/ProjectileEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/ProjectileEventListener.java
@@ -64,6 +64,8 @@ public class ProjectileEventListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onLingeringPotionSplash(LingeringPotionSplashEvent event) {
+        // Cancelling projectile hit events still results in area effect clouds.
+        // We need to cancel the splash events to get rid of those.
         onProjectileHit(event);
     }
 
@@ -84,6 +86,9 @@ public class ProjectileEventListener implements Listener {
         if (count > 0 && count == event.getAffectedEntities().size()) {
             event.setCancelled(true);
         } else {
+            // Cancelling projectile hit events still results in potions
+            // splashing in the world. We need to cancel the splash events to
+            // avoid that.
             onProjectileHit(event);
         }
     }


### PR DESCRIPTION
## Overview

Area effect clouds get spawned when throwing a lingering potion on someone else's plot. Similarly, splash potions result in splash events.

## Description

In https://github.com/IntellectualSites/PlotSquared/pull/3154 I said that the ProjectileHitEvent is called before the splash events, and while that's true, cancelling projectile hit apparently still results in potion splashes. When I made that other PR, I was certain cancelling projectile hit also got rid of the potion splashes (I looked through the Paper code), and I thought I tested it, but I guess something went wrong there…

This PR reverts the splash handling code to the old version, while keeping the updated generic projectile hit code.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v5/CONTRIBUTING.md)
