### PR TITLE
Slightly change how flag permissions are handled

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/permissions/BukkitPermissionHandler.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/permissions/BukkitPermissionHandler.java
@@ -92,6 +92,16 @@ public class BukkitPermissionHandler implements PermissionHandler {
             return player != null && player.hasPermission(permission);
         }
 
+        @Override
+        public boolean hasKeyedPermission(
+                final @Nullable String world,
+                final @NonNull String stub,
+                final @NonNull String key
+        ) {
+            final Player player = this.playerReference.get();
+            return player != null && (player.hasPermission(stub + "." + key) || player.hasPermission(stub + ".*"));
+        }
+
     }
 
 }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/permissions/VaultPermissionHandler.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/permissions/VaultPermissionHandler.java
@@ -117,6 +117,26 @@ public class VaultPermissionHandler implements PermissionHandler {
             return permissions.playerHas(world, offlinePlayer, permission);
         }
 
+        @Override
+        public boolean hasKeyedPermission(
+                final @Nullable String world,
+                final @NonNull String stub,
+                final @NonNull String key
+        ) {
+            if (permissions == null) {
+                return false;
+            }
+            if (world == null && offlinePlayer instanceof BukkitPlayer) {
+                return permissions.playerHas(
+                        ((BukkitPlayer) offlinePlayer).getPlatformPlayer(),
+                        stub + ".*"
+                ) || permissions.playerHas(((BukkitPlayer) offlinePlayer).getPlatformPlayer(), stub + "." + key);
+            }
+            return permissions.playerHas(world, offlinePlayer, stub + ".*") || permissions.playerHas(world, offlinePlayer,
+                    stub + "." + key
+            );
+        }
+
     }
 
 }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/player/BukkitOfflinePlayer.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/player/BukkitOfflinePlayer.java
@@ -82,4 +82,14 @@ public class BukkitOfflinePlayer implements OfflinePlotPlayer {
         return this.permissionProfile.hasPermission(world, permission);
     }
 
+    @Override
+    public boolean hasKeyedPermission(
+            final @Nullable String world,
+            final @NonNull String stub,
+            final @NonNull String key
+    ) {
+        return this.permissionProfile.hasPermission(world, stub + "." + key) || this.permissionProfile.hasPermission(world,
+                stub + ".*");
+    }
+
 }

--- a/Bukkit/src/main/resources/plugin.yml
+++ b/Bukkit/src/main/resources/plugin.yml
@@ -319,45 +319,78 @@ permissions:
       plots.flag.remove: true
       plots.flag.list: true
       plots.flag.info: true
+      plots.set.flag.titles: true
       plots.set.flag.titles.*: true
-      plots.set.flag.greeting.*: true
-      plots.set.flag.farewell.*: true
+      plots.set.flag.description: true
+      plots.set.flag.greeting: true
+      plots.set.flag.farewell: true
+      plots.set.flag.notify-enter: true
       plots.set.flag.notify-enter.*: true
+      plots.set.flag.notify-leave: true
       plots.set.flag.notify-leave.*: true
+      plots.set.flag.feed: true
       plots.set.flag.feed.*: true
+      plots.set.flag.heal: true
       plots.set.flag.heal.*: true
+      plots.set.flag.invincible: true
       plots.set.flag.invincible.*: true
+      plots.set.flag.instabreak: true
       plots.set.flag.instabreak.*: true
+      plots.set.flag.fly: true
       plots.set.flag.fly.*: true
       plots.set.flag.gamemode: true
       plots.set.flag.gamemode.creative: true
       plots.set.flag.gamemode.survival: true
       plots.set.flag.gamemode.adventure: true
-      plots.set.flag.time.*: true
+      plots.set.flag.time: true
+      plots.set.flag.weather: true
       plots.set.flag.weather.*: true
+      plots.set.flag.music: true
       plots.set.flag.music.*: true
+      plots.set.flag.disable-physics: true
       plots.set.flag.disable-physics.*: true
+      plots.set.flag.pve: true
       plots.set.flag.pve.*: true
+      plots.set.flag.pvp: true
       plots.set.flag.pvp.*: true
+      plots.set.flag.explosion: true
       plots.set.flag.explosion.*: true
