### PR TITLE
Handle edge cases of EntityChangeBlockEvent

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
@@ -331,9 +331,6 @@ public class EntityEventListener implements Listener {
         Entity e = event.getEntity();
         Material type = event.getBlock().getType();
         Location location = BukkitUtil.adapt(event.getBlock().getLocation());
-        if (!this.plotAreaManager.hasPlotArea(location.getWorldName())) {
-            return;
-        }
         PlotArea area = location.getPlotArea();
         if (area == null) {
             return;


### PR DESCRIPTION
## Overview

**Fixes https://github.com/IntellectualSites/PlotSquared/issues/3161**

## Description

Modifies the handling of EntityChangeBlockEvent so events involving players, projectiles and boats are handled more carefully. This PR aims to apply my suggestions in https://github.com/IntellectualSites/PlotSquared/issues/3161. The changes are as follows:
1. Boats are now allowed to break lily pads. If you want to plough through lily pads on your plot, I think you should be able to without setting entity-change-block to true.
2. Burning players evaporating powder snow blocks, is now handled similarly to trampling farmland in the PlayerInteractEvent listener, i.e. you can allow it with the 'use' flag for non-added players.
3. Other player interacts are left to other flags (primarily the 'use' flag). So the 'entity-change-block' flag doesn't affect players tilting big dripleaves, picking glow berries, trampling farmland and interacting with redstone ore.
4. Projectiles shot by players and blocks are now handled similarly to the ProjectileHitEvent. The 'entity-change-block' flag doesn't affect them. For other shooters the 'entity-change-block' determines whether the event is cancelled or not. So added players can now evaporate powder snow with flame arrows, put out flames with water bottles, tilt big dripleaves with projectiles, break pointed dripstone with tridents and light TNT with flame arrows.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v5/CONTRIBUTING.md)
