### PR TITLE
fix: Flag list parsing for console players

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
@@ -408,13 +408,9 @@ public abstract class PlotArea {
             }
         }
         this.getFlagContainer().addAll(parseFlags(flags));
-
-        Component flagsComponent = null;
-        Collection<PlotFlag<?, ?>> flagCollection = this.getFlagContainer().getFlagMap().values();
-        flagsComponent = getFlagsComponent(flagsComponent, flagCollection);
         ConsolePlayer.getConsole().sendMessage(
                 TranslatableCaption.of("flags.area_flags"),
-                Template.of("flags", flagsComponent)
+                Template.of("flags", flags.toString())
         );
 
         this.spawnEggs = config.getBoolean("event.spawn.egg");
@@ -433,13 +429,9 @@ public abstract class PlotArea {
             }
         }
         this.getRoadFlagContainer().addAll(parseFlags(roadflags));
-
-        Component roadFlagsComponent = null;
-        Collection<PlotFlag<?, ?>> roadFlagCollection = this.getRoadFlagContainer().getFlagMap().values();
-        roadFlagsComponent = getFlagsComponent(roadFlagsComponent, roadFlagCollection);
         ConsolePlayer.getConsole().sendMessage(
                 TranslatableCaption.of("flags.road_flags"),
-                Template.of("flags", roadFlagsComponent)
+                Template.of("flags", roadflags.toString())
         );
 
         loadConfiguration(config);


### PR DESCRIPTION
When parsing road and area flag lists on startup e.g, only the first entry is printed. Instead of fixing the logic here, we can reuse what we used above to read the entries and simply print them.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/PlotSquared/blob/v6/CONTRIBUTING.md)
