### PR TITLE
Respect non-visible players in tab completion (Closes #3263)

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Add.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Add.java
@@ -166,7 +166,7 @@ public class Add extends Command {
 
     @Override
     public Collection<Command> tab(final PlotPlayer<?> player, final String[] args, final boolean space) {
-        return TabCompletions.completePlayers(String.join(",", args).trim(), Collections.emptyList());
+        return TabCompletions.completePlayers(player, String.join(",", args).trim(), Collections.emptyList());
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/command/Area.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Area.java
@@ -856,11 +856,11 @@ public class Area extends SubCommand {
                     ) {
                     }).collect(Collectors.toCollection(LinkedList::new));
             if (Permissions.hasPermission(player, Permission.PERMISSION_AREA) && args[0].length() > 0) {
-                commands.addAll(TabCompletions.completePlayers(args[0], Collections.emptyList()));
+                commands.addAll(TabCompletions.completePlayers(player, args[0], Collections.emptyList()));
             }
             return commands;
         }
-        return TabCompletions.completePlayers(String.join(",", args).trim(), Collections.emptyList());
+        return TabCompletions.completePlayers(player, String.join(",", args).trim(), Collections.emptyList());
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/command/Cluster.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Cluster.java
@@ -916,11 +916,11 @@ public class Cluster extends SubCommand {
                     ) {
                     }).collect(Collectors.toCollection(LinkedList::new));
             if (Permissions.hasPermission(player, Permission.PERMISSION_CLUSTER) && args[0].length() > 0) {
-                commands.addAll(TabCompletions.completePlayers(args[0], Collections.emptyList()));
+                commands.addAll(TabCompletions.completePlayers(player, args[0], Collections.emptyList()));
             }
             return commands;
         }
-        return TabCompletions.completePlayers(String.join(",", args).trim(), Collections.emptyList());
+        return TabCompletions.completePlayers(player, String.join(",", args).trim(), Collections.emptyList());
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/command/Deny.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Deny.java
@@ -157,7 +157,7 @@ public class Deny extends SubCommand {
 
     @Override
     public Collection<Command> tab(final PlotPlayer<?> player, final String[] args, final boolean space) {
-        return TabCompletions.completePlayers(String.join(",", args).trim(), Collections.emptyList());
+        return TabCompletions.completePlayers(player, String.join(",", args).trim(), Collections.emptyList());
     }
 
     private void handleKick(PlotPlayer<?> player, Plot plot) {

--- a/Core/src/main/java/com/plotsquared/core/command/Dislike.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Dislike.java
@@ -70,11 +70,11 @@ public class Dislike extends SubCommand {
                     .map(completion -> new Command(null, true, completion, "", RequiredType.PLAYER, CommandCategory.INFO) {
                     }).collect(Collectors.toCollection(LinkedList::new));
             if (Permissions.hasPermission(player, Permission.PERMISSION_RATE) && args[0].length() > 0) {
-                commands.addAll(TabCompletions.completePlayers(args[0], Collections.emptyList()));
+                commands.addAll(TabCompletions.completePlayers(player, args[0], Collections.emptyList()));
             }
             return commands;
         }
-        return TabCompletions.completePlayers(String.join(",", args).trim(), Collections.emptyList());
+        return TabCompletions.completePlayers(player, String.join(",", args).trim(), Collections.emptyList());
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/command/Download.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Download.java
@@ -173,11 +173,11 @@ public class Download extends SubCommand {
                     ) {
                     }).collect(Collectors.toCollection(LinkedList::new));
             if (Permissions.hasPermission(player, Permission.PERMISSION_DOWNLOAD) && args[0].length() > 0) {
-                commands.addAll(TabCompletions.completePlayers(args[0], Collections.emptyList()));
+                commands.addAll(TabCompletions.completePlayers(player, args[0], Collections.emptyList()));
             }
             return commands;
         }
-        return TabCompletions.completePlayers(String.join(",", args).trim(), Collections.emptyList());
+        return TabCompletions.completePlayers(player, String.join(",", args).trim(), Collections.emptyList());
     }
 
     private void upload(PlotPlayer<?> player, Plot plot) {

--- a/Core/src/main/java/com/plotsquared/core/command/Grant.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Grant.java
@@ -176,11 +176,11 @@ public class Grant extends Command {
                     ) {
                     }).collect(Collectors.toCollection(LinkedList::new));
             if (Permissions.hasPermission(player, Permission.PERMISSION_GRANT_SINGLE) && args[0].length() > 0) {
-                commands.addAll(TabCompletions.completePlayers(args[0], Collections.emptyList()));
+                commands.addAll(TabCompletions.completePlayers(player, args[0], Collections.emptyList()));
             }
             return commands;
         }
-        return TabCompletions.completePlayers(String.join(",", args).trim(), Collections.emptyList());
+        return TabCompletions.completePlayers(player, String.join(",", args).trim(), Collections.emptyList());
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/command/Inbox.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Inbox.java
@@ -307,11 +307,11 @@ public class Inbox extends SubCommand {
                     .map(completion -> new Command(null, true, completion, "", RequiredType.PLAYER, CommandCategory.CHAT) {
                     }).collect(Collectors.toCollection(LinkedList::new));
             if (Permissions.hasPermission(player, Permission.PERMISSION_INBOX) && args[0].length() > 0) {
-                commands.addAll(TabCompletions.completePlayers(args[0], Collections.emptyList()));
+                commands.addAll(TabCompletions.completePlayers(player, args[0], Collections.emptyList()));
             }
             return commands;
         }
-        return TabCompletions.completePlayers(String.join(",", args).trim(), Collections.emptyList());
+        return TabCompletions.completePlayers(player, String.join(",", args).trim(), Collections.emptyList());
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/command/Info.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Info.java
@@ -161,7 +161,7 @@ public class Info extends SubCommand {
                 }).collect(Collectors.toCollection(LinkedList::new));
 
         if (Permissions.hasPermission(player, Permission.PERMISSION_AREA_INFO_FORCE) && args[0].length() > 0) {
-            commands.addAll(TabCompletions.completePlayers(args[0], Collections.emptyList()));
+            commands.addAll(TabCompletions.completePlayers(player, args[0], Collections.emptyList()));
         }
 
         return commands;

--- a/Core/src/main/java/com/plotsquared/core/command/Like.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Like.java
@@ -220,11 +220,11 @@ public class Like extends SubCommand {
                     .map(completion -> new Command(null, true, completion, "", RequiredType.PLAYER, CommandCategory.INFO) {
                     }).collect(Collectors.toCollection(LinkedList::new));
             if (Permissions.hasPermission(player, Permission.PERMISSION_RATE) && args[0].length() > 0) {
-                commands.addAll(TabCompletions.completePlayers(args[0], Collections.emptyList()));
+                commands.addAll(TabCompletions.completePlayers(player, args[0], Collections.emptyList()));
             }
             return commands;
         }
-        return TabCompletions.completePlayers(String.join(",", args).trim(), Collections.emptyList());
+        return TabCompletions.completePlayers(player, String.join(",", args).trim(), Collections.emptyList());
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/command/ListCmd.java
+++ b/Core/src/main/java/com/plotsquared/core/command/ListCmd.java
@@ -532,7 +532,7 @@ public class ListCmd extends SubCommand {
                 }).collect(Collectors.toCollection(LinkedList::new));
 
         if (Permissions.hasPermission(player, Permission.PERMISSION_LIST_PLAYER) && args[0].length() > 0) {
-            commands.addAll(TabCompletions.completePlayers(args[0], Collections.emptyList()));
+            commands.addAll(TabCompletions.completePlayers(player, args[0], Collections.emptyList()));
         }
 
         return commands;

