### PR TITLE
perf: get rid of guice overhead when accessing the plot area manager

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -1180,6 +1180,11 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
         return this.injector;
     }
 
+    @Override
+    public @NonNull PlotAreaManager plotAreaManager() {
+        return this.plotAreaManager;
+    }
+
     @NonNull
     @Override
     public Locale getLocale() {

--- a/Core/src/main/java/com/plotsquared/core/PlotPlatform.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotPlatform.java
@@ -38,6 +38,7 @@ import com.plotsquared.core.inject.annotations.DefaultGenerator;
 import com.plotsquared.core.location.World;
 import com.plotsquared.core.permissions.PermissionHandler;
 import com.plotsquared.core.player.PlotPlayer;
+import com.plotsquared.core.plot.world.PlotAreaManager;
 import com.plotsquared.core.queue.GlobalBlockQueue;
 import com.plotsquared.core.util.ChunkManager;
 import com.plotsquared.core.util.EconHandler;
@@ -267,6 +268,13 @@ public interface PlotPlatform<P> extends LocaleHolder {
     default @NonNull ChunkManager chunkManager() {
         return injector().getInstance(ChunkManager.class);
     }
+
+    /**
+     * Get the {@link PlotAreaManager} implementation.
+     *
+     * @return the PlotAreaManager
+     */
+    @NonNull PlotAreaManager plotAreaManager();
 
     /**
      * Get the platform specific console {@link Audience}

--- a/Core/src/main/java/com/plotsquared/core/PlotSquared.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotSquared.java
@@ -283,7 +283,7 @@ public class PlotSquared {
      * @return Plot area manager
      */
     public @NonNull PlotAreaManager getPlotAreaManager() {
-        return this.platform.injector().getInstance(PlotAreaManager.class);
+        return this.platform.plotAreaManager();
     }
 
     public void startExpiryTasks() {


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, please create one so we can look into it before approving your PR.
-->

Fixes #3311

## Description

Guice introduces significant overhead whenever the injector needs to look up an implementation. This was the case for the PlotAreaManager when accessed from the PlotSquared class, although the implementation is present as property in the BukkitPlatform already.

This Pull Request exposes the PlotAreaManager from the PlotPlatform instead of using the injector.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)