### PR TITLE
Better deciding of heights to use for generation and schematics

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/backup/PlayerBackupProfile.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/PlayerBackupProfile.java
@@ -193,19 +193,28 @@ public class PlayerBackupProfile implements BackupProfile {
                     future.completeExceptionally(new IllegalArgumentException(
                             "The backup is non-existent or not in the correct format"));
                 } else {
-                    this.schematicHandler.paste(schematic, plot, 0, 1, 0, false, player, new RunnableVal<Boolean>() {
-                        @Override
-                        public void run(Boolean value) {
-                            if (value) {
-                                future.complete(null);
-                            } else {
-                                future.completeExceptionally(new RuntimeException(MINI_MESSAGE.stripTokens(
-                                        TranslatableCaption
-                                                .of("schematics.schematic_paste_failed")
-                                                .getComponent(ConsolePlayer.getConsole()))));
+                    this.schematicHandler.paste(
+                            schematic,
+                            plot,
+                            0,
+                            plot.getArea().getMinBuildHeight(),
+                            0,
+                            false,
+                            player,
+                            new RunnableVal<>() {
+                                @Override
+                                public void run(Boolean value) {
+                                    if (value) {
+                                        future.complete(null);
+                                    } else {
+                                        future.completeExceptionally(new RuntimeException(MINI_MESSAGE.stripTokens(
+                                                TranslatableCaption
+                                                        .of("schematics.schematic_paste_failed")
+                                                        .getComponent(ConsolePlayer.getConsole()))));
+                                    }
+                                }
                             }
-                        }
-                    });
+                    );
                 }
             });
         }