--- a/Core/src/main/java/com/plotsquared/core/command/Owner.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Owner.java
@@ -209,7 +209,7 @@ public class Owner extends SetCommand {
 
     @Override
     public Collection<Command> tab(final PlotPlayer<?> player, final String[] args, final boolean space) {
-        return TabCompletions.completePlayers(String.join(",", args).trim(), Collections.emptyList());
+        return TabCompletions.completePlayers(player, String.join(",", args).trim(), Collections.emptyList());
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/command/Rate.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Rate.java
@@ -292,11 +292,11 @@ public class Rate extends SubCommand {
                     .map(completion -> new Command(null, true, completion, "", RequiredType.PLAYER, CommandCategory.INFO) {
                     }).collect(Collectors.toCollection(LinkedList::new));
             if (Permissions.hasPermission(player, Permission.PERMISSION_RATE) && args[0].length() > 0) {
-                commands.addAll(TabCompletions.completePlayers(args[0], Collections.emptyList()));
+                commands.addAll(TabCompletions.completePlayers(player, args[0], Collections.emptyList()));
             }
             return commands;
         }
-        return TabCompletions.completePlayers(String.join(",", args).trim(), Collections.emptyList());
+        return TabCompletions.completePlayers(player, String.join(",", args).trim(), Collections.emptyList());
     }
 
     private static class MutableInt {

--- a/Core/src/main/java/com/plotsquared/core/command/Remove.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Remove.java
@@ -142,7 +142,7 @@ public class Remove extends SubCommand {
         if (plot == null) {
             return Collections.emptyList();
         }
-        return TabCompletions.completeAddedPlayers(plot, String.join(",", args).trim(),
+        return TabCompletions.completeAddedPlayers(player, plot, String.join(",", args).trim(),
                 Collections.singletonList(player.getName())
         );
     }

--- a/Core/src/main/java/com/plotsquared/core/command/SchematicCmd.java
+++ b/Core/src/main/java/com/plotsquared/core/command/SchematicCmd.java
@@ -317,11 +317,11 @@ public class SchematicCmd extends SubCommand {
                     ) {
                     }).collect(Collectors.toCollection(LinkedList::new));
             if (Permissions.hasPermission(player, Permission.PERMISSION_SCHEMATIC) && args[0].length() > 0) {
-                commands.addAll(TabCompletions.completePlayers(args[0], Collections.emptyList()));
+                commands.addAll(TabCompletions.completePlayers(player, args[0], Collections.emptyList()));
             }
             return commands;
         }
-        return TabCompletions.completePlayers(String.join(",", args).trim(), Collections.emptyList());
+        return TabCompletions.completePlayers(player, String.join(",", args).trim(), Collections.emptyList());
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/command/Set.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Set.java
@@ -288,7 +288,7 @@ public class Set extends SubCommand {
                     }).collect(Collectors.toCollection(LinkedList::new));
 
             if (Permissions.hasPermission(player, Permission.PERMISSION_SET) && args[0].length() > 0) {
-                commands.addAll(TabCompletions.completePlayers(args[0], Collections.emptyList()));
+                commands.addAll(TabCompletions.completePlayers(player, args[0], Collections.emptyList()));
             }
             return commands;
         } else if (args.length > 1) {

--- a/Core/src/main/java/com/plotsquared/core/command/Template.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Template.java
@@ -305,11 +305,11 @@ public class Template extends SubCommand {
                     ) {
                     }).collect(Collectors.toCollection(LinkedList::new));
             if (Permissions.hasPermission(player, Permission.PERMISSION_TEMPLATE) && args[0].length() > 0) {
-                commands.addAll(TabCompletions.completePlayers(args[0], Collections.emptyList()));
+                commands.addAll(TabCompletions.completePlayers(player, args[0], Collections.emptyList()));
             }
             return commands;
         }