+      plots.set.flag.hostile-interact: true
       plots.set.flag.hostile-interact.*: true
+      plots.set.flag.hostile-attack: true
       plots.set.flag.hostile-attack.*: true
+      plots.set.flag.player-interact: true
       plots.set.flag.player-interact.*: true
+      plots.set.flag.animal-interact: true
       plots.set.flag.animal-interact.*: true
+      plots.set.flag.animal-attack: true
       plots.set.flag.animal-attack.*: true
+      plots.set.flag.tamed-interact: true
       plots.set.flag.tamed-interact.*: true
+      plots.set.flag.tamed-attack: true
       plots.set.flag.tamed-attack.*: true
+      plots.set.flag.misc-interact: true
       plots.set.flag.misc-interact.*: true
+      plots.set.flag.hanging-place: true
       plots.set.flag.hanging-place.*: true
+      plots.set.flag.hanging-break: true
       plots.set.flag.hanging-break.*: true
+      plots.set.flag.vehicle-use: true
       plots.set.flag.vehicle-use.*: true
+      plots.set.flag.vehicle-place: true
       plots.set.flag.vehicle-place.*: true
+      plots.set.flag.vehicle-break: true
       plots.set.flag.vehicle-break.*: true
+      plots.set.flag.place: true
       plots.set.flag.place.*: true
+      plots.set.flag.break: true
       plots.set.flag.break.*: true
+      plots.set.flag.use: true
       plots.set.flag.use.*: true
+      plots.set.flag.forcefield: true
       plots.set.flag.forcefield.*: true
-      plots.set.flag.price.*: true
+      plots.set.flag.price: true
+      plots.set.flag.no-worldedit: true
       plots.set.flag.no-worldedit.*: true
   plots.permpack.basicinbox:
     default: false

--- a/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
@@ -146,7 +146,7 @@ public final class FlagCommand extends Command {
             } catch (final Exception e) {
                 return false;
             }
-            return true;//
+            return true;
         }
         boolean result;
         String basePerm = Permission.PERMISSION_SET_FLAG_KEY.format(key.toLowerCase());

--- a/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
@@ -102,22 +102,23 @@ public final class FlagCommand extends Command {
             try {
                 int numeric = Integer.parseInt(value);
                 perm = perm.substring(0, perm.length() - value.length() - 1);
+                boolean result = false;
                 if (numeric > 0) {
                     int checkRange = PlotSquared.get().getPlatform().equalsIgnoreCase("bukkit") ?
                             numeric :
                             Settings.Limit.MAX_PLOTS;
-                    final boolean result = player.hasPermissionRange(perm, checkRange) >= numeric;
-                    if (!result) {
-                        player.sendMessage(
-                                TranslatableCaption.of("permission.no_permission"),
-                                Template.of(
-                                        "node",
-                                        Permission.PERMISSION_SET_FLAG_KEY_VALUE.format(key.toLowerCase(), value.toLowerCase())
-                                )
-                        );
-                    }
-                    return result;
+                    result = player.hasPermissionRange(perm, checkRange) >= numeric;
                 }
+                if (!result) {
+                    player.sendMessage(
+                            TranslatableCaption.of("permission.no_permission"),
+                            Template.of(
+                                    "node",
+                                    perm
+                            )
+                    );
+                }
+                return result;
             } catch (NumberFormatException ignore) {
             }
         } else if (flag instanceof final ListFlag<?, ?> listFlag) {
@@ -145,9 +146,16 @@ public final class FlagCommand extends Command {
             } catch (final Exception e) {
                 return false;
             }
-            return true;
+            return true;//
         }
-        final boolean result = Permissions.hasPermission(player, perm);
+        boolean result;
+        String basePerm = Permission.PERMISSION_SET_FLAG_KEY.format(key.toLowerCase());
+        if (flag.isValuedPermission()) {
+            result = Permissions.hasKeyedPermission(player, basePerm, value);
+        } else {
+            result = Permissions.hasPermission(player, basePerm);
+            perm = basePerm;
+        }
         if (!result) {
             player.sendMessage(TranslatableCaption.of("permission.no_permission"), Template.of("node", perm));
         }

