### PR TITLE
Fix emptying buckets in plot border

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -1170,7 +1170,8 @@ public class PlayerEventListener extends PlotListener implements Listener {
         final Block block;
         // if the block can be waterlogged, the event might waterlog the block
         // sometimes
-        if (event.getBlockClicked().getBlockData() instanceof Waterlogged) {
+        if (event.getBlockClicked().getBlockData() instanceof Waterlogged waterlogged
+                && !waterlogged.isWaterlogged() && event.getBucket() != Material.LAVA_BUCKET) {
             block = event.getBlockClicked();
         } else {
             block = event.getBlockClicked().getLocation()

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -1167,6 +1167,10 @@ public class PlayerEventListener extends PlotListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBucketEmpty(PlayerBucketEmptyEvent event) {
         BlockFace bf = event.getBlockFace();
+        // Note: a month after Bukkit 1.14.4 released, they added the API method
+        // PlayerBucketEmptyEvent#getBlock(), which returns the block the
+        // bucket contents is going to be placed at. Currently we determine this
+        // block ourselves to retain compatibility with 1.13.
         final Block block;
         // if the block can be waterlogged, the event might waterlog the block
         // sometimes


### PR DESCRIPTION
## Overview

You can currently place water in the plot border as follows: place a waterloggable block on the edge of your plot, waterlog it, click on the side of the block connecting to the plot border with a water bucket. The water will be placed inside the plot border.

Similarly, you can also place lava in plot borders. You don't even need to waterlog the block (although the block does need to be waterloggable).

## Description

In the `PlayerBucketEmptyEvent` listener, fix the code that determines where the fluid is going to be placed:
- If the waterloggable block is waterlogged, the water is going to be placed on the side.
- If the bucket contains lava, the lava is going to be placed on the side.

A month after Bukkit updated to 1.14.4, the `PlayerBucketEmptyEvent` got the API method `getBlock()` that tells you where the fluid is going to be placed. Using that API method would make PlotSquared more robust to future Minecraft changes. However, I believe v6 is supposed to support 1.13, so I opted against using that API method.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v6/CONTRIBUTING.md)