-        return TabCompletions.completePlayers(String.join(",", args).trim(), Collections.emptyList());
+        return TabCompletions.completePlayers(player, String.join(",", args).trim(), Collections.emptyList());
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/command/Trust.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Trust.java
@@ -168,7 +168,7 @@ public class Trust extends Command {
 
     @Override
     public Collection<Command> tab(final PlotPlayer<?> player, final String[] args, final boolean space) {
-        return TabCompletions.completePlayers(String.join(",", args).trim(), Collections.emptyList());
+        return TabCompletions.completePlayers(player, String.join(",", args).trim(), Collections.emptyList());
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/command/Visit.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Visit.java
@@ -334,7 +334,7 @@ public class Visit extends Command {
     public Collection<Command> tab(PlotPlayer<?> player, String[] args, boolean space) {
         final List<Command> completions = new ArrayList<>();
         switch (args.length - 1) {
-            case 0 -> completions.addAll(TabCompletions.completePlayers(args[0], Collections.emptyList()));
+            case 0 -> completions.addAll(TabCompletions.completePlayers(player, args[0], Collections.emptyList()));
             case 1 -> {
                 completions.addAll(
                         TabCompletions.completeAreas(args[1]));

--- a/Core/src/main/java/com/plotsquared/core/util/TabCompletions.java
+++ b/Core/src/main/java/com/plotsquared/core/util/TabCompletions.java
@@ -74,8 +74,6 @@ public final class TabCompletions {
                 "This is a utility class and cannot be instantiated");
     }
 
-
-
     /**
      * Get a list of tab completions corresponding to player names. This uses the UUID pipeline
      * cache, so it will complete will all names known to PlotSquared
@@ -85,6 +83,7 @@ public final class TabCompletions {
      * @return List of completions
      * @deprecated In favor {@link #completePlayers(PlotPlayer, String, List)}
      */
+    @Deprecated(forRemoval = true)
     public static @NonNull List<Command> completePlayers(
             final @NonNull String input,
             final @NonNull List<String> existing
@@ -119,6 +118,7 @@ public final class TabCompletions {
      *
      * @deprecated In favor {@link #completeAddedPlayers(PlotPlayer, Plot, String, List)}
      */
+    @Deprecated(forRemoval = true)
     public static @NonNull List<Command> completeAddedPlayers(
             final @NonNull Plot plot,
             final @NonNull String input, final @NonNull List<String> existing
@@ -256,7 +256,6 @@ public final class TabCompletions {
         return Collections.unmodifiableList(completions);
     }
 
-
     /**
      * @param cacheIdentifier Cache key
      * @param input           Command input
@@ -265,6 +264,7 @@ public final class TabCompletions {
      * @return List of completions
      * @deprecated In favor {@link #completePlayers(String, PlotPlayer, String, List, Predicate)}
      */
+    @Deprecated(forRemoval = true)
     private static List<Command> completePlayers(
             final @NonNull String cacheIdentifier,
             final @NonNull String input, final @NonNull List<String> existing,

--- a/Core/src/main/java/com/plotsquared/core/util/TabCompletions.java
+++ b/Core/src/main/java/com/plotsquared/core/util/TabCompletions.java
@@ -1,283 +1,1 @@
-/*
- *       _____  _       _    _____                                _
- *      |  __ \| |     | |  / ____|                              | |
- *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
- *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
- *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
- *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
- *                                    | |
- *                                    |_|
- *            PlotSquared plot management system for Minecraft
- *                  Copyright (C) 2021 IntellectualSites
- *
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-package com.plotsquared.core.util;
-
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import com.plotsquared.core.PlotSquared;
-import com.plotsquared.core.command.Command;
-import com.plotsquared.core.command.CommandCategory;
-import com.plotsquared.core.command.RequiredType;
-import com.plotsquared.core.configuration.Settings;
-import com.plotsquared.core.player.PlotPlayer;
-import com.plotsquared.core.plot.Plot;
-import com.plotsquared.core.plot.PlotArea;
-import com.plotsquared.core.uuid.UUIDMapping;
-import org.checkerframework.checker.nullness.qual.NonNull;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
-/**
- * Tab completion utilities
- */
-public final class TabCompletions {
-
-    private static final Cache<String, List<String>> cachedCompletionValues =
-            CacheBuilder.newBuilder()
-                    .expireAfterWrite(Settings.Tab_Completions.CACHE_EXPIRATION, TimeUnit.SECONDS)
-                    .build();
-
-    private static final Command booleanTrueCompletion = new Command(null, false, "true", "",
-            RequiredType.NONE, null
-    ) {
-    };
-    private static final Command booleanFalseCompletion = new Command(null, false, "false", "",
-            RequiredType.NONE, null
-    ) {
-    };
-
-    private TabCompletions() {
-        throw new UnsupportedOperationException(
-                "This is a utility class and cannot be instantiated");
-    }
-
-    /**
-     * Get a list of tab completions corresponding to player names. This uses the UUID pipeline
-     * cache, so it will complete will all names known to PlotSquared
-     *
-     * @param input    Command input
-     * @param issuer   The player who issued the tab completion
-     * @param existing Players that should not be included in completions
-     * @return List of completions
-     */
-    public static @NonNull List<Command> completePlayers(
-            final @NonNull PlotPlayer<?> issuer,
-            final @NonNull String input,
-            final @NonNull List<String> existing
-    ) {
-        return completePlayers("players", issuer, input, existing, uuid -> true);
-    }
-
-    /**
-     * Get a list of tab completions corresponding to player names added to the given plot.
-     *
-     * @param issuer          The player who issued the tab completion
-     * @param plot     Plot to complete added players for
-     * @param input    Command input
-     * @param existing Players that should not be included in completions
-     * @return List of completions
-     */
-    public static @NonNull List<Command> completeAddedPlayers(
-            final @NonNull PlotPlayer<?> issuer,
-            final @NonNull Plot plot,
-            final @NonNull String input, final @NonNull List<String> existing
-    ) {
-        return completePlayers("added" + plot, issuer, input, existing,
-                uuid -> plot.getMembers().contains(uuid)
-                        || plot.getTrusted().contains(uuid)
-                        || plot.getDenied().contains(uuid)
-        );
-    }
-
-    public static @NonNull List<Command> completePlayersInPlot(
-            final @NonNull Plot plot,
-            final @NonNull String input, final @NonNull List<String> existing
-    ) {
-        List<String> players = cachedCompletionValues.getIfPresent("inPlot" + plot);
-        if (players == null) {
-            final List<PlotPlayer<?>> inPlot = plot.getPlayersInPlot();
-            players = new ArrayList<>(inPlot.size());
-            for (PlotPlayer<?> player : inPlot) {
-                players.add(player.getName());
-            }
-            cachedCompletionValues.put("inPlot" + plot, players);
-        }
-        return filterCached(players, input, existing);
-    }
-
-    /**
-     * Get a list of completions corresponding to WorldEdit(/FAWE) patterns. This uses
-     * WorldEdit's pattern completer internally.
-     *
-     * @param input Command input
-     * @return List of completions
-     */
-    public static @NonNull List<Command> completePatterns(final @NonNull String input) {
-        return PatternUtil.getSuggestions(input.trim()).stream()
-                .map(value -> value.toLowerCase(Locale.ENGLISH).replace("minecraft:", ""))
-                .filter(value -> value.startsWith(input.toLowerCase(Locale.ENGLISH)))
-                .map(value -> new Command(null, false, value, "", RequiredType.NONE, null) {
-                }).collect(Collectors.toList());
-    }
-
-    public static @NonNull List<Command> completeBoolean(final @NonNull String input) {
-        if (input.isEmpty()) {
-            return Arrays.asList(booleanTrueCompletion, booleanFalseCompletion);
-        }
-        if ("true".startsWith(input)) {
-            return Collections.singletonList(booleanTrueCompletion);
-        }
-        if ("false".startsWith(input)) {
-            return Collections.singletonList(booleanFalseCompletion);
-        }
-        return Collections.emptyList();
-    }
-
-    /**
-     * Get a list of integer numbers matching the given input. If the input string
-     * is empty, nothing will be returned. The list is unmodifiable.
-     *
-     * @param input        Input to filter with
-     * @param amountLimit  Maximum amount of suggestions
-     * @param highestLimit Highest number to include
-     * @return Unmodifiable list of number completions
-     */
-    public static @NonNull List<Command> completeNumbers(
-            final @NonNull String input,
-            final int amountLimit, final int highestLimit
-    ) {
-        if (input.isEmpty() || input.length() > highestLimit || !MathMan.isInteger(input)) {
-            return Collections.emptyList();
-        }
-        int offset;
-        try {
-            offset = Integer.parseInt(input) * 10;
-        } catch (NumberFormatException ignored) {
-            return Collections.emptyList();
-        }
-        final List<String> commands = new ArrayList<>();
-        for (int i = offset; i < highestLimit && (offset - i + amountLimit) > 0; i++) {
-            commands.add(String.valueOf(i));
-        }
-        return asCompletions(commands.toArray(new String[0]));
-    }
-
-    /**
-     * Get a list of plot areas matching the given input.
-     * The list is unmodifiable.
-     *
-     * @param input Input to filter with
-     * @return Unmodifiable list of area completions
-     */
-    public static @NonNull List<Command> completeAreas(final @NonNull String input) {
-        final List<Command> completions = new ArrayList<>();
-        for (final PlotArea area : PlotSquared.get().getPlotAreaManager().getAllPlotAreas()) {
-            String areaName = area.getWorldName();
-            if (area.getId() != null) {
-                areaName += ";" + area.getId();
-            }
-            if (!areaName.toLowerCase().startsWith(input.toLowerCase())) {
-                continue;
-            }
-            completions.add(new Command(null, false, areaName, "",
-                    RequiredType.NONE, null
-            ) {
-            });
-        }
-        return Collections.unmodifiableList(completions);
-    }
-
-    public static @NonNull List<Command> asCompletions(String... toFilter) {
-        final List<Command> completions = new ArrayList<>();
-        for (String completion : toFilter) {
-            completions.add(new Command(null, false, completion, "",
-                    RequiredType.NONE, null
-            ) {
-            });
-        }
-        return Collections.unmodifiableList(completions);
-    }
-
-    /**
-     * @param cacheIdentifier Cache key
-     * @param issuer          The player who issued the tab completion
-     * @param input           Command input
-     * @param existing        Players that should not be included in completions
-     * @param uuidFilter      Filter applied before caching values
-     * @return List of completions
-     */
-    private static List<Command> completePlayers(
-            final @NonNull String cacheIdentifier,
-            final @NonNull PlotPlayer<?> issuer,
-            final @NonNull String input, final @NonNull List<String> existing,
-            final @NonNull Predicate<UUID> uuidFilter
-    ) {
-        List<String> players;
-        if (Settings.Enabled_Components.EXTENDED_USERNAME_COMPLETION) {
-            players = cachedCompletionValues.getIfPresent(cacheIdentifier);
-            if (players == null) {
-                final Collection<UUIDMapping> mappings =
-                        PlotSquared.get().getImpromptuUUIDPipeline().getAllImmediately();
-                players = new ArrayList<>(mappings.size());
-                for (final UUIDMapping mapping : mappings) {
-                    if (uuidFilter.test(mapping.getUuid())) {
-                        players.add(mapping.getUsername());
-                    }
-                }
-                cachedCompletionValues.put(cacheIdentifier, players);
-            }
-        } else {
-            final Collection<? extends PlotPlayer<?>> onlinePlayers = PlotSquared.platform().playerManager().getPlayers();
-            players = new ArrayList<>(onlinePlayers.size());
-            for (final PlotPlayer<?> player : onlinePlayers) {
-                if (!uuidFilter.test(player.getUUID())) {
-                    continue;
-                }
-                if (!issuer.canSee(player)) {
-                    continue;
-                }
-                players.add(player.getName());
-            }
-        }
-        return filterCached(players, input, existing);
-    }
-
-    private static List<Command> filterCached(
-            Collection<String> playerNames, String input,
-            List<String> existing
-    ) {
-        final String processedInput = input.toLowerCase(Locale.ENGLISH);
-        return playerNames.stream().filter(player -> player.toLowerCase(Locale.ENGLISH).startsWith(processedInput))
-                .filter(player -> !existing.contains(player)).map(
-                        player -> new Command(null, false, player, "", RequiredType.NONE,
-                                CommandCategory.INFO
-                        ) {
-                        })
-                /* If there are more than 200 suggestions, just send the first 200 */
-                .limit(200)
-                .collect(Collectors.toList());
-    }
-
-}
+/* *       _____  _       _    _____                                _ *      |  __ \| |     | |  / ____|                              | | *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| | *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` | *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| | *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_| *                                    | | *                                    |_| *            PlotSquared plot management system for Minecraft *                  Copyright (C) 2021 IntellectualSites * *     This program is free software: you can redistribute it and/or modify *     it under the terms of the GNU General Public License as published by *     the Free Software Foundation, either version 3 of the License, or *     (at your option) any later version. * *     This program is distributed in the hope that it will be useful, *     but WITHOUT ANY WARRANTY; without even the implied warranty of *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the *     GNU General Public License for more details. * *     You should have received a copy of the GNU General Public License *     along with this program.  If not, see <https://www.gnu.org/licenses/>. */package com.plotsquared.core.util;import com.google.common.cache.Cache;import com.google.common.cache.CacheBuilder;import com.plotsquared.core.PlotSquared;import com.plotsquared.core.command.Command;import com.plotsquared.core.command.CommandCategory;import com.plotsquared.core.command.RequiredType;import com.plotsquared.core.configuration.Settings;import com.plotsquared.core.player.PlotPlayer;import com.plotsquared.core.plot.Plot;import com.plotsquared.core.plot.PlotArea;import com.plotsquared.core.uuid.UUIDMapping;import org.checkerframework.checker.nullness.qual.NonNull;import org.checkerframework.checker.nullness.qual.Nullable;import java.util.ArrayList;import java.util.Arrays;import java.util.Collection;import java.util.Collections;import java.util.List;import java.util.Locale;import java.util.UUID;import java.util.concurrent.TimeUnit;import java.util.function.Predicate;import java.util.stream.Collectors;/** * Tab completion utilities */public final class TabCompletions {    private static final Cache<String, List<String>> cachedCompletionValues =            CacheBuilder.newBuilder()                    .expireAfterWrite(Settings.Tab_Completions.CACHE_EXPIRATION, TimeUnit.SECONDS)                    .build();    private static final Command booleanTrueCompletion = new Command(null, false, "true", "",            RequiredType.NONE, null    ) {    };    private static final Command booleanFalseCompletion = new Command(null, false, "false", "",            RequiredType.NONE, null    ) {    };    private TabCompletions() {        throw new UnsupportedOperationException(                "This is a utility class and cannot be instantiated");    }    /**     * Get a list of tab completions corresponding to player names. This uses the UUID pipeline     * cache, so it will complete will all names known to PlotSquared     *     * @param input    Command input     * @param existing Players that should not be included in completions     * @return List of completions     * @deprecated In favor {@link #completePlayers(PlotPlayer, String, List)}     */    public static @NonNull List<Command> completePlayers(            final @NonNull String input,            final @NonNull List<String> existing    ) {        return completePlayers(null, input, existing);    }    /**     * Get a list of tab completions corresponding to player names. This uses the UUID pipeline     * cache, so it will complete will all names known to PlotSquared     *     * @param input    Command input     * @param issuer   The player who issued the tab completion     * @param existing Players that should not be included in completions     * @return List of completions     */    public static @NonNull List<Command> completePlayers(            final @Nullable PlotPlayer<?> issuer,            final @NonNull String input,            final @NonNull List<String> existing    ) {        return completePlayers("players", issuer, input, existing, uuid -> true);    }    /**     * Get a list of tab completions corresponding to player names added to the given plot.     *     * @param plot     Plot to complete added players for     * @param input    Command input     * @param existing Players that should not be included in completions     * @return List of completions     *     * @deprecated In favor {@link #completeAddedPlayers(PlotPlayer, Plot, String, List)}     */    public static @NonNull List<Command> completeAddedPlayers(            final @NonNull Plot plot,            final @NonNull String input, final @NonNull List<String> existing    ) {        return completeAddedPlayers(null, plot, input, existing);    }    /**     * Get a list of tab completions corresponding to player names added to the given plot.     *     * @param issuer   The player who issued the tab completion     * @param plot     Plot to complete added players for     * @param input    Command input     * @param existing Players that should not be included in completions     * @return List of completions     */    public static @NonNull List<Command> completeAddedPlayers(            final @Nullable PlotPlayer<?> issuer,            final @NonNull Plot plot,            final @NonNull String input, final @NonNull List<String> existing    ) {        return completePlayers("added" + plot, issuer, input, existing,                uuid -> plot.getMembers().contains(uuid)                        || plot.getTrusted().contains(uuid)                        || plot.getDenied().contains(uuid)        );    }    public static @NonNull List<Command> completePlayersInPlot(            final @NonNull Plot plot,            final @NonNull String input, final @NonNull List<String> existing    ) {        List<String> players = cachedCompletionValues.getIfPresent("inPlot" + plot);        if (players == null) {            final List<PlotPlayer<?>> inPlot = plot.getPlayersInPlot();            players = new ArrayList<>(inPlot.size());            for (PlotPlayer<?> player : inPlot) {                players.add(player.getName());            }            cachedCompletionValues.put("inPlot" + plot, players);        }        return filterCached(players, input, existing);    }    /**     * Get a list of completions corresponding to WorldEdit(/FAWE) patterns. This uses     * WorldEdit's pattern completer internally.     *     * @param input Command input     * @return List of completions     */    public static @NonNull List<Command> completePatterns(final @NonNull String input) {        return PatternUtil.getSuggestions(input.trim()).stream()                .map(value -> value.toLowerCase(Locale.ENGLISH).replace("minecraft:", ""))                .filter(value -> value.startsWith(input.toLowerCase(Locale.ENGLISH)))                .map(value -> new Command(null, false, value, "", RequiredType.NONE, null) {                }).collect(Collectors.toList());    }    public static @NonNull List<Command> completeBoolean(final @NonNull String input) {        if (input.isEmpty()) {            return Arrays.asList(booleanTrueCompletion, booleanFalseCompletion);        }        if ("true".startsWith(input)) {            return Collections.singletonList(booleanTrueCompletion);        }        if ("false".startsWith(input)) {            return Collections.singletonList(booleanFalseCompletion);        }        return Collections.emptyList();    }    /**     * Get a list of integer numbers matching the given input. If the input string     * is empty, nothing will be returned. The list is unmodifiable.     *     * @param input        Input to filter with     * @param amountLimit  Maximum amount of suggestions     * @param highestLimit Highest number to include     * @return Unmodifiable list of number completions     */    public static @NonNull List<Command> completeNumbers(            final @NonNull String input,            final int amountLimit, final int highestLimit    ) {        if (input.isEmpty() || input.length() > highestLimit || !MathMan.isInteger(input)) {            return Collections.emptyList();        }        int offset;        try {            offset = Integer.parseInt(input) * 10;        } catch (NumberFormatException ignored) {            return Collections.emptyList();        }        final List<String> commands = new ArrayList<>();        for (int i = offset; i < highestLimit && (offset - i + amountLimit) > 0; i++) {            commands.add(String.valueOf(i));        }        return asCompletions(commands.toArray(new String[0]));    }    /**     * Get a list of plot areas matching the given input.     * The list is unmodifiable.     *     * @param input Input to filter with     * @return Unmodifiable list of area completions     */    public static @NonNull List<Command> completeAreas(final @NonNull String input) {        final List<Command> completions = new ArrayList<>();        for (final PlotArea area : PlotSquared.get().getPlotAreaManager().getAllPlotAreas()) {            String areaName = area.getWorldName();            if (area.getId() != null) {                areaName += ";" + area.getId();            }            if (!areaName.toLowerCase().startsWith(input.toLowerCase())) {                continue;            }            completions.add(new Command(null, false, areaName, "",                    RequiredType.NONE, null            ) {            });        }        return Collections.unmodifiableList(completions);    }    public static @NonNull List<Command> asCompletions(String... toFilter) {        final List<Command> completions = new ArrayList<>();        for (String completion : toFilter) {            completions.add(new Command(null, false, completion, "",                    RequiredType.NONE, null            ) {            });        }        return Collections.unmodifiableList(completions);    }    /**     * @param cacheIdentifier Cache key     * @param input           Command input     * @param existing        Players that should not be included in completions     * @param uuidFilter      Filter applied before caching values     * @return List of completions     * @deprecated In favor {@link #completePlayers(String, PlotPlayer, String, List, Predicate)}     */    private static List<Command> completePlayers(            final @NonNull String cacheIdentifier,            final @NonNull String input, final @NonNull List<String> existing,            final @NonNull Predicate<UUID> uuidFilter    ) {        return completePlayers(cacheIdentifier, null, input, existing, uuidFilter);    }    /**     * @param cacheIdentifier Cache key     * @param issuer          The player who issued the tab completion     * @param input           Command input     * @param existing        Players that should not be included in completions     * @param uuidFilter      Filter applied before caching values     * @return List of completions     */    private static List<Command> completePlayers(            final @NonNull String cacheIdentifier,            final @Nullable PlotPlayer<?> issuer,            final @NonNull String input, final @NonNull List<String> existing,            final @NonNull Predicate<UUID> uuidFilter    ) {        List<String> players;        if (Settings.Enabled_Components.EXTENDED_USERNAME_COMPLETION) {            players = cachedCompletionValues.getIfPresent(cacheIdentifier);            if (players == null) {                final Collection<UUIDMapping> mappings =                        PlotSquared.get().getImpromptuUUIDPipeline().getAllImmediately();                players = new ArrayList<>(mappings.size());                for (final UUIDMapping mapping : mappings) {                    if (uuidFilter.test(mapping.getUuid())) {                        players.add(mapping.getUsername());                    }                }                cachedCompletionValues.put(cacheIdentifier, players);            }        } else {            final Collection<? extends PlotPlayer<?>> onlinePlayers = PlotSquared.platform().playerManager().getPlayers();            players = new ArrayList<>(onlinePlayers.size());            for (final PlotPlayer<?> player : onlinePlayers) {                if (!uuidFilter.test(player.getUUID())) {                    continue;                }                if (issuer != null && !issuer.canSee(player)) {                    continue;                }                players.add(player.getName());            }        }        return filterCached(players, input, existing);    }    private static List<Command> filterCached(            Collection<String> playerNames, String input,            List<String> existing    ) {        final String processedInput = input.toLowerCase(Locale.ENGLISH);        return playerNames.stream().filter(player -> player.toLowerCase(Locale.ENGLISH).startsWith(processedInput))                .filter(player -> !existing.contains(player)).map(                        player -> new Command(null, false, player, "", RequiredType.NONE,                                CommandCategory.INFO                        ) {                        })                /* If there are more than 200 suggestions, just send the first 200 */                .limit(200)                .collect(Collectors.toList());    }}

--- a/Core/src/main/java/com/plotsquared/core/util/TabCompletions.java
+++ b/Core/src/main/java/com/plotsquared/core/util/TabCompletions.java
@@ -1,1 +1,336 @@
-/* *       _____  _       _    _____                                _ *      |  __ \| |     | |  / ____|                              | | *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| | *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` | *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| | *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_| *                                    | | *                                    |_| *            PlotSquared plot management system for Minecraft *                  Copyright (C) 2021 IntellectualSites * *     This program is free software: you can redistribute it and/or modify *     it under the terms of the GNU General Public License as published by *     the Free Software Foundation, either version 3 of the License, or *     (at your option) any later version. * *     This program is distributed in the hope that it will be useful, *     but WITHOUT ANY WARRANTY; without even the implied warranty of *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the *     GNU General Public License for more details. * *     You should have received a copy of the GNU General Public License *     along with this program.  If not, see <https://www.gnu.org/licenses/>. */package com.plotsquared.core.util;import com.google.common.cache.Cache;import com.google.common.cache.CacheBuilder;import com.plotsquared.core.PlotSquared;import com.plotsquared.core.command.Command;import com.plotsquared.core.command.CommandCategory;import com.plotsquared.core.command.RequiredType;import com.plotsquared.core.configuration.Settings;import com.plotsquared.core.player.PlotPlayer;import com.plotsquared.core.plot.Plot;import com.plotsquared.core.plot.PlotArea;import com.plotsquared.core.uuid.UUIDMapping;import org.checkerframework.checker.nullness.qual.NonNull;import org.checkerframework.checker.nullness.qual.Nullable;import java.util.ArrayList;import java.util.Arrays;import java.util.Collection;import java.util.Collections;import java.util.List;import java.util.Locale;import java.util.UUID;import java.util.concurrent.TimeUnit;import java.util.function.Predicate;import java.util.stream.Collectors;/** * Tab completion utilities */public final class TabCompletions {    private static final Cache<String, List<String>> cachedCompletionValues =            CacheBuilder.newBuilder()                    .expireAfterWrite(Settings.Tab_Completions.CACHE_EXPIRATION, TimeUnit.SECONDS)                    .build();    private static final Command booleanTrueCompletion = new Command(null, false, "true", "",            RequiredType.NONE, null    ) {    };    private static final Command booleanFalseCompletion = new Command(null, false, "false", "",            RequiredType.NONE, null    ) {    };    private TabCompletions() {        throw new UnsupportedOperationException(                "This is a utility class and cannot be instantiated");    }    /**     * Get a list of tab completions corresponding to player names. This uses the UUID pipeline     * cache, so it will complete will all names known to PlotSquared     *     * @param input    Command input     * @param existing Players that should not be included in completions     * @return List of completions     * @deprecated In favor {@link #completePlayers(PlotPlayer, String, List)}     */    public static @NonNull List<Command> completePlayers(            final @NonNull String input,            final @NonNull List<String> existing    ) {        return completePlayers(null, input, existing);    }    /**     * Get a list of tab completions corresponding to player names. This uses the UUID pipeline     * cache, so it will complete will all names known to PlotSquared     *     * @param input    Command input     * @param issuer   The player who issued the tab completion     * @param existing Players that should not be included in completions     * @return List of completions     */    public static @NonNull List<Command> completePlayers(            final @Nullable PlotPlayer<?> issuer,            final @NonNull String input,            final @NonNull List<String> existing    ) {        return completePlayers("players", issuer, input, existing, uuid -> true);    }    /**     * Get a list of tab completions corresponding to player names added to the given plot.     *     * @param plot     Plot to complete added players for     * @param input    Command input     * @param existing Players that should not be included in completions     * @return List of completions     *     * @deprecated In favor {@link #completeAddedPlayers(PlotPlayer, Plot, String, List)}     */    public static @NonNull List<Command> completeAddedPlayers(            final @NonNull Plot plot,            final @NonNull String input, final @NonNull List<String> existing    ) {        return completeAddedPlayers(null, plot, input, existing);    }    /**     * Get a list of tab completions corresponding to player names added to the given plot.     *     * @param issuer   The player who issued the tab completion     * @param plot     Plot to complete added players for     * @param input    Command input     * @param existing Players that should not be included in completions     * @return List of completions     */    public static @NonNull List<Command> completeAddedPlayers(            final @Nullable PlotPlayer<?> issuer,            final @NonNull Plot plot,            final @NonNull String input, final @NonNull List<String> existing    ) {        return completePlayers("added" + plot, issuer, input, existing,                uuid -> plot.getMembers().contains(uuid)                        || plot.getTrusted().contains(uuid)                        || plot.getDenied().contains(uuid)        );    }    public static @NonNull List<Command> completePlayersInPlot(            final @NonNull Plot plot,            final @NonNull String input, final @NonNull List<String> existing    ) {        List<String> players = cachedCompletionValues.getIfPresent("inPlot" + plot);        if (players == null) {            final List<PlotPlayer<?>> inPlot = plot.getPlayersInPlot();            players = new ArrayList<>(inPlot.size());            for (PlotPlayer<?> player : inPlot) {                players.add(player.getName());            }            cachedCompletionValues.put("inPlot" + plot, players);        }        return filterCached(players, input, existing);    }    /**     * Get a list of completions corresponding to WorldEdit(/FAWE) patterns. This uses     * WorldEdit's pattern completer internally.     *     * @param input Command input     * @return List of completions     */    public static @NonNull List<Command> completePatterns(final @NonNull String input) {        return PatternUtil.getSuggestions(input.trim()).stream()                .map(value -> value.toLowerCase(Locale.ENGLISH).replace("minecraft:", ""))                .filter(value -> value.startsWith(input.toLowerCase(Locale.ENGLISH)))                .map(value -> new Command(null, false, value, "", RequiredType.NONE, null) {                }).collect(Collectors.toList());    }    public static @NonNull List<Command> completeBoolean(final @NonNull String input) {        if (input.isEmpty()) {            return Arrays.asList(booleanTrueCompletion, booleanFalseCompletion);        }        if ("true".startsWith(input)) {            return Collections.singletonList(booleanTrueCompletion);        }        if ("false".startsWith(input)) {            return Collections.singletonList(booleanFalseCompletion);        }        return Collections.emptyList();    }    /**     * Get a list of integer numbers matching the given input. If the input string     * is empty, nothing will be returned. The list is unmodifiable.     *     * @param input        Input to filter with     * @param amountLimit  Maximum amount of suggestions     * @param highestLimit Highest number to include     * @return Unmodifiable list of number completions     */    public static @NonNull List<Command> completeNumbers(            final @NonNull String input,            final int amountLimit, final int highestLimit    ) {        if (input.isEmpty() || input.length() > highestLimit || !MathMan.isInteger(input)) {            return Collections.emptyList();        }        int offset;        try {            offset = Integer.parseInt(input) * 10;        } catch (NumberFormatException ignored) {            return Collections.emptyList();        }        final List<String> commands = new ArrayList<>();        for (int i = offset; i < highestLimit && (offset - i + amountLimit) > 0; i++) {            commands.add(String.valueOf(i));        }        return asCompletions(commands.toArray(new String[0]));    }    /**     * Get a list of plot areas matching the given input.     * The list is unmodifiable.     *     * @param input Input to filter with     * @return Unmodifiable list of area completions     */    public static @NonNull List<Command> completeAreas(final @NonNull String input) {        final List<Command> completions = new ArrayList<>();        for (final PlotArea area : PlotSquared.get().getPlotAreaManager().getAllPlotAreas()) {            String areaName = area.getWorldName();            if (area.getId() != null) {                areaName += ";" + area.getId();            }            if (!areaName.toLowerCase().startsWith(input.toLowerCase())) {                continue;            }            completions.add(new Command(null, false, areaName, "",                    RequiredType.NONE, null            ) {            });        }        return Collections.unmodifiableList(completions);    }    public static @NonNull List<Command> asCompletions(String... toFilter) {        final List<Command> completions = new ArrayList<>();        for (String completion : toFilter) {            completions.add(new Command(null, false, completion, "",                    RequiredType.NONE, null            ) {            });        }        return Collections.unmodifiableList(completions);    }    /**     * @param cacheIdentifier Cache key     * @param input           Command input     * @param existing        Players that should not be included in completions     * @param uuidFilter      Filter applied before caching values     * @return List of completions     * @deprecated In favor {@link #completePlayers(String, PlotPlayer, String, List, Predicate)}     */    private static List<Command> completePlayers(            final @NonNull String cacheIdentifier,            final @NonNull String input, final @NonNull List<String> existing,            final @NonNull Predicate<UUID> uuidFilter    ) {        return completePlayers(cacheIdentifier, null, input, existing, uuidFilter);    }    /**     * @param cacheIdentifier Cache key     * @param issuer          The player who issued the tab completion     * @param input           Command input     * @param existing        Players that should not be included in completions     * @param uuidFilter      Filter applied before caching values     * @return List of completions     */    private static List<Command> completePlayers(            final @NonNull String cacheIdentifier,            final @Nullable PlotPlayer<?> issuer,            final @NonNull String input, final @NonNull List<String> existing,            final @NonNull Predicate<UUID> uuidFilter    ) {        List<String> players;        if (Settings.Enabled_Components.EXTENDED_USERNAME_COMPLETION) {            players = cachedCompletionValues.getIfPresent(cacheIdentifier);            if (players == null) {                final Collection<UUIDMapping> mappings =                        PlotSquared.get().getImpromptuUUIDPipeline().getAllImmediately();                players = new ArrayList<>(mappings.size());                for (final UUIDMapping mapping : mappings) {                    if (uuidFilter.test(mapping.getUuid())) {                        players.add(mapping.getUsername());                    }                }                cachedCompletionValues.put(cacheIdentifier, players);            }        } else {            final Collection<? extends PlotPlayer<?>> onlinePlayers = PlotSquared.platform().playerManager().getPlayers();            players = new ArrayList<>(onlinePlayers.size());            for (final PlotPlayer<?> player : onlinePlayers) {                if (!uuidFilter.test(player.getUUID())) {                    continue;                }                if (issuer != null && !issuer.canSee(player)) {                    continue;                }                players.add(player.getName());            }        }        return filterCached(players, input, existing);    }    private static List<Command> filterCached(            Collection<String> playerNames, String input,            List<String> existing    ) {        final String processedInput = input.toLowerCase(Locale.ENGLISH);        return playerNames.stream().filter(player -> player.toLowerCase(Locale.ENGLISH).startsWith(processedInput))                .filter(player -> !existing.contains(player)).map(                        player -> new Command(null, false, player, "", RequiredType.NONE,                                CommandCategory.INFO                        ) {                        })                /* If there are more than 200 suggestions, just send the first 200 */                .limit(200)                .collect(Collectors.toList());    }}
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2021 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.util;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.plotsquared.core.PlotSquared;
+import com.plotsquared.core.command.Command;
+import com.plotsquared.core.command.CommandCategory;
+import com.plotsquared.core.command.RequiredType;
+import com.plotsquared.core.configuration.Settings;
+import com.plotsquared.core.player.PlotPlayer;
+import com.plotsquared.core.plot.Plot;
+import com.plotsquared.core.plot.PlotArea;
+import com.plotsquared.core.uuid.UUIDMapping;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Tab completion utilities
+ */
+public final class TabCompletions {
+
+    private static final Cache<String, List<String>> cachedCompletionValues =
+            CacheBuilder.newBuilder()
+                    .expireAfterWrite(Settings.Tab_Completions.CACHE_EXPIRATION, TimeUnit.SECONDS)
+                    .build();
+
+    private static final Command booleanTrueCompletion = new Command(null, false, "true", "",
+            RequiredType.NONE, null
+    ) {
+    };
+    private static final Command booleanFalseCompletion = new Command(null, false, "false", "",
+            RequiredType.NONE, null
+    ) {
+    };
+
+    private TabCompletions() {
+        throw new UnsupportedOperationException(
+                "This is a utility class and cannot be instantiated");
+    }
+
+
+
+    /**
+     * Get a list of tab completions corresponding to player names. This uses the UUID pipeline
+     * cache, so it will complete will all names known to PlotSquared
+     *
+     * @param input    Command input
+     * @param existing Players that should not be included in completions
+     * @return List of completions
+     * @deprecated In favor {@link #completePlayers(PlotPlayer, String, List)}
+     */
+    public static @NonNull List<Command> completePlayers(
+            final @NonNull String input,
+            final @NonNull List<String> existing
+    ) {
+        return completePlayers(null, input, existing);
+    }
+
+    /**
+     * Get a list of tab completions corresponding to player names. This uses the UUID pipeline
+     * cache, so it will complete will all names known to PlotSquared
+     *
+     * @param input    Command input
+     * @param issuer   The player who issued the tab completion
+     * @param existing Players that should not be included in completions
+     * @return List of completions
+     */
+    public static @NonNull List<Command> completePlayers(
+            final @Nullable PlotPlayer<?> issuer,
+            final @NonNull String input,
+            final @NonNull List<String> existing
+    ) {
+        return completePlayers("players", issuer, input, existing, uuid -> true);
+    }
+
+    /**
+     * Get a list of tab completions corresponding to player names added to the given plot.
+     *
+     * @param plot     Plot to complete added players for
+     * @param input    Command input
+     * @param existing Players that should not be included in completions
+     * @return List of completions
+     *
+     * @deprecated In favor {@link #completeAddedPlayers(PlotPlayer, Plot, String, List)}
+     */
+    public static @NonNull List<Command> completeAddedPlayers(
+            final @NonNull Plot plot,
+            final @NonNull String input, final @NonNull List<String> existing
+    ) {
+        return completeAddedPlayers(null, plot, input, existing);
+    }
+
+    /**
+     * Get a list of tab completions corresponding to player names added to the given plot.
+     *
+     * @param issuer   The player who issued the tab completion
+     * @param plot     Plot to complete added players for
+     * @param input    Command input
+     * @param existing Players that should not be included in completions
+     * @return List of completions
+     */
+    public static @NonNull List<Command> completeAddedPlayers(
+            final @Nullable PlotPlayer<?> issuer,
+            final @NonNull Plot plot,
+            final @NonNull String input, final @NonNull List<String> existing
+    ) {
+        return completePlayers("added" + plot, issuer, input, existing,
+                uuid -> plot.getMembers().contains(uuid)
+                        || plot.getTrusted().contains(uuid)
+                        || plot.getDenied().contains(uuid)
+        );
+    }
+
+    public static @NonNull List<Command> completePlayersInPlot(
+            final @NonNull Plot plot,
+            final @NonNull String input, final @NonNull List<String> existing
+    ) {
+        List<String> players = cachedCompletionValues.getIfPresent("inPlot" + plot);
+        if (players == null) {
+            final List<PlotPlayer<?>> inPlot = plot.getPlayersInPlot();
+            players = new ArrayList<>(inPlot.size());
+            for (PlotPlayer<?> player : inPlot) {
+                players.add(player.getName());
+            }
+            cachedCompletionValues.put("inPlot" + plot, players);
+        }
+        return filterCached(players, input, existing);
+    }
+
+    /**
+     * Get a list of completions corresponding to WorldEdit(/FAWE) patterns. This uses
+     * WorldEdit's pattern completer internally.
+     *
+     * @param input Command input
+     * @return List of completions
+     */
+    public static @NonNull List<Command> completePatterns(final @NonNull String input) {
+        return PatternUtil.getSuggestions(input.trim()).stream()
+                .map(value -> value.toLowerCase(Locale.ENGLISH).replace("minecraft:", ""))
+                .filter(value -> value.startsWith(input.toLowerCase(Locale.ENGLISH)))
+                .map(value -> new Command(null, false, value, "", RequiredType.NONE, null) {
+                }).collect(Collectors.toList());
+    }
+
+    public static @NonNull List<Command> completeBoolean(final @NonNull String input) {
+        if (input.isEmpty()) {
+            return Arrays.asList(booleanTrueCompletion, booleanFalseCompletion);
+        }
+        if ("true".startsWith(input)) {
+            return Collections.singletonList(booleanTrueCompletion);
+        }
+        if ("false".startsWith(input)) {
+            return Collections.singletonList(booleanFalseCompletion);
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Get a list of integer numbers matching the given input. If the input string
+     * is empty, nothing will be returned. The list is unmodifiable.
+     *
+     * @param input        Input to filter with
+     * @param amountLimit  Maximum amount of suggestions
+     * @param highestLimit Highest number to include
+     * @return Unmodifiable list of number completions
+     */
+    public static @NonNull List<Command> completeNumbers(
+            final @NonNull String input,
+            final int amountLimit, final int highestLimit
+    ) {
+        if (input.isEmpty() || input.length() > highestLimit || !MathMan.isInteger(input)) {
+            return Collections.emptyList();
+        }
+        int offset;
+        try {
+            offset = Integer.parseInt(input) * 10;
+        } catch (NumberFormatException ignored) {
+            return Collections.emptyList();
+        }
+        final List<String> commands = new ArrayList<>();
+        for (int i = offset; i < highestLimit && (offset - i + amountLimit) > 0; i++) {
+            commands.add(String.valueOf(i));
+        }
+        return asCompletions(commands.toArray(new String[0]));
+    }
+
+    /**
+     * Get a list of plot areas matching the given input.
+     * The list is unmodifiable.
+     *
+     * @param input Input to filter with
+     * @return Unmodifiable list of area completions
+     */
+    public static @NonNull List<Command> completeAreas(final @NonNull String input) {
+        final List<Command> completions = new ArrayList<>();
+        for (final PlotArea area : PlotSquared.get().getPlotAreaManager().getAllPlotAreas()) {
+            String areaName = area.getWorldName();
+            if (area.getId() != null) {
+                areaName += ";" + area.getId();
+            }
+            if (!areaName.toLowerCase().startsWith(input.toLowerCase())) {
+                continue;
+            }
+            completions.add(new Command(null, false, areaName, "",
+                    RequiredType.NONE, null
+            ) {
+            });
+        }
+        return Collections.unmodifiableList(completions);
+    }
+
+    public static @NonNull List<Command> asCompletions(String... toFilter) {
+        final List<Command> completions = new ArrayList<>();
+        for (String completion : toFilter) {
+            completions.add(new Command(null, false, completion, "",
+                    RequiredType.NONE, null
+            ) {
+            });
+        }
+        return Collections.unmodifiableList(completions);
+    }
+
+
+    /**
+     * @param cacheIdentifier Cache key
+     * @param input           Command input
+     * @param existing        Players that should not be included in completions
+     * @param uuidFilter      Filter applied before caching values
+     * @return List of completions
+     * @deprecated In favor {@link #completePlayers(String, PlotPlayer, String, List, Predicate)}
+     */
+    private static List<Command> completePlayers(
+            final @NonNull String cacheIdentifier,
+            final @NonNull String input, final @NonNull List<String> existing,
+            final @NonNull Predicate<UUID> uuidFilter
+    ) {
+        return completePlayers(cacheIdentifier, null, input, existing, uuidFilter);
+    }
+
+    /**
+     * @param cacheIdentifier Cache key
+     * @param issuer          The player who issued the tab completion
+     * @param input           Command input
+     * @param existing        Players that should not be included in completions
+     * @param uuidFilter      Filter applied before caching values
+     * @return List of completions
+     */
+    private static List<Command> completePlayers(
+            final @NonNull String cacheIdentifier,
+            final @Nullable PlotPlayer<?> issuer,
+            final @NonNull String input, final @NonNull List<String> existing,
+            final @NonNull Predicate<UUID> uuidFilter
+    ) {
+        List<String> players;
+        if (Settings.Enabled_Components.EXTENDED_USERNAME_COMPLETION) {
+            players = cachedCompletionValues.getIfPresent(cacheIdentifier);
+            if (players == null) {
+                final Collection<UUIDMapping> mappings =
+                        PlotSquared.get().getImpromptuUUIDPipeline().getAllImmediately();
+                players = new ArrayList<>(mappings.size());
+                for (final UUIDMapping mapping : mappings) {
+                    if (uuidFilter.test(mapping.getUuid())) {
+                        players.add(mapping.getUsername());
+                    }
+                }
+                cachedCompletionValues.put(cacheIdentifier, players);
+            }
+        } else {
+            final Collection<? extends PlotPlayer<?>> onlinePlayers = PlotSquared.platform().playerManager().getPlayers();
+            players = new ArrayList<>(onlinePlayers.size());
+            for (final PlotPlayer<?> player : onlinePlayers) {
+                if (!uuidFilter.test(player.getUUID())) {
+                    continue;
+                }
+                if (issuer != null && !issuer.canSee(player)) {
+                    continue;
+                }
+                players.add(player.getName());
+            }
+        }
+        return filterCached(players, input, existing);
+    }
+
+    private static List<Command> filterCached(
+            Collection<String> playerNames, String input,
+            List<String> existing
+    ) {
+        final String processedInput = input.toLowerCase(Locale.ENGLISH);
+        return playerNames.stream().filter(player -> player.toLowerCase(Locale.ENGLISH).startsWith(processedInput))
+                .filter(player -> !existing.contains(player)).map(
+                        player -> new Command(null, false, player, "", RequiredType.NONE,
+                                CommandCategory.INFO
+                        ) {
+                        })
+                /* If there are more than 200 suggestions, just send the first 200 */
+                .limit(200)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/util/TabCompletions.java
+++ b/Core/src/main/java/com/plotsquared/core/util/TabCompletions.java
@@ -32,6 +32,7 @@ import com.plotsquared.core.command.Command;
 import com.plotsquared.core.command.CommandCategory;
 import com.plotsquared.core.command.RequiredType;
 import com.plotsquared.core.configuration.Settings;
+import com.plotsquared.core.player.ConsolePlayer;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
@@ -88,7 +89,7 @@ public final class TabCompletions {
             final @NonNull String input,
             final @NonNull List<String> existing
     ) {
-        return completePlayers(null, input, existing);
+        return completePlayers(ConsolePlayer.getConsole(), input, existing);
     }
 
     /**
@@ -101,7 +102,7 @@ public final class TabCompletions {
      * @return List of completions
      */
     public static @NonNull List<Command> completePlayers(
-            final @Nullable PlotPlayer<?> issuer,
+            final @NonNull PlotPlayer<?> issuer,
             final @NonNull String input,
             final @NonNull List<String> existing
     ) {
@@ -123,7 +124,7 @@ public final class TabCompletions {
             final @NonNull Plot plot,
             final @NonNull String input, final @NonNull List<String> existing
     ) {
-        return completeAddedPlayers(null, plot, input, existing);
+        return completeAddedPlayers(ConsolePlayer.getConsole(), plot, input, existing);
     }
 
     /**
@@ -136,7 +137,7 @@ public final class TabCompletions {
      * @return List of completions
      */
     public static @NonNull List<Command> completeAddedPlayers(
-            final @Nullable PlotPlayer<?> issuer,
+            final @NonNull PlotPlayer<?> issuer,
             final @NonNull Plot plot,
             final @NonNull String input, final @NonNull List<String> existing
     ) {
@@ -270,7 +271,7 @@ public final class TabCompletions {
             final @NonNull String input, final @NonNull List<String> existing,
             final @NonNull Predicate<UUID> uuidFilter
     ) {
-        return completePlayers(cacheIdentifier, null, input, existing, uuidFilter);
+        return completePlayers(cacheIdentifier, ConsolePlayer.getConsole(), input, existing, uuidFilter);
     }
 
     /**
@@ -283,7 +284,7 @@ public final class TabCompletions {
      */
     private static List<Command> completePlayers(
             final @NonNull String cacheIdentifier,
-            final @Nullable PlotPlayer<?> issuer,
+            final @NonNull PlotPlayer<?> issuer,
             final @NonNull String input, final @NonNull List<String> existing,
             final @NonNull Predicate<UUID> uuidFilter
     ) {


### PR DESCRIPTION
## Overview
**Fixes https://github.com/IntellectualSites/PlotSquared/issues/3263**

## Description
Tabcompletions for PlotSquared now respects Bukkits Player#canSee (platform independent: PlotPlayer#canSee) to ensure only visible players are recommended using tab completion.

Changes signatures:
- `TabCompletions.completePlayers(String, List<String>)` -> `completePlayers(PlotPlayer<?>, String, List<String>)` 
- `TabCompletions.completePlayers(String, String, List<String>, Predicate<UUID>)` -> `completePlayers(String, PlotPlayer<?>, String, List<String>, Predicate<UUID>) `
- `TabCompletions.completeAddedPlayers(Plot, String, List<String>)` -> `completePlayers(PlotPlayer<?>, Plot, String, List<String>)` 

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v6/CONTRIBUTING.md)
