### PR TITLE
Use a more player friendly done message on restricted building

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -318,8 +318,7 @@ public class BlockEventListener implements Listener {
             } else if (Settings.Done.RESTRICT_BUILDING && DoneFlag.isDone(plot)) {
                 if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_BUILD_OTHER)) {
                     pp.sendMessage(
-                            TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_OTHER))
+                            TranslatableCaption.of("done.building_restricted")
                     );
                     event.setCancelled(true);
                     return;
@@ -401,8 +400,7 @@ public class BlockEventListener implements Listener {
             } else if (Settings.Done.RESTRICT_BUILDING && DoneFlag.isDone(plot)) {
                 if (!Permissions.hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_BUILD_OTHER)) {
                     plotPlayer.sendMessage(
-                            TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_OTHER))
+                            TranslatableCaption.of("done.building_restricted")
                     );
                     event.setCancelled(true);
                     return;

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -985,8 +985,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             if (Settings.Done.RESTRICT_BUILDING && DoneFlag.isDone(plot)) {
                 if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_BUILD_OTHER)) {
                     pp.sendMessage(
-                            TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_OTHER))
+                            TranslatableCaption.of("done.building_restricted")
                     );
                     e.setCancelled(true);
                     return;
@@ -1258,8 +1257,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
         } else if (Settings.Done.RESTRICT_BUILDING && DoneFlag.isDone(plot)) {
             if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_BUILD_OTHER)) {
                 pp.sendMessage(
-                        TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_OTHER))
+                        TranslatableCaption.of("done.building_restricted")
                 );
                 event.setCancelled(true);
             }
@@ -1332,8 +1330,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
         } else if (Settings.Done.RESTRICT_BUILDING && DoneFlag.isDone(plot)) {
             if (!Permissions.hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_BUILD_OTHER)) {
                 plotPlayer.sendMessage(
-                        TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_OTHER))
+                        TranslatableCaption.of("done.building_restricted")
                 );
                 event.setCancelled(true);
             }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitEntityUtil.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitEntityUtil.java
@@ -178,8 +178,7 @@ public class BukkitEntityUtil {
                         if (!Permissions
                                 .hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_BUILD_OTHER)) {
                             plotPlayer.sendMessage(
-                                    TranslatableCaption.of("permission.no_permission_event"),
-                                    Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_OTHER))
+                                    TranslatableCaption.of("done.building_restricted")
                             );
                             return false;
                         }

--- a/Core/src/main/resources/lang/messages_en.json
+++ b/Core/src/main/resources/lang/messages_en.json
@@ -94,6 +94,7 @@
   "done.done_insufficient_complexity": "<prefix><red>This plot is too simple. Please add more detail before using this command.</red>",
   "done.done_success": "<prefix><gold>Successfully marked this plot as done.</gold>",
   "done.done_removed": "<prefix><gray>You may now continue building in this plot.</gray>",
+  "done.building_restricted": "<prefix><gray>You can't build on plots marked as done.</gray>",
   "ratings.ratings_purged": "<prefix><gray>Purged ratings for this plot.</gray>",
   "ratings.rating_not_valid": "<prefix><red>You need to specify a number between 1 and 10.</red>",
   "ratings.rating_already_exists": "<prefix><gray>You have already rated plot <plot>.</gray>",


### PR DESCRIPTION
## Description
PlotSquared uses user friendly messages where applicable. Marking your plot as done while setting restricted building to true throws an administrative permission lacking message instead of letting the user know, that they cannot build on their plot when it's marked as done.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)