--- a/Core/src/main/java/com/plotsquared/core/command/Load.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Load.java
@@ -149,7 +149,7 @@ public class Load extends SubCommand {
                                 0,
                                 false,
                                 player,
-                                new RunnableVal<Boolean>() {
+                                new RunnableVal<>() {
                                     @Override
                                     public void run(Boolean value) {
                                         plot.removeRunning();

--- a/Core/src/main/java/com/plotsquared/core/command/SchematicCmd.java
+++ b/Core/src/main/java/com/plotsquared/core/command/SchematicCmd.java
@@ -166,7 +166,7 @@ public class SchematicCmd extends SubCommand {
                             0,
                             false,
                             player,
-                            new RunnableVal<Boolean>() {
+                            new RunnableVal<>() {
                                 @Override
                                 public void run(Boolean value) {
                                     SchematicCmd.this.running = false;

--- a/Core/src/main/java/com/plotsquared/core/generator/ClassicPlotManager.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/ClassicPlotManager.java
@@ -506,16 +506,32 @@ public class ClassicPlotManager extends SquarePlotManager {
                 Location.at(
                         classicPlotWorld.getWorldName(),
                         sx,
-                        Math.min(classicPlotWorld.WALL_HEIGHT, classicPlotWorld.ROAD_HEIGHT) + 1,
+                        Math.min(
+                                classicPlotWorld.PLOT_HEIGHT,
+                                Math.min(classicPlotWorld.WALL_HEIGHT, classicPlotWorld.ROAD_HEIGHT)
+                        ) + 1,
                         sz + 1
                 ),
                 Location.at(classicPlotWorld.getWorldName(), ex, maxY, ez - 1), BlockTypes.AIR.getDefaultState()
         );
-        queue.setCuboid(
-                Location.at(classicPlotWorld.getWorldName(), sx, 0, sz + 1),
-                Location.at(classicPlotWorld.getWorldName(), ex, 0, ez - 1),
-                BlockUtil.get((short) 7, (byte) 0)
-        );
+        if (classicPlotWorld.PLOT_BEDROCK) {
+            queue.setCuboid(
+                    Location.at(classicPlotWorld.getWorldName(), sx, 0, sz + 1),
+                    Location.at(classicPlotWorld.getWorldName(), ex, 0, ez - 1),
+                    BlockTypes.BEDROCK.getDefaultState()
+            );
+            queue.setCuboid(
+                    Location.at(classicPlotWorld.getWorldName(), sx, 1, sz + 1),
+                    Location.at(classicPlotWorld.getWorldName(), sx, classicPlotWorld.WALL_HEIGHT, ez - 1),
+                    classicPlotWorld.WALL_FILLING.toPattern()
+            );
+        } else {
+            queue.setCuboid(
+                    Location.at(classicPlotWorld.getWorldName(), sx, 0, sz + 1),
+                    Location.at(classicPlotWorld.getWorldName(), sx, classicPlotWorld.WALL_HEIGHT, ez - 1),
+                    classicPlotWorld.WALL_FILLING.toPattern()
+            );
+        }
         queue.setCuboid(
                 Location.at(classicPlotWorld.getWorldName(), sx, 1, sz + 1),
                 Location.at(classicPlotWorld.getWorldName(), sx, classicPlotWorld.WALL_HEIGHT, ez - 1),
@@ -568,7 +584,10 @@ public class ClassicPlotManager extends SquarePlotManager {
                 Location.at(
                         classicPlotWorld.getWorldName(),
                         sx + 1,
-                        Math.min(classicPlotWorld.WALL_HEIGHT, classicPlotWorld.ROAD_HEIGHT) + 1,
+                        Math.min(
+                                classicPlotWorld.PLOT_HEIGHT,
+                                Math.min(classicPlotWorld.WALL_HEIGHT, classicPlotWorld.ROAD_HEIGHT)
+                        ) + 1,
                         sz
                 ),
                 Location.at(classicPlotWorld.getWorldName(), ex - 1, classicPlotWorld.getPlotManager().getWorldHeight(), ez),
@@ -663,7 +682,10 @@ public class ClassicPlotManager extends SquarePlotManager {
                         Location.at(
                                 classicPlotWorld.getWorldName(),
                                 sx,
-                                Math.min(classicPlotWorld.PLOT_HEIGHT, classicPlotWorld.ROAD_HEIGHT) + 1,
+                                Math.min(
+                                        classicPlotWorld.PLOT_HEIGHT,
+                                        Math.min(classicPlotWorld.WALL_HEIGHT, classicPlotWorld.ROAD_HEIGHT)
+                                ) + 1,
                                 sz
                         ),
                         Location.at(classicPlotWorld.getWorldName(), ex, classicPlotWorld.getPlotManager().getWorldHeight(), ez),
@@ -703,7 +725,10 @@ public class ClassicPlotManager extends SquarePlotManager {
                         Location.at(
                                 classicPlotWorld.getWorldName(),
                                 sx,
-                                Math.min(classicPlotWorld.PLOT_HEIGHT, classicPlotWorld.ROAD_HEIGHT) + 1,
+                                Math.min(
+                                        classicPlotWorld.PLOT_HEIGHT,
+                                        Math.min(classicPlotWorld.WALL_HEIGHT, classicPlotWorld.ROAD_HEIGHT)
+                                ) + 1,
                                 sz
                         ),
                         Location.at(classicPlotWorld.getWorldName(), ex, classicPlotWorld.getPlotManager().getWorldHeight(), ez),
@@ -742,7 +767,10 @@ public class ClassicPlotManager extends SquarePlotManager {
                         Location.at(
                                 classicPlotWorld.getWorldName(),
                                 sx,
-                                Math.min(classicPlotWorld.PLOT_HEIGHT, classicPlotWorld.ROAD_HEIGHT) + 1,
+                                Math.min(
+                                        classicPlotWorld.PLOT_HEIGHT,
+                                        Math.min(classicPlotWorld.WALL_HEIGHT, classicPlotWorld.ROAD_HEIGHT)
+                                ) + 1,
                                 sz
                         ),
                         Location.at(classicPlotWorld.getWorldName(), ex, classicPlotWorld.getPlotManager().getWorldHeight(), ez),

--- a/Core/src/main/java/com/plotsquared/core/generator/HybridGen.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridGen.java
@@ -63,7 +63,7 @@ public class HybridGen extends IndependentPlotGenerator {
                 && Settings.Schematics.PASTE_ON_TOP)) {
             minY = world.SCHEM_Y;
         } else {
-            minY = 1;
+            minY = world.getMinBuildHeight();
         }
         BaseBlock[] blocks = world.G_SCH.get(MathMan.pair(relativeX, relativeZ));
         if (blocks != null) {
@@ -156,11 +156,12 @@ public class HybridGen extends IndependentPlotGenerator {
             }
         }
         // generation
+        int startY = hybridPlotWorld.PLOT_BEDROCK ? 1 : 0;
         for (short x = 0; x < 16; x++) {
             if (insideRoadX[x]) {
                 for (short z = 0; z < 16; z++) {
                     // Road
-                    for (int y = 1; y <= hybridPlotWorld.ROAD_HEIGHT; y++) {
+                    for (int y = startY; y <= hybridPlotWorld.ROAD_HEIGHT; y++) {
                         result.setBlock(x, y, z, hybridPlotWorld.ROAD_BLOCK.toPattern());
                     }
                     if (hybridPlotWorld.ROAD_SCHEMATIC_ENABLED) {
@@ -171,7 +172,7 @@ public class HybridGen extends IndependentPlotGenerator {
                 for (short z = 0; z < 16; z++) {
                     if (insideRoadZ[z]) {
                         // road
-                        for (int y = 1; y <= hybridPlotWorld.ROAD_HEIGHT; y++) {
+                        for (int y = startY; y <= hybridPlotWorld.ROAD_HEIGHT; y++) {
                             result.setBlock(x, y, z, hybridPlotWorld.ROAD_BLOCK.toPattern());
                         }
                         if (hybridPlotWorld.ROAD_SCHEMATIC_ENABLED) {
@@ -181,7 +182,7 @@ public class HybridGen extends IndependentPlotGenerator {
                         }
                     } else {
                         // wall
-                        for (int y = 1; y <= hybridPlotWorld.WALL_HEIGHT; y++) {
+                        for (int y = startY; y <= hybridPlotWorld.WALL_HEIGHT; y++) {
                             result.setBlock(x, y, z, hybridPlotWorld.WALL_FILLING.toPattern());
                         }
                         if (!hybridPlotWorld.ROAD_SCHEMATIC_ENABLED) {
@@ -201,7 +202,7 @@ public class HybridGen extends IndependentPlotGenerator {
                 for (short z = 0; z < 16; z++) {
                     if (insideRoadZ[z]) {
                         // road
-                        for (int y = 1; y <= hybridPlotWorld.ROAD_HEIGHT; y++) {
+                        for (int y = startY; y <= hybridPlotWorld.ROAD_HEIGHT; y++) {
                             result.setBlock(x, y, z, hybridPlotWorld.ROAD_BLOCK.toPattern());
                         }
                         if (hybridPlotWorld.ROAD_SCHEMATIC_ENABLED) {
@@ -211,7 +212,7 @@ public class HybridGen extends IndependentPlotGenerator {
                         }
                     } else if (insideWallZ[z]) {
                         // wall
-                        for (int y = 1; y <= hybridPlotWorld.WALL_HEIGHT; y++) {
+                        for (int y = startY; y <= hybridPlotWorld.WALL_HEIGHT; y++) {
                             result.setBlock(x, y, z, hybridPlotWorld.WALL_FILLING.toPattern());
                         }
                         if (!hybridPlotWorld.ROAD_SCHEMATIC_ENABLED) {
@@ -227,7 +228,7 @@ public class HybridGen extends IndependentPlotGenerator {
                         }
                     } else {
                         // plot
-                        for (int y = 1; y < hybridPlotWorld.PLOT_HEIGHT; y++) {
+                        for (int y = startY; y < hybridPlotWorld.PLOT_HEIGHT; y++) {
                             result.setBlock(x, y, z, hybridPlotWorld.MAIN_BLOCK.toPattern());
                         }
                         result.setBlock(x, hybridPlotWorld.PLOT_HEIGHT, z,

--- a/Core/src/main/java/com/plotsquared/core/generator/HybridPlotManager.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridPlotManager.java
@@ -152,7 +152,7 @@ public class HybridPlotManager extends ClassicPlotManager {
         if ((isRoad && Settings.Schematics.PASTE_ROAD_ON_TOP) || (!isRoad && Settings.Schematics.PASTE_ON_TOP)) {
             minY = hybridPlotWorld.SCHEM_Y;
         } else {
-            minY = 1;
+            minY = hybridPlotWorld.getMinBuildHeight();
         }
         BaseBlock airBlock = BlockTypes.AIR.getDefaultState().toBaseBlock();
         for (int x = pos1.getX(); x <= pos2.getX(); x++) {

--- a/Core/src/main/java/com/plotsquared/core/generator/HybridPlotManager.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridPlotManager.java
@@ -249,12 +249,11 @@ public class HybridPlotManager extends ClassicPlotManager {
         final Pattern plotfloor = hybridPlotWorld.TOP_BLOCK.toPattern();
         final Pattern filling = hybridPlotWorld.MAIN_BLOCK.toPattern();
 
-        final BlockState bedrock;
-        final BlockState air = BlockTypes.AIR.getDefaultState();
+        final Pattern bedrock;
         if (hybridPlotWorld.PLOT_BEDROCK) {
             bedrock = BlockTypes.BEDROCK.getDefaultState();
         } else {
-            bedrock = air;
+            bedrock = hybridPlotWorld.MAIN_BLOCK.toPattern();
         }
 
         final BiomeType biome = hybridPlotWorld.getPlotBiome();
@@ -274,7 +273,7 @@ public class HybridPlotManager extends ClassicPlotManager {
             // Each component has a different layer
             queue.setCuboid(pos1.withY(1), pos2.withY(hybridPlotWorld.PLOT_HEIGHT - 1), filling);
             queue.setCuboid(pos1.withY(hybridPlotWorld.PLOT_HEIGHT), pos2.withY(hybridPlotWorld.PLOT_HEIGHT), plotfloor);
-            queue.setCuboid(pos1.withY(hybridPlotWorld.PLOT_HEIGHT + 1), pos2.withY(getWorldHeight()), air);
+            queue.setCuboid(pos1.withY(hybridPlotWorld.PLOT_HEIGHT + 1), pos2.withY(getWorldHeight()), BlockTypes.AIR.getDefaultState());
             queue.setBiomeCuboid(pos1, pos2, biome);
         } else {
             queue.setRegenRegion(new CuboidRegion(pos1.getBlockVector3(), pos2.getBlockVector3()));

--- a/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
@@ -253,22 +253,32 @@ public class HybridPlotWorld extends ClassicPlotWorld {
         int shift = this.ROAD_WIDTH / 2;
         int oddshift = (this.ROAD_WIDTH & 1) == 0 ? 0 : 1;
 
-        SCHEM_Y = Math.min(PLOT_HEIGHT, ROAD_HEIGHT);
+        SCHEM_Y = Math.min(PLOT_HEIGHT, Math.min(WALL_HEIGHT, ROAD_HEIGHT));
         int plotY = PLOT_HEIGHT - SCHEM_Y;
-        int roadY = ROAD_HEIGHT - SCHEM_Y;
+        int roadY = Math.min(ROAD_HEIGHT, WALL_HEIGHT) - SCHEM_Y;
 
-        if (schematic3 != null && schematic3.getClipboard().getDimensions().getY() == 256) {
-            SCHEM_Y = 0;
-            plotY = 0;
-            roadY = ROAD_HEIGHT;
+        if (schematic3 != null) {
+            if (schematic3.getClipboard().getDimensions().getY() == 256) {
+                SCHEM_Y = plotY = 0;
+            } else if (!Settings.Schematics.PASTE_ON_TOP) {
+                SCHEM_Y = plotY = getMinBuildHeight();
+            }
         }
 
-        if (schematic1 != null && schematic1.getClipboard().getDimensions().getY() == 256) {
-            SCHEM_Y = 0;
-            if (schematic3 != null && schematic3.getClipboard().getDimensions().getY() != 256) {
-                plotY = PLOT_HEIGHT;
+        if (schematic1 != null) {
+            if (schematic1.getClipboard().getDimensions().getY() == 256) {
+                SCHEM_Y = roadY = 0;
+                if (schematic3 != null && schematic3.getClipboard().getDimensions().getY() != 256
+                        && !Settings.Schematics.PASTE_ON_TOP) {
+                    plotY = PLOT_HEIGHT;
+                }
+            } else if (!Settings.Schematics.PASTE_ROAD_ON_TOP) {
+                SCHEM_Y = roadY = getMinBuildHeight();
+                if (schematic3 != null && schematic3.getClipboard().getDimensions().getY() != 256
+                        && !Settings.Schematics.PASTE_ON_TOP) {
+                    plotY = PLOT_HEIGHT;
+                }
             }
-            roadY = 0;
         }
 
         if (schematic3 != null) {
@@ -324,7 +334,7 @@ public class HybridPlotWorld extends ClassicPlotWorld {
                 LOGGER.info("- plot schematic: {}", schematic3File.getPath());
             }
         }
-        if (schematic1 == null || schematic2 == null || this.ROAD_WIDTH == 0) {
+        if ((schematic1 == null&& schematic2 == null) || this.ROAD_WIDTH == 0) {
             if (Settings.DEBUG) {
                 LOGGER.info("- schematic: false");
             }

--- a/Core/src/main/java/com/plotsquared/core/generator/HybridUtils.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridUtils.java
@@ -504,9 +504,10 @@ public class HybridUtils {
         Location top = plot.getTopAbs();
         final HybridPlotWorld plotworld = (HybridPlotWorld) plot.getArea();
         PlotManager plotManager = plotworld.getPlotManager();
+        int schemY = Math.min(plotworld.PLOT_HEIGHT, Math.min(plotworld.WALL_HEIGHT, plotworld.ROAD_HEIGHT));
         int sx = bot.getX() - plotworld.ROAD_WIDTH + 1;
         int sz = bot.getZ() + 1;
-        int sy = Settings.Schematics.PASTE_ROAD_ON_TOP ? plotworld.ROAD_HEIGHT : 1;
+        int sy = Settings.Schematics.PASTE_ROAD_ON_TOP ? schemY : plot.getArea().getMinBuildHeight();
         int ex = bot.getX();
         int ez = top.getZ();
         int ey = get_ey(plotManager, queue, sx, ex, sz, ez, sy);

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -1733,16 +1733,25 @@ public class Plot {
                 e.printStackTrace();
                 return true;
             }
-            schematicHandler.paste(sch, this, 0, 1, 0, Settings.Schematics.PASTE_ON_TOP, player, new RunnableVal<>() {
-                @Override
-                public void run(Boolean value) {
-                    if (value) {
-                        player.sendMessage(TranslatableCaption.of("schematics.schematic_paste_success"));
-                    } else {
-                        player.sendMessage(TranslatableCaption.of("schematics.schematic_paste_failed"));
+            schematicHandler.paste(
+                    sch,
+                    this,
+                    0,
+                    getArea().getMinBuildHeight(),
+                    0,
+                    Settings.Schematics.PASTE_ON_TOP,
+                    player,
+                    new RunnableVal<>() {
+                        @Override
+                        public void run(Boolean value) {
+                            if (value) {
+                                player.sendMessage(TranslatableCaption.of("schematics.schematic_paste_success"));
+                            } else {
+                                player.sendMessage(TranslatableCaption.of("schematics.schematic_paste_failed"));
+                            }
+                        }
                     }
-                }
-            });
+            );
         }
         plotworld.getPlotManager().claimPlot(this, null);
         return true;


### PR DESCRIPTION
 - If bedrock is disabled, we should still be filling the space with something
 - Use minBuildHeight instead of hardcoding "1" for schematics (it is still 1 by default) to ensure all-encompassing schematics
 - Schematic generation/handling for roads etc. should be accounting for all of wall, road, and plot heights for deciding point of origin
 - Fixes #3269
 - Starts to address #3175