### PR TITLE
Fix index out of bounds for '/p h'

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/HomeCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/HomeCommand.java
@@ -76,7 +76,7 @@ public class HomeCommand extends Command {
         if (plots.isEmpty()) {
             player.sendMessage(TranslatableCaption.of("invalid.found_no_plots"));
             return;
-        } else if (plots.size() < page) {
+        } else if (plots.size() < page || page < 1) {
             player.sendMessage(
                     TranslatableCaption.of("invalid.number_not_in_range"),
                     Template.of("min", "1"),


### PR DESCRIPTION
## Overview

Running `/p h n` for `n <= 0` throws an index out of bounds exception. You may need to have at least one plot for the exception to be thrown.

## Description

The only change is that we check for the lower bound of 1 on the `page` variable.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v6/CONTRIBUTING.md)