--- a/Core/src/main/java/com/plotsquared/core/permissions/ConsolePermissionProfile.java
+++ b/Core/src/main/java/com/plotsquared/core/permissions/ConsolePermissionProfile.java
@@ -39,4 +39,13 @@ public enum ConsolePermissionProfile implements PermissionProfile {
         return true;
     }
 
+    @Override
+    public boolean hasKeyedPermission(
+            final @Nullable String world,
+            final @NonNull String permission,
+            final @NonNull String key
+    ) {
+        return true;
+    }
+
 }

--- a/Core/src/main/java/com/plotsquared/core/permissions/NullPermissionProfile.java
+++ b/Core/src/main/java/com/plotsquared/core/permissions/NullPermissionProfile.java
@@ -39,4 +39,13 @@ public enum NullPermissionProfile implements PermissionProfile {
         return false;
     }
 
+    @Override
+    public boolean hasKeyedPermission(
+            final @Nullable String world,
+            final @NonNull String permission,
+            final @NonNull String key
+    ) {
+        return false;
+    }
+
 }

--- a/Core/src/main/java/com/plotsquared/core/permissions/PermissionHolder.java
+++ b/Core/src/main/java/com/plotsquared/core/permissions/PermissionHolder.java
@@ -116,9 +116,6 @@ public interface PermissionHolder {
      * @param key        Permission "key"
      * @return {@code true} if the owner has the given permission, else {@code false}
      */
-    boolean hasKeyedPermission(
-            @Nullable String world, final @NonNull String permission,
-            final @NonNull String key
-    );
+    boolean hasKeyedPermission(@Nullable String world, @NonNull String permission, @NonNull String key);
 
 }

--- a/Core/src/main/java/com/plotsquared/core/permissions/PermissionHolder.java
+++ b/Core/src/main/java/com/plotsquared/core/permissions/PermissionHolder.java
@@ -46,6 +46,21 @@ public interface PermissionHolder {
     }
 
     /**
+     * Check if the owner of the profile has a given (global) keyed permission. Checks both {@code permission.key}
+     * and {@code permission.*}
+     *
+     * @param permission Permission
+     * @param key        Permission "key"
+     * @return {@code true} if the owner has the given permission, else {@code false}
+     */
+    default boolean hasKeyedPermission(
+            final @NonNull String permission,
+            final @NonNull String key
+    ) {
+        return hasKeyedPermission(null, permission, key);
+    }
+
+    /**
      * Check the highest permission a PlotPlayer has within a specified range.<br>
      * - Excessively high values will lag<br>
      * - The default range that is checked is {@link Settings.Limit#MAX_PLOTS}<br>
@@ -91,5 +106,19 @@ public interface PermissionHolder {
      * @return {@code true} if the owner has the given permission, else {@code false}
      */
     boolean hasPermission(@Nullable String world, @NonNull String permission);
+
+    /**
+     * Check if the owner of the profile has a given keyed permission. Checks both {@code permission.key}
+     * and {@code permission.*}
+     *
+     * @param world      World name
+     * @param permission Permission
+     * @param key        Permission "key"
+     * @return {@code true} if the owner has the given permission, else {@code false}
+     */
+    boolean hasKeyedPermission(
+            @Nullable String world, final @NonNull String permission,
+            final @NonNull String key
+    );
 
 }

--- a/Core/src/main/java/com/plotsquared/core/permissions/PermissionProfile.java
+++ b/Core/src/main/java/com/plotsquared/core/permissions/PermissionProfile.java
@@ -52,4 +52,33 @@ public interface PermissionProfile {
      */
     boolean hasPermission(final @Nullable String world, @NonNull String permission);
 
+    /**
+     * Check if the owner of the profile has a given (global) keyed permission. Checks both {@code permission.key}
+     * and {@code permission.*}
+     *
+     * @param permission Permission
+     * @param key        Permission "key"
+     * @return {@code true} if the owner has the given permission, else {@code false}
+     */
+    default boolean hasKeyedPermission(
+            final @NonNull String permission,
+            final @NonNull String key
+    ) {
+        return hasKeyedPermission(null, permission, key);
+    }
+
+    /**
+     * Check if the owner of the profile has a given keyed permission. Checks both {@code permission.key}
+     * and {@code permission.*}
+     *
+     * @param world      World name
+     * @param permission Permission
+     * @param key        Permission "key"
+     * @return {@code true} if the owner has the given permission, else {@code false}
+     */
+    boolean hasKeyedPermission(
+            @Nullable String world, final @NonNull String permission,
+            final @NonNull String key
+    );
+
 }

