### PR TITLE
Return base plot when using alias

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -368,7 +368,7 @@ public class Plot {
             for (Plot p : plots) {
                 String name = p.getAlias();
                 if (!name.isEmpty() && name.equalsIgnoreCase(arg)) {
-                    return p;
+                    return p.getBasePlot(false);
                 }
             }
             if (message && player != null) {


### PR DESCRIPTION
## Overview
Currently, when using for example /p h test, and the plot consist out of multiple plots, the home location is ignored
and when using /p info test and /p info on the same plot the returned plot is always different.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v6/CONTRIBUTING.md)
