### PR TITLE
fix for issue 3317 (flag untrusted-visit not working)

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Visit.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Visit.java
@@ -140,18 +140,13 @@ public class Visit extends Command {
                 return;
             }
         } else {
-            if (!Permissions.hasPermission(player, Permission.PERMISSION_VISIT_OTHER)) {
+            // allow visit, if UntrustedVisit flag is set, or if the player has either the plot.visit.other or
+            // plot.admin.visit.untrusted permission
+            if (!plot.getFlag(UntrustedVisitFlag.class) && !Permissions.hasPermission(player, Permission.PERMISSION_VISIT_OTHER)
+                && !Permissions.hasPermission(player, Permission.PERMISSION_ADMIN_VISIT_UNTRUSTED)) {
                 player.sendMessage(
                         TranslatableCaption.of("permission.no_permission"),
                         Templates.of("node", "plots.visit.other")
-                );
-                return;
-            }
-            if (!plot.getFlag(UntrustedVisitFlag.class) && !Permissions
-                    .hasPermission(player, Permission.PERMISSION_ADMIN_VISIT_UNTRUSTED)) {
-                player.sendMessage(
-                        TranslatableCaption.of("permission.no_permission"),
-                        Templates.of("node", "plots.admin.visit.untrusted")
                 );
                 return;
             }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, please create one so we can look into it before approving your PR.
-->

Fixes #3317 

## Description
<!-- Please describe what this pull request does. -->
This is my solution as described in #3317. I kept both permissions, but the error message (if the player has neither and untrusted-visit is not set) will show only plots.visit.other. 

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)