### PR TITLE
Fix sponge absorbing water across plot borders

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -1191,25 +1191,17 @@ public class BlockEventListener implements Listener {
         PlotArea area = location.getPlotArea();
         List<org.bukkit.block.BlockState> blocks = event.getBlocks();
         if (area == null) {
-            for (int i = blocks.size() - 1; i >= 0; i--) {
-                location = BukkitUtil.adapt(blocks.get(i).getLocation());
-                if (location.isPlotArea()) {
-                    blocks.remove(i);
-                }
-            }
+            blocks.removeIf(block -> BukkitUtil.adapt(block.getLocation()).isPlotArea());
         } else {
             Plot origin = area.getOwnedPlot(location);
-            for (int i = blocks.size() - 1; i >= 0; i--) {
-                location = BukkitUtil.adapt(blocks.get(i).getLocation());
-                if (!area.contains(location.getX(), location.getZ())) {
-                    blocks.remove(i);
-                    continue;
+            blocks.removeIf(block -> {
+                var blockLocation = BukkitUtil.adapt(block.getLocation());
+                if (!area.contains(blockLocation.getX(), blockLocation.getZ())) {
+                    return true;
                 }
-                Plot plot = area.getOwnedPlot(location);
-                if (!Objects.equals(plot, origin)) {
-                    blocks.remove(i);
-                }
-            }
+                Plot plot = area.getOwnedPlot(blockLocation);
+                return !Objects.equals(plot, origin);
+            });
         }
         if (blocks.isEmpty()) {
             // Cancel event so the sponge block doesn't turn into a wet sponge

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -1195,7 +1195,7 @@ public class BlockEventListener implements Listener {
         } else {
             Plot origin = area.getOwnedPlot(location);
             blocks.removeIf(block -> {
-                var blockLocation = BukkitUtil.adapt(block.getLocation());
+                Location blockLocation = BukkitUtil.adapt(block.getLocation());
                 if (!area.contains(blockLocation.getX(), blockLocation.getZ())) {
                     return true;
                 }


### PR DESCRIPTION
## Overview

Currently sponges placed on plots also absorb water on the road. E.g. waterlog a plot wall slab, place some water next to it on the road, then place a sponge on your plot next to the waterlogged slab. The water in the waterlogged slab and on road will get removed.

## Description

Use the `SpongeAbsorbEvent` to deal with absorbing water across plot borders (and area borders). This event was added to Bukkit right after it updated to 1.13.

I copied the `StructureGrowEvent` listener and changed it around a bit:
- Removed this seemingly useless part https://github.com/IntellectualSites/PlotSquared/blob/6e7bd0a5365040f9579ff369f11761fd5834c5b3/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java#L1007-L1024
- Don't cancel water absorption on unowned plots and roads, so staff can use sponges to clear up water there if they so desire.
- Cancel event if no water is going to be absorbed, so the sponge doesn't turn into a wet sponge.

I only tested in a square plot world, I didn't stuff across area borders.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v6/CONTRIBUTING.md)