--- a/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
+++ b/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
@@ -197,6 +197,15 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
         return this.permissionProfile.hasPermission(world, permission);
     }
 
+    @Override
+    public final boolean hasKeyedPermission(
+            final @Nullable String world,
+            final @NonNull String permission,
+            final @NonNull String key
+    ) {
+        return this.permissionProfile.hasKeyedPermission(world, permission, key);
+    }
+
     public abstract Actor toActor();
 
     public abstract P getPlatformPlayer();

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/PlotFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/PlotFlag.java
@@ -159,6 +159,15 @@ public abstract class PlotFlag<T, F extends PlotFlag<T, F>> {
     }
 
     /**
+     * Get if the flag's permission should check for values. E.g. plot.flag.set.music.VALUE
+     *
+     * @return if valued permission
+     */
+    public boolean isValuedPermission() {
+        return true;
+    }
+
+    /**
      * An example of a string that would parse into a valid
      * flag value.
      *

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/PlotFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/PlotFlag.java
@@ -159,7 +159,7 @@ public abstract class PlotFlag<T, F extends PlotFlag<T, F>> {
     }
 
     /**
-     * Get if the flag's permission should check for values. E.g. plot.flag.set.music.VALUE
+     * Get if the flag's permission should check for values. E.g. plots.flag.set.music.VALUE
      *
      * @return if valued permission
      */

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/types/DoubleFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/types/DoubleFlag.java
@@ -68,4 +68,9 @@ public abstract class DoubleFlag<F extends NumberFlag<Double, F>> extends Number
         }
     }
 
+    @Override
+    public boolean isValuedPermission() {
+        return false;
+    }
+
 }

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/types/LongFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/types/LongFlag.java
@@ -72,4 +72,9 @@ public abstract class LongFlag<F extends NumberFlag<Long, F>> extends NumberFlag
         }
     }
 
+    @Override
+    public boolean isValuedPermission() {
+        return false;
+    }
+
 }

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/types/StringFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/types/StringFlag.java
@@ -29,6 +29,10 @@ import com.plotsquared.core.configuration.caption.Caption;
 import com.plotsquared.core.plot.flag.PlotFlag;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+/**
+ * Plot flag representing a string value.
+ * This should be used where strings are not "keys" themselves, e.g. when setting enums
+ */
 public abstract class StringFlag<F extends StringFlag<F>> extends PlotFlag<String, F> {
 
     /**
@@ -44,6 +48,11 @@ public abstract class StringFlag<F extends StringFlag<F>> extends PlotFlag<Strin
             final @NonNull Caption flagDescription
     ) {
         super(value, flagCategory, flagDescription);
+    }
+
+    @Override
+    public boolean isValuedPermission() {
+        return false;
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/util/Permissions.java
+++ b/Core/src/main/java/com/plotsquared/core/util/Permissions.java
@@ -67,6 +67,22 @@ public class Permissions {
     }
 
     /**
+     * Check if the owner of the profile has a given (global) keyed permission. Checks both {@code permission.key}
+     * and {@code permission.*}
+     *
+     * @param caller     permission holder
+     * @param permission Permission
+     * @param key        Permission "key"
+     * @return {@code true} if the owner has the given permission, else {@code false}
+     */
+    public static boolean hasKeyedPermission(
+            final @NonNull PermissionHolder caller, final @NonNull String permission,
+            final @NonNull String key
+    ) {
+        return caller.hasKeyedPermission(permission, key);
+    }
+
+    /**
      * Checks if a PlotPlayer has a permission, and optionally send the no permission message if applicable.
      *
      * @param player     permission holder


### PR DESCRIPTION
- Some flags should not check for a permission "value", mainly string flags
- Add a default true method for asking a flag if it requires a "valued" permission
- Add "keyed" permissions, where we would only expect certain values from a permission, allowing for the "*" modifier to make sense. E.g. with the music flag.
- Flag permissions without the ".*" make sense to be given to players in the permpack
- Fixes #3151