### PR TITLE
refactor: Address MiniMessage deprecations

### DIFF
--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -98,6 +98,7 @@ tasks {
         opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-core/7.2.7/")
         opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-bukkit/7.2.7/")
         opt.links("https://jd.adventure.kyori.net/api/4.9.3/")
+        opt.links("https://notmyfault.github.io/MiniMessage-Javadocs/") // Temporary hosting for 4.2.0-SNAPSHOT, exchange when we jump to 4.10.0
         opt.links("https://google.github.io/guice/api-docs/5.0.1/javadoc/")
         opt.links("https://checkerframework.org/api/")
     }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -283,15 +283,15 @@ public class BlockEventListener implements Listener {
                 event.setCancelled(true);
                 pp.sendMessage(
                         TranslatableCaption.of("height.height_limit"),
-                        Template.of("minHeight", String.valueOf(area.getMinBuildHeight())),
-                        Template.of("maxHeight", String.valueOf(area.getMaxBuildHeight()))
+                        Template.template("minHeight", String.valueOf(area.getMinBuildHeight())),
+                        Template.template("maxHeight", String.valueOf(area.getMaxBuildHeight()))
                 );
             }
             if (!plot.hasOwner()) {
                 if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_BUILD_UNOWNED)) {
                     pp.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_UNOWNED))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_UNOWNED))
                     );
                     event.setCancelled(true);
                     return;
@@ -308,7 +308,7 @@ public class BlockEventListener implements Listener {
                 if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_BUILD_OTHER)) {
                     pp.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_OTHER))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_OTHER))
                     );
                     event.setCancelled(true);
                     plot.debug(player.getName() + " could not place " + event.getBlock().getType()
@@ -335,7 +335,7 @@ public class BlockEventListener implements Listener {
         } else if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_BUILD_ROAD)) {
             pp.sendMessage(
                     TranslatableCaption.of("permission.no_permission_event"),
-                    Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_ROAD))
+                    Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_ROAD))
             );
             event.setCancelled(true);
         }
@@ -357,7 +357,7 @@ public class BlockEventListener implements Listener {
                         .hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_DESTROY_GROUNDLEVEL)) {
                     plotPlayer.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_GROUNDLEVEL))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_GROUNDLEVEL))
                     );
                     event.setCancelled(true);
                     return;
@@ -368,8 +368,8 @@ public class BlockEventListener implements Listener {
                 event.setCancelled(true);
                 plotPlayer.sendMessage(
                         TranslatableCaption.of("height.height_limit"),
-                        Template.of("minHeight", String.valueOf(area.getMinBuildHeight())),
-                        Template.of("maxHeight", String.valueOf(area.getMaxBuildHeight()))
+                        Template.template("minHeight", String.valueOf(area.getMinBuildHeight())),
+                        Template.template("maxHeight", String.valueOf(area.getMaxBuildHeight()))
                 );
             }
             if (!plot.hasOwner()) {
@@ -394,7 +394,7 @@ public class BlockEventListener implements Listener {
                 }
                 plotPlayer.sendMessage(
                         TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_OTHER))
+                        Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_OTHER))
                 );
                 event.setCancelled(true);
             } else if (Settings.Done.RESTRICT_BUILDING && DoneFlag.isDone(plot)) {
@@ -420,7 +420,7 @@ public class BlockEventListener implements Listener {
         }
         pp.sendMessage(
                 TranslatableCaption.of("permission.no_permission_event"),
-                Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_ROAD))
+                Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_ROAD))
         );
         event.setCancelled(true);
     }
@@ -1095,7 +1095,7 @@ public class BlockEventListener implements Listener {
                 if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_BUILD_ROAD)) {
                     pp.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_ROAD))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_ROAD))
                     );
                     event.setCancelled(true);
                 }
@@ -1103,7 +1103,7 @@ public class BlockEventListener implements Listener {
                 if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_BUILD_UNOWNED)) {
                     pp.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_UNOWNED))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_UNOWNED))
                     );
                     event.setCancelled(true);
                 }
@@ -1111,7 +1111,7 @@ public class BlockEventListener implements Listener {
                 if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_BUILD_OTHER)) {
                     pp.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_OTHER))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_OTHER))
                     );
                     event.setCancelled(true);
                 }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
@@ -302,7 +302,7 @@ public class PaperListener implements Listener {
             final PlotPlayer<?> plotPlayer = BukkitUtil.adapt(event.getPlayer());
             plotPlayer.sendMessage(
                     TranslatableCaption.of("errors.tile_entity_cap_reached"),
-                    Template.of("amount", String.valueOf(Settings.Chunk_Processor.MAX_TILES))
+                    Template.template("amount", String.valueOf(Settings.Chunk_Processor.MAX_TILES))
             );
             event.setCancelled(true);
             event.setBuild(false);

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener113.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener113.java
@@ -84,7 +84,7 @@ public class PaperListener113 extends PaperListener {
             final PlotPlayer<?> plotPlayer = BukkitUtil.adapt(event.getPlayer());
             plotPlayer.sendMessage(
                     TranslatableCaption.of("errors.tile_entity_cap_reached"),
-                    Template.of("amount", String.valueOf(Settings.Chunk_Processor.MAX_TILES))
+                    Template.template("amount", String.valueOf(Settings.Chunk_Processor.MAX_TILES))
             );
             event.setCancelled(true);
             event.setBuild(false);

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -364,9 +364,9 @@ public class PlayerEventListener extends PlotListener implements Listener {
                 && PremiumVerification.isPremium() && UpdateUtility.hasUpdate) {
             Caption boundary = TranslatableCaption.of("update.update_boundary");
             Caption updateNotification = TranslatableCaption.of("update.update_notification");
-            Template internalVersion = Template.of("p2version", UpdateUtility.internalVersion.versionString());
-            Template spigotVersion = Template.of("spigotversion", UpdateUtility.spigotVersion);
-            Template downloadUrl = Template.of("downloadurl", "https://www.spigotmc.org/resources/77506/updates");
+            Template internalVersion = Template.template("p2version", UpdateUtility.internalVersion.versionString());
+            Template spigotVersion = Template.template("spigotversion", UpdateUtility.spigotVersion);
+            Template downloadUrl = Template.template("downloadurl", "https://www.spigotmc.org/resources/77506/updates");
             pp.sendMessage(boundary);
             pp.sendMessage(updateNotification, internalVersion, spigotVersion, downloadUrl);
             pp.sendMessage(boundary);
@@ -419,7 +419,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                             .equals(BukkitUtil.adaptComplete(to)))) {
                         pp.sendMessage(
                                 TranslatableCaption.of("permission.no_permission_event"),
-                                Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_ENTRY_DENIED))
+                                Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_ENTRY_DENIED))
                         );
                         event.setCancelled(true);
                     }
@@ -535,7 +535,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                     if (lastPlot != null && !plotExit(pp, lastPlot) && this.tmpTeleport && !kickAccess.get().orElse(false)) {
                         pp.sendMessage(
                                 TranslatableCaption.of("permission.no_permission_event"),
-                                Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_EXIT_DENIED))
+                                Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_EXIT_DENIED))
                         );
                         this.tmpTeleport = false;
                         if (lastPlot.equals(BukkitUtil.adapt(from).getPlot())) {
@@ -553,7 +553,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             } else if (!plotEntry(pp, now) && this.tmpTeleport) {
                 pp.sendMessage(
                         TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_ENTRY_DENIED))
+                        Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_ENTRY_DENIED))
                 );
                 this.tmpTeleport = false;
                 to.setX(from.getBlockX());
@@ -625,7 +625,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                     if (lastPlot != null && !plotExit(pp, lastPlot) && this.tmpTeleport && !kickAccess.get().orElse(false)) {
                         pp.sendMessage(
                                 TranslatableCaption.of("permission.no_permission_event"),
-                                Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_EXIT_DENIED))
+                                Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_EXIT_DENIED))
                         );
                         this.tmpTeleport = false;
                         if (lastPlot.equals(BukkitUtil.adapt(from).getPlot())) {
@@ -643,7 +643,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             } else if (!plotEntry(pp, now) && this.tmpTeleport) {
                 pp.sendMessage(
                         TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_ENTRY_DENIED))
+                        Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_ENTRY_DENIED))
                 );
                 this.tmpTeleport = false;
                 player.teleport(from);
@@ -729,9 +729,9 @@ public class PlayerEventListener extends PlotListener implements Listener {
         String worldName = plot.getWorldName();
         Caption msg = TranslatableCaption.of("chat.plot_chat_format");
         Template msgTemplate;
-        Template worldNameTemplate = Template.of("world", worldName);
-        Template plotTemplate = Template.of("plot_id", id.toString());
-        Template senderTemplate = Template.of("sender", sender);
+        Template worldNameTemplate = Template.template("world", worldName);
+        Template plotTemplate = Template.template("plot_id", id.toString());
+        Template senderTemplate = Template.template("sender", sender);
         // If we do/don't want colour, we need to be careful about how to go about it, as players could attempt either <gold></gold> or &6 etc.
         // In both cases, we want to use a Component Template to ensure that the player cannot use any placeholders in their message on purpose
         //  or accidentally, as component templates are done at the end. We also need to deserialize from legacy color codes to a Component if
@@ -746,7 +746,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                             ))
                     );
         } else {
-            msgTemplate = Template.of("msg", BukkitUtil.MINI_MESSAGE.deserialize(
+            msgTemplate = Template.template("msg", BukkitUtil.MINI_MESSAGE.deserialize(
                     ChatColor.stripColor(BukkitUtil.LEGACY_COMPONENT_SERIALIZER.serialize(Component.text(message)))));
         }
         for (PlotPlayer<?> receiver : plotRecipients) {
@@ -754,18 +754,18 @@ public class PlayerEventListener extends PlotListener implements Listener {
         }
         if (!spies.isEmpty()) {
             Caption spymsg = TranslatableCaption.of("chat.plot_chat_spy_format");
-            Template plotidTemplate = Template.of("plot_id", id.getX() + ";" + id.getY());
-            Template spysenderTemplate = Template.of("sender", sender);
-            Template spymessageTemplate = Template.of("msg", Component.text(message));
+            Template plotidTemplate = Template.template("plot_id", id.getX() + ";" + id.getY());
+            Template spysenderTemplate = Template.template("sender", sender);
+            Template spymessageTemplate = Template.template("msg", Component.text(message));
             for (PlotPlayer<?> player : spies) {
                 player.sendMessage(spymsg, worldNameTemplate, plotidTemplate, spysenderTemplate, spymessageTemplate);
             }
         }
         if (Settings.Chat.LOG_PLOTCHAT_TO_CONSOLE) {
             Caption spymsg = TranslatableCaption.of("chat.plot_chat_spy_format");
-            Template plotidTemplate = Template.of("plot_id", id.getX() + ";" + id.getY());
-            Template spysenderTemplate = Template.of("sender", sender);
-            Template spymessageTemplate = Template.of("msg", Component.text(message));
+            Template plotidTemplate = Template.template("plot_id", id.getX() + ";" + id.getY());
+            Template spysenderTemplate = Template.template("sender", sender);
+            Template spymessageTemplate = Template.template("msg", Component.text(message));
             ConsolePlayer.getConsole().sendMessage(spymsg, worldNameTemplate, plotidTemplate, spysenderTemplate,
                     spymessageTemplate
             );
@@ -921,7 +921,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_INTERACT_ROAD)) {
                 pp.sendMessage(
                         TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_ROAD))
+                        Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_ROAD))
                 );
                 cancelled = true;
             }
@@ -929,7 +929,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_INTERACT_UNOWNED)) {
                 pp.sendMessage(
                         TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_UNOWNED))
+                        Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_UNOWNED))
                 );
                 cancelled = true;
             }
@@ -939,7 +939,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                 if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_INTERACT_OTHER)) {
                     pp.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_OTHER))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_OTHER))
                     );
                     cancelled = true;
                 }
@@ -977,7 +977,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                     .hasPermission(pp, Permission.PERMISSION_ADMIN_INTERACT_ROAD)) {
                 pp.sendMessage(
                         TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_ROAD))
+                        Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_ROAD))
                 );
                 e.setCancelled(true);
             }
@@ -995,7 +995,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                 if (!Permissions.hasPermission(pp, "plots.admin.interact.unowned")) {
                     pp.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_UNOWNED))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_UNOWNED))
                     );
                     e.setCancelled(true);
                 }
@@ -1010,7 +1010,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                 if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_INTERACT_OTHER)) {
                     pp.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_OTHER))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_OTHER))
                     );
                     e.setCancelled(true);
                     plot.debug(pp.getName() + " could not interact with " + entity.getType()
@@ -1226,7 +1226,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             }
             pp.sendMessage(
                     TranslatableCaption.of("permission.no_permission_event"),
-                    Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_ROAD))
+                    Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_ROAD))
             );
             event.setCancelled(true);
         } else if (!plot.hasOwner()) {
@@ -1235,7 +1235,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             }
             pp.sendMessage(
                     TranslatableCaption.of("permission.no_permission_event"),
-                    Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_UNOWNED))
+                    Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_UNOWNED))
             );
             event.setCancelled(true);
         } else if (!plot.isAdded(pp.getUUID())) {
@@ -1251,7 +1251,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             }
             pp.sendMessage(
                     TranslatableCaption.of("permission.no_permission_event"),
-                    Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_OTHER))
+                    Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_OTHER))
             );
             event.setCancelled(true);
         } else if (Settings.Done.RESTRICT_BUILDING && DoneFlag.isDone(plot)) {
@@ -1298,7 +1298,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             }
             plotPlayer.sendMessage(
                     TranslatableCaption.of("permission.no_permission_event"),
-                    Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_ROAD))
+                    Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_ROAD))
             );
             event.setCancelled(true);
         } else if (!plot.hasOwner()) {
@@ -1307,7 +1307,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             }
             plotPlayer.sendMessage(
                     TranslatableCaption.of("permission.no_permission_event"),
-                    Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_UNOWNED))
+                    Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_UNOWNED))
             );
             event.setCancelled(true);
         } else if (!plot.isAdded(plotPlayer.getUUID())) {
@@ -1324,7 +1324,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             }
             plotPlayer.sendMessage(
                     TranslatableCaption.of("permission.no_permission_event"),
-                    Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_OTHER))
+                    Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_OTHER))
             );
             event.setCancelled(true);
         } else if (Settings.Done.RESTRICT_BUILDING && DoneFlag.isDone(plot)) {
@@ -1356,7 +1356,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_BUILD_ROAD)) {
                 pp.sendMessage(
                         TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_ROAD))
+                        Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_ROAD))
                 );
                 event.setCancelled(true);
             }
@@ -1365,7 +1365,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                 if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_BUILD_UNOWNED)) {
                     pp.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_UNOWNED))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_UNOWNED))
                     );
                     event.setCancelled(true);
                 }
@@ -1376,7 +1376,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                     if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_BUILD_OTHER)) {
                         pp.sendMessage(
                                 TranslatableCaption.of("permission.no_permission_event"),
-                                Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_OTHER))
+                                Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_OTHER))
                         );
                         event.setCancelled(true);
                     }
@@ -1405,7 +1405,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                 if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_DESTROY_ROAD)) {
                     pp.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_ROAD))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_ROAD))
                     );
                     event.setCancelled(true);
                 }
@@ -1413,7 +1413,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                 if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_DESTROY_UNOWNED)) {
                     pp.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_UNOWNED))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_UNOWNED))
                     );
                     event.setCancelled(true);
                 }
@@ -1424,7 +1424,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                 if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_DESTROY_OTHER)) {
                     pp.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_OTHER))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_OTHER))
                     );
                     event.setCancelled(true);
                     plot.debug(p.getName()
@@ -1446,7 +1446,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                                 .hasPermission(player, Permission.PERMISSION_ADMIN_DESTROY_UNOWNED)) {
                             player.sendMessage(
                                     TranslatableCaption.of("permission.no_permission_event"),
-                                    Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_UNOWNED))
+                                    Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_UNOWNED))
                             );
                             event.setCancelled(true);
                         }
@@ -1456,7 +1456,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                                     .hasPermission(player, Permission.PERMISSION_ADMIN_DESTROY_OTHER)) {
                                 player.sendMessage(
                                         TranslatableCaption.of("permission.no_permission_event"),
-                                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_OTHER))
+                                        Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_OTHER))
                                 );
                                 event.setCancelled(true);
                                 plot.debug(player.getName()
@@ -1488,7 +1488,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_INTERACT_ROAD)) {
                 pp.sendMessage(
                         TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_ROAD))
+                        Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_ROAD))
                 );
                 event.setCancelled(true);
             }
@@ -1496,7 +1496,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_INTERACT_UNOWNED)) {
                 pp.sendMessage(
                         TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_UNOWNED))
+                        Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_UNOWNED))
                 );
                 event.setCancelled(true);
             }
@@ -1554,7 +1554,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_INTERACT_OTHER)) {
                 pp.sendMessage(
                         TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_OTHER))
+                        Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_INTERACT_OTHER))
                 );
                 event.setCancelled(true);
             }
@@ -1576,7 +1576,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                 if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_DESTROY_VEHICLE_ROAD)) {
                     pp.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_VEHICLE_ROAD))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_VEHICLE_ROAD))
                     );
                     event.setCancelled(true);
                 }
@@ -1585,7 +1585,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                     if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_DESTROY_VEHICLE_UNOWNED)) {
                         pp.sendMessage(
                                 TranslatableCaption.of("permission.no_permission_event"),
-                                Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_VEHICLE_UNOWNED))
+                                Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_VEHICLE_UNOWNED))
                         );
                         event.setCancelled(true);
                         return;
@@ -1599,7 +1599,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
                     if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_DESTROY_VEHICLE_OTHER)) {
                         pp.sendMessage(
                                 TranslatableCaption.of("permission.no_permission_event"),
-                                Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_VEHICLE_OTHER))
+                                Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_DESTROY_VEHICLE_OTHER))
                         );
                         event.setCancelled(true);
                         plot.debug(pp.getName()
@@ -1624,7 +1624,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             if (!Permissions.hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_PROJECTILE_ROAD)) {
                 plotPlayer.sendMessage(
                         TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_PROJECTILE_ROAD))
+                        Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_PROJECTILE_ROAD))
                 );
                 event.setHatching(false);
             }
@@ -1632,7 +1632,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             if (!Permissions.hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_PROJECTILE_UNOWNED)) {
                 plotPlayer.sendMessage(
                         TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_PROJECTILE_UNOWNED))
+                        Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_PROJECTILE_UNOWNED))
                 );
                 event.setHatching(false);
             }
@@ -1640,7 +1640,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             if (!Permissions.hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_PROJECTILE_OTHER)) {
                 plotPlayer.sendMessage(
                         TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_PROJECTILE_OTHER))
+                        Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_PROJECTILE_OTHER))
                 );
                 event.setHatching(false);
             }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/managers/MultiverseWorldManager.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/managers/MultiverseWorldManager.java
@@ -36,7 +36,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * world creation by executing a console command
  *
  * @deprecated Deprecated and scheduled for removal without replacement
- *         in favor of the build in setup wizard.
+ * in favor of the build in setup wizard.
  */
 @Deprecated(forRemoval = true)
 @Singleton

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitEntityUtil.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitEntityUtil.java
@@ -188,7 +188,7 @@ public class BukkitEntityUtil {
                 if (!Permissions.hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_DESTROY + "." + stub)) {
                     plotPlayer.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", Permission.PERMISSION_ADMIN_DESTROY + "." + stub)
+                            Template.template("node", Permission.PERMISSION_ADMIN_DESTROY + "." + stub)
                     );
                     return false;
                 }
@@ -200,7 +200,7 @@ public class BukkitEntityUtil {
                 if (!Permissions.hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_DESTROY + "." + stub)) {
                     plotPlayer.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", Permission.PERMISSION_ADMIN_DESTROY + "." + stub)
+                            Template.template("node", Permission.PERMISSION_ADMIN_DESTROY + "." + stub)
                     );
                     if (plot != null) {
                         plot.debug(player.getName()
@@ -221,7 +221,7 @@ public class BukkitEntityUtil {
                 if (!Permissions.hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_PVE + "." + stub)) {
                     plotPlayer.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", Permission.PERMISSION_ADMIN_PVE + "." + stub)
+                            Template.template("node", Permission.PERMISSION_ADMIN_PVE + "." + stub)
                     );
                     if (plot != null) {
                         plot.debug(player.getName() + " could not attack " + entityType
@@ -242,7 +242,7 @@ public class BukkitEntityUtil {
                 if (!Permissions.hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_PVE + "." + stub)) {
                     plotPlayer.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", Permission.PERMISSION_ADMIN_PVE + "." + stub)
+                            Template.template("node", Permission.PERMISSION_ADMIN_PVE + "." + stub)
                     );
                     if (plot != null) {
                         plot.debug(player.getName() + " could not attack " + entityType
@@ -256,7 +256,7 @@ public class BukkitEntityUtil {
                             .hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_PVP + "." + stub)) {
                         plotPlayer.sendMessage(
                                 TranslatableCaption.of("permission.no_permission_event"),
-                                Template.of("node", Permission.PERMISSION_ADMIN_PVP + "." + stub)
+                                Template.template("node", Permission.PERMISSION_ADMIN_PVP + "." + stub)
                         );
                         plot.debug(player.getName() + " could not attack " + entityType
                                 + " because pve = false");
@@ -270,7 +270,7 @@ public class BukkitEntityUtil {
                 if (!Permissions.hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_PVP + "." + stub)) {
                     plotPlayer.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", Permission.PERMISSION_ADMIN_PVP + "." + stub)
+                            Template.template("node", Permission.PERMISSION_ADMIN_PVP + "." + stub)
                     );
                     return false;
                 }
@@ -287,7 +287,7 @@ public class BukkitEntityUtil {
                 if (!Permissions.hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_PVE + "." + stub)) {
                     plotPlayer.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", Permission.PERMISSION_ADMIN_PVE + "." + stub)
+                            Template.template("node", Permission.PERMISSION_ADMIN_PVE + "." + stub)
                     );
                     if (plot != null) {
                         plot.debug(player.getName() + " could not attack " + entityType
@@ -309,7 +309,7 @@ public class BukkitEntityUtil {
                 if (!Permissions.hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_PVE + "." + stub)) {
                     plotPlayer.sendMessage(
                             TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", Permission.PERMISSION_ADMIN_PVE + "." + stub)
+                            Template.template("node", Permission.PERMISSION_ADMIN_PVE + "." + stub)
                     );
                     if (plot != null) {
                         plot.debug(player.getName() + " could not attack " + entityType

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
@@ -54,6 +54,7 @@ import io.papermc.lib.PaperLib;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -369,7 +370,8 @@ public class BukkitUtil extends WorldUtil {
             if (blockstate instanceof final Sign sign) {
                 for (int i = 0; i < lines.length; i++) {
                     sign.setLine(i, LEGACY_COMPONENT_SERIALIZER
-                            .serialize(MINI_MESSAGE.parse(lines[i].getComponent(LocaleHolder.console()), replacements)));
+                            .serialize(MINI_MESSAGE.deserialize(lines[i].getComponent(LocaleHolder.console()),
+                                    TemplateResolver.templates(replacements))));
                 }
                 sign.update(true);
             }

--- a/Core/build.gradle.kts
+++ b/Core/build.gradle.kts
@@ -49,9 +49,9 @@ dependencies {
 tasks.processResources {
     filesMatching("plugin.properties") {
         expand(
-                "version" to project.version.toString(),
-                "commit" to rootProject.grgit.head().abbreviatedId,
-                "date" to rootProject.grgit.head().dateTime.format(DateTimeFormatter.ofPattern("yy.MM.dd"))
+            "version" to project.version.toString(),
+            "commit" to rootProject.grgit.head().abbreviatedId,
+            "date" to rootProject.grgit.head().dateTime.format(DateTimeFormatter.ofPattern("yy.MM.dd"))
         )
     }
 }

--- a/Core/src/main/java/com/plotsquared/core/backup/SimpleBackupManager.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/SimpleBackupManager.java
@@ -107,7 +107,7 @@ public class SimpleBackupManager implements BackupManager {
             if (player != null) {
                 player.sendMessage(
                         TranslatableCaption.of("backups.backup_automatic_started"),
-                        Template.of("plot", plot.getId().toString())
+                        Template.template("plot", plot.getId().toString())
                 );
             }
             profile.createBackup().whenComplete((backup, throwable) -> {

--- a/Core/src/main/java/com/plotsquared/core/command/Add.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Add.java
@@ -77,7 +77,7 @@ public class Add extends Command {
                 TranslatableCaption.of("permission.no_plot_perms")
         );
         checkTrue(args.length == 1, TranslatableCaption.of("commandconfig.command_syntax"),
-                Template.of("value", "/plot add <player | *>")
+                Template.template("value", "/plot add <player | *>")
         );
         final CompletableFuture<Boolean> future = new CompletableFuture<>();
         PlayerManager.getUUIDsFromString(args[0], (uuids, throwable) -> {
@@ -87,7 +87,7 @@ public class Add extends Command {
                 } else {
                     player.sendMessage(
                             TranslatableCaption.of("errors.invalid_player"),
-                            Template.of("value", args[0])
+                            Template.template("value", args[0])
                     );
                 }
                 future.completeExceptionally(throwable);
@@ -95,7 +95,7 @@ public class Add extends Command {
             } else {
                 try {
                     checkTrue(!uuids.isEmpty(), TranslatableCaption.of("errors.invalid_player"),
-                            Template.of("value", args[0])
+                            Template.template("value", args[0])
                     );
                     Iterator<UUID> iterator = uuids.iterator();
                     int size = plot.getTrusted().size() + plot.getMembers().size();
@@ -106,7 +106,7 @@ public class Add extends Command {
                                         .hasPermission(player, Permission.PERMISSION_ADMIN_COMMAND_TRUST))) {
                             player.sendMessage(
                                     TranslatableCaption.of("errors.invalid_player"),
-                                    Template.of("value", PlayerManager.getName(uuid))
+                                    Template.template("value", PlayerManager.getName(uuid))
                             );
                             iterator.remove();
                             continue;
@@ -114,7 +114,7 @@ public class Add extends Command {
                         if (plot.isOwner(uuid)) {
                             player.sendMessage(
                                     TranslatableCaption.of("member.already_added"),
-                                    Template.of("player", PlayerManager.getName(uuid))
+                                    Template.template("player", PlayerManager.getName(uuid))
                             );
                             iterator.remove();
                             continue;
@@ -122,7 +122,7 @@ public class Add extends Command {
                         if (plot.getMembers().contains(uuid)) {
                             player.sendMessage(
                                     TranslatableCaption.of("member.already_added"),
-                                    Template.of("player", PlayerManager.getName(uuid))
+                                    Template.template("player", PlayerManager.getName(uuid))
                             );
                             iterator.remove();
                             continue;
@@ -135,7 +135,7 @@ public class Add extends Command {
                     if (localAddSize >= maxAddSize) {
                         player.sendMessage(
                                 TranslatableCaption.of("members.plot_max_members_added"),
-                                Template.of("amount", String.valueOf(localAddSize))
+                                Template.template("amount", String.valueOf(localAddSize))
                         );
                         return;
                     }

--- a/Core/src/main/java/com/plotsquared/core/command/Alias.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Alias.java
@@ -99,7 +99,7 @@ public class Alias extends SubCommand {
                 } else {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ALIAS_SET))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_ALIAS_SET))
                     );
                 }
             }
@@ -115,7 +115,7 @@ public class Alias extends SubCommand {
                 } else {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ALIAS_REMOVE))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_ALIAS_REMOVE))
                     );
                 }
             }
@@ -156,13 +156,13 @@ public class Alias extends SubCommand {
                     .anyMatch()) {
                 player.sendMessage(
                         TranslatableCaption.of("alias.alias_is_taken"),
-                        Template.of("alias", alias)
+                        Template.template("alias", alias)
                 );
                 return;
             }
             if (Settings.UUID.OFFLINE) {
                 plot.setAlias(alias);
-                player.sendMessage(TranslatableCaption.of("alias.alias_set_to"), Template.of("alias", alias));
+                player.sendMessage(TranslatableCaption.of("alias.alias_set_to"), Template.template("alias", alias));
                 return;
             }
             PlotSquared.get().getImpromptuUUIDPipeline().getSingle(alias, ((uuid, throwable) -> {
@@ -171,13 +171,13 @@ public class Alias extends SubCommand {
                 } else if (uuid != null) {
                     player.sendMessage(
                             TranslatableCaption.of("alias.alias_is_taken"),
-                            Template.of("alias", alias)
+                            Template.template("alias", alias)
                     );
                 } else {
                     plot.setAlias(alias);
                     player.sendMessage(
                             TranslatableCaption.of("alias.alias_set_to"),
-                            Template.of("alias", alias)
+                            Template.template("alias", alias)
                     );
                 }
             }));
@@ -189,7 +189,7 @@ public class Alias extends SubCommand {
         if (!plot.getAlias().isEmpty()) {
             player.sendMessage(
                     TranslatableCaption.of("alias.alias_removed"),
-                    Template.of("alias", alias)
+                    Template.template("alias", alias)
             );
         } else {
             player.sendMessage(

--- a/Core/src/main/java/com/plotsquared/core/command/Area.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Area.java
@@ -76,6 +76,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.regions.Region;
 import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.io.File;
@@ -147,14 +148,14 @@ public class Area extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_AREA_CREATE)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_AREA_CREATE))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_AREA_CREATE))
                     );
                     return false;
                 }
                 if (args.length < 2) {
                     player.sendMessage(
                             TranslatableCaption.of("single.single_area_needs_name"),
-                            Template.of("command", "/plot area single <name>")
+                            Template.template("command", "/plot area single <name>")
                     );
                     return false;
                 }
@@ -285,7 +286,7 @@ public class Area extends SubCommand {
                     } else {
                         player.sendMessage(
                                 TranslatableCaption.of("errors.error_create"),
-                                Template.of("world", hybridPlotWorld.getWorldName())
+                                Template.template("world", hybridPlotWorld.getWorldName())
                         );
                     }
                 };
@@ -296,7 +297,7 @@ public class Area extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_AREA_CREATE)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_AREA_CREATE))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_AREA_CREATE))
                     );
                     return false;
                 }
@@ -329,12 +330,12 @@ public class Area extends SubCommand {
                                 );
                                 player.sendMessage(
                                         TranslatableCaption.of("set.set_attribute"),
-                                        Template.of("attribute", "area_pos1"),
-                                        Template.of("value", location.getX() + "," + location.getZ())
+                                        Template.template("attribute", "area_pos1"),
+                                        Template.template("value", location.getX() + "," + location.getZ())
                                 );
                                 player.sendMessage(
                                         TranslatableCaption.of("area.set_pos2"),
-                                        Template.of("command", "/plot area create pos2")
+                                        Template.template("command", "/plot area create pos2")
                                 );
                                 return true;
                             }
@@ -374,7 +375,7 @@ public class Area extends SubCommand {
                                 if (!areas.isEmpty()) {
                                     player.sendMessage(
                                             TranslatableCaption.of("cluster.cluster_intersection"),
-                                            Template.of("cluster", areas.iterator().next().toString())
+                                            Template.template("cluster", areas.iterator().next().toString())
                                     );
                                     return false;
                                 }
@@ -413,7 +414,7 @@ public class Area extends SubCommand {
                                     } else {
                                         player.sendMessage(
                                                 TranslatableCaption.of("errors.error_create"),
-                                                Template.of("world", area.getWorldName())
+                                                Template.template("world", area.getWorldName())
                                         );
                                     }
                                 };
@@ -447,7 +448,7 @@ public class Area extends SubCommand {
                         if (other != null && Objects.equals(pa.getId(), other.getId())) {
                             player.sendMessage(
                                     TranslatableCaption.of("setup.setup_world_taken"),
-                                    Template.of("value", pa.toString())
+                                    Template.template("value", pa.toString())
                             );
                             return false;
                         }
@@ -462,8 +463,8 @@ public class Area extends SubCommand {
                             if (pair.length != 2) {
                                 player.sendMessage(
                                         TranslatableCaption.of("commandconfig.command_syntax_extended"),
-                                        Template.of("value1,", getCommandString()),
-                                        Template.of("value2", " create [world[:id]] [<modifier>=<value>]...")
+                                        Template.template("value1,", getCommandString()),
+                                        Template.template("value2", " create [world[:id]] [<modifier>=<value>]...")
                                 );
                                 return false;
                             }
@@ -499,8 +500,8 @@ public class Area extends SubCommand {
                                 default -> {
                                     player.sendMessage(
                                             TranslatableCaption.of("commandconfig.command_syntax_extended"),
-                                            Template.of("value1", getCommandString()),
-                                            Template.of("value2", " create [world[:id]] [<modifier>=<value>]...")
+                                            Template.template("value1", getCommandString()),
+                                            Template.template("value2", " create [world[:id]] [<modifier>=<value>]...")
                                     );
                                     return false;
                                 }
@@ -510,7 +511,7 @@ public class Area extends SubCommand {
                             if (this.worldUtil.isWorld(pa.getWorldName())) {
                                 player.sendMessage(
                                         TranslatableCaption.of("setup.setup_world_taken"),
-                                        Template.of("value", pa.getWorldName())
+                                        Template.template("value", pa.getWorldName())
                                 );
                                 return false;
                             }
@@ -531,7 +532,7 @@ public class Area extends SubCommand {
                                 } else {
                                     player.sendMessage(
                                             TranslatableCaption.of("errors.error_create"),
-                                            Template.of("world", pa.getWorldName())
+                                            Template.template("world", pa.getWorldName())
                                     );
                                 }
                                 try {
@@ -550,12 +551,12 @@ public class Area extends SubCommand {
                         if (pa.getId() == null) {
                             player.sendMessage(
                                     TranslatableCaption.of("commandconfig.command_syntax"),
-                                    Template.of("value", getUsage())
+                                    Template.template("value", getUsage())
                             );
                             player.sendMessage(
                                     TranslatableCaption.of("commandconfig.command_syntax_extended"),
-                                    Template.of("value1", getCommandString()),
-                                    Template.of("value2", " create [world[:id]] [<modifier>=<value>]...")
+                                    Template.template("value1", getCommandString()),
+                                    Template.template("value2", " create [world[:id]] [<modifier>=<value>]...")
                             );
                             return false;
                         }
@@ -572,7 +573,7 @@ public class Area extends SubCommand {
                         metaData.computeIfAbsent(player.getUUID(), missingUUID -> new HashMap<>()).put("area_create_area", pa);
                         player.sendMessage(
                                 TranslatableCaption.of("single.get_position"),
-                                Template.of("command", getCommandString())
+                                Template.template("command", getCommandString())
                         );
                         break;
                 }
@@ -582,7 +583,7 @@ public class Area extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_AREA_INFO)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_AREA_INFO))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_AREA_INFO))
                     );
                     return false;
                 }
@@ -593,15 +594,15 @@ public class Area extends SubCommand {
                     default -> {
                         player.sendMessage(
                                 TranslatableCaption.of("commandconfig.command_syntax_extended"),
-                                Template.of("value1", getCommandString()),
-                                Template.of("value2", " info [area]")
+                                Template.template("value1", getCommandString()),
+                                Template.template("value2", " info [area]")
                         );
                         return false;
                     }
                 }
                 if (area == null) {
                     if (args.length == 2) {
-                        player.sendMessage(TranslatableCaption.of("errors.not_valid_plot_world"), Template.of("value", args[1]));
+                        player.sendMessage(TranslatableCaption.of("errors.not_valid_plot_world"), Template.template("value", args[1]));
                     } else {
                         player.sendMessage(TranslatableCaption.of("errors.not_in_plot_world"));
                     }
@@ -625,19 +626,19 @@ public class Area extends SubCommand {
                     percent = claimed == 0 ? 0 : 100d * claimed / Integer.MAX_VALUE;
                     region = "N/A";
                 }
-                Template headerTemplate = Template.of(
+                Template headerTemplate = Template.template(
                         "header",
                         TranslatableCaption.of("info.plot_info_header").getComponent(player)
                 );
-                Template nameTemplate = Template.of("name", name);
-                Template typeTemplate = Template.of("type", area.getType().name());
-                Template terrainTemplate = Template.of("terrain", area.getTerrain().name());
-                Template usageTemplate = Template.of("usage", String.format("%.2f", percent));
-                Template claimedTemplate = Template.of("claimed", String.valueOf(claimed));
-                Template clustersTemplate = Template.of("clusters", String.valueOf(clusters));
-                Template regionTemplate = Template.of("region", region);
-                Template generatorTemplate = Template.of("generator", generator);
-                Template footerTemplate = Template.of(
+                Template nameTemplate = Template.template("name", name);
+                Template typeTemplate = Template.template("type", area.getType().name());
+                Template terrainTemplate = Template.template("terrain", area.getTerrain().name());
+                Template usageTemplate = Template.template("usage", String.format("%.2f", percent));
+                Template claimedTemplate = Template.template("claimed", String.valueOf(claimed));
+                Template clustersTemplate = Template.template("clusters", String.valueOf(clusters));
+                Template regionTemplate = Template.template("region", region);
+                Template generatorTemplate = Template.template("generator", generator);
+                Template footerTemplate = Template.template(
                         "footer",
                         TranslatableCaption.of("info.plot_info_footer").getComponent(player)
                 );
@@ -660,7 +661,7 @@ public class Area extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_AREA_LIST)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_AREA_LIST))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_AREA_LIST))
                     );
                     return false;
                 }
@@ -677,13 +678,13 @@ public class Area extends SubCommand {
                     default:
                         player.sendMessage(
                                 TranslatableCaption.of("commandconfig.command_syntax_extended"),
-                                Template.of("value1", getCommandString()),
-                                Template.of("value2", " list [#]")
+                                Template.template("value1", getCommandString()),
+                                Template.template("value2", " list [#]")
                         );
                         return false;
                 }
                 final List<PlotArea> areas = new ArrayList<>(Arrays.asList(this.plotAreaManager.getAllPlotAreas()));
-                paginate(player, areas, 8, page, new RunnableVal3<Integer, PlotArea, CaptionHolder>() {
+                paginate(player, areas, 8, page, new RunnableVal3<>() {
                     @Override
                     public void run(Integer i, PlotArea area, CaptionHolder caption) {
                         String name;
@@ -704,27 +705,27 @@ public class Area extends SubCommand {
                             percent = claimed == 0 ? 0 : (double) claimed / Short.MAX_VALUE * Short.MAX_VALUE;
                             region = "N/A";
                         }
-                        Template claimedTemplate = Template.of("claimed", String.valueOf(claimed));
-                        Template usageTemplate = Template.of("usage", String.format("%.2f", percent) + "%");
-                        Template clustersTemplate = Template.of("clusters", String.valueOf(clusters));
-                        Template regionTemplate = Template.of("region", region);
-                        Template generatorTemplate = Template.of("generator", generator);
+                        Template claimedTemplate = Template.template("claimed", String.valueOf(claimed));
+                        Template usageTemplate = Template.template("usage", String.format("%.2f", percent) + "%");
+                        Template clustersTemplate = Template.template("clusters", String.valueOf(clusters));
+                        Template regionTemplate = Template.template("region", region);
+                        Template generatorTemplate = Template.template("generator", generator);
                         String tooltip = MINI_MESSAGE.serialize(MINI_MESSAGE
-                                .parse(
+                                .deserialize(
                                         TranslatableCaption.of("info.area_list_tooltip").getComponent(player),
-                                        claimedTemplate,
-                                        usageTemplate,
-                                        clustersTemplate,
-                                        regionTemplate,
-                                        generatorTemplate
+                                        TemplateResolver.templates(claimedTemplate,
+                                                usageTemplate,
+                                                clustersTemplate,
+                                                regionTemplate,
+                                                generatorTemplate)
                                 ));
-                        Template tooltipTemplate = Template.of("hover_info", tooltip);
-                        Template visitcmdTemplate = Template.of("command_tp", "/plot area tp " + area);
-                        Template infocmdTemplate = Template.of("command_info", "/plot area info " + area);
-                        Template numberTemplate = Template.of("number", String.valueOf(i));
-                        Template nameTemplate = Template.of("area_name", name);
-                        Template typeTemplate = Template.of("area_type", area.getType().name());
-                        Template terrainTemplate = Template.of("area_terrain", area.getTerrain().name());
+                        Template tooltipTemplate = Template.template("hover_info", tooltip);
+                        Template visitcmdTemplate = Template.template("command_tp", "/plot area tp " + area);
+                        Template infocmdTemplate = Template.template("command_info", "/plot area info " + area);
+                        Template numberTemplate = Template.template("number", String.valueOf(i));
+                        Template nameTemplate = Template.template("area_name", name);
+                        Template typeTemplate = Template.template("area_type", area.getType().name());
+                        Template terrainTemplate = Template.template("area_terrain", area.getTerrain().name());
                         caption.set(TranslatableCaption.of("info.area_list_item"));
                         caption.setTemplates(
                                 tooltipTemplate,
@@ -743,7 +744,7 @@ public class Area extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_AREA_REGEN)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_AREA_REGEN))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_AREA_REGEN))
                     );
                     return false;
                 }
@@ -755,7 +756,7 @@ public class Area extends SubCommand {
                 if (area.getType() != PlotAreaType.PARTIAL) {
                     player.sendMessage(
                             TranslatableCaption.of("single.delete_world_region"),
-                            Template.of("world", area.getWorldName())
+                            Template.template("world", area.getWorldName())
                     );
                     return false;
                 }
@@ -776,20 +777,20 @@ public class Area extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_AREA_TP)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_AREA_TP))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_AREA_TP))
                     );
                     return false;
                 }
                 if (args.length != 2) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "/plot area tp [area]")
+                            Template.template("value", "/plot area tp [area]")
                     );
                     return false;
                 }
                 PlotArea area = this.plotAreaManager.getPlotAreaByString(args[1]);
                 if (area == null) {
-                    player.sendMessage(TranslatableCaption.of("errors.not_valid_plot_world"), Template.of("value", args[1]));
+                    player.sendMessage(TranslatableCaption.of("errors.not_valid_plot_world"), Template.template("value", args[1]));
                     return false;
                 }
                 Location center;

--- a/Core/src/main/java/com/plotsquared/core/command/Auto.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Auto.java
@@ -117,13 +117,13 @@ public class Auto extends SubCommand {
                     if (diff < 0 && grantedPlots < sizeX * sizeZ) {
                         player.sendMessage(
                                 TranslatableCaption.of("permission.cant_claim_more_plots"),
-                                Template.of("amount", String.valueOf(diff + grantedPlots))
+                                Template.template("amount", String.valueOf(diff + grantedPlots))
                         );
                         return false;
                     } else if (diff >= 0 && grantedPlots + diff < sizeX * sizeZ) {
                         player.sendMessage(
                                 TranslatableCaption.of("permission.cant_claim_more_plots"),
-                                Template.of("amount", String.valueOf(diff + grantedPlots))
+                                Template.template("amount", String.valueOf(diff + grantedPlots))
                         );
                         return false;
                     } else {
@@ -135,14 +135,14 @@ public class Auto extends SubCommand {
                         }
                         player.sendMessage(
                                 TranslatableCaption.of("economy.removed_granted_plot"),
-                                Template.of("usedGrants", String.valueOf(grantedPlots - left)),
-                                Template.of("remainingGrants", String.valueOf(left))
+                                Template.template("usedGrants", String.valueOf(grantedPlots - left)),
+                                Template.template("remainingGrants", String.valueOf(left))
                         );
                     }
                 } else {
                     player.sendMessage(
                             TranslatableCaption.of("permission.cant_claim_more_plots"),
-                            Template.of("amount", String.valueOf(player.getAllowedPlots())
+                            Template.template("amount", String.valueOf(player.getAllowedPlots())
                             )
                     );
                     return false;
@@ -222,7 +222,7 @@ public class Auto extends SubCommand {
                 } else {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", getUsage())
+                            Template.template("value", getUsage())
                     );
                     return true;
                 }
@@ -245,7 +245,7 @@ public class Auto extends SubCommand {
         if (event.getEventResult() == Result.DENY) {
             player.sendMessage(
                     TranslatableCaption.of("events.event_denied"),
-                    Template.of("value", "Auto claim")
+                    Template.template("value", "Auto claim")
             );
             return true;
         }
@@ -256,13 +256,13 @@ public class Auto extends SubCommand {
         if (!force && mega && !Permissions.hasPermission(player, Permission.PERMISSION_AUTO_MEGA)) {
             player.sendMessage(
                     TranslatableCaption.of("permission.no_permission"),
-                    Template.of("node", String.valueOf(Permission.PERMISSION_AUTO_MEGA))
+                    Template.template("node", String.valueOf(Permission.PERMISSION_AUTO_MEGA))
             );
         }
         if (!force && sizeX * sizeZ > Settings.Claim.MAX_AUTO_AREA) {
             player.sendMessage(
                     TranslatableCaption.of("permission.cant_claim_more_plots_num"),
-                    Template.of("amount", String.valueOf(Settings.Claim.MAX_AUTO_AREA))
+                    Template.template("amount", String.valueOf(Settings.Claim.MAX_AUTO_AREA))
             );
             return false;
         }
@@ -280,8 +280,8 @@ public class Auto extends SubCommand {
             if (!plotarea.hasSchematic(schematic)) {
                 player.sendMessage(
                         TranslatableCaption.of("schematics.schematic_invalid_named"),
-                        Template.of("schemname", schematic),
-                        Template.of("reason", "non-existent")
+                        Template.template("schemname", schematic),
+                        Template.template("reason", "non-existent")
                 );
                 return true;
             }
@@ -292,7 +292,7 @@ public class Auto extends SubCommand {
                     .hasPermission(player, "plots.admin.command.schematic")) {
                 player.sendMessage(
                         TranslatableCaption.of("permission.no_permission"),
-                        Template.of("node", "plots.claim.%s0")
+                        Template.template("node", "plots.claim.%s0")
                 );
                 return true;
             }
@@ -311,15 +311,15 @@ public class Auto extends SubCommand {
                 if (!force && this.econHandler.getMoney(player) < cost) {
                     player.sendMessage(
                             TranslatableCaption.of("economy.cannot_afford_plot"),
-                            Template.of("money", this.econHandler.format(cost)),
-                            Template.of("balance", this.econHandler.format(this.econHandler.getMoney(player)))
+                            Template.template("money", this.econHandler.format(cost)),
+                            Template.template("balance", this.econHandler.format(this.econHandler.getMoney(player)))
                     );
                     return false;
                 }
                 this.econHandler.withdrawMoney(player, cost);
                 player.sendMessage(
                         TranslatableCaption.of("economy.removed_balance"),
-                        Template.of("money", this.econHandler.format(cost))
+                        Template.template("money", this.econHandler.format(cost))
                 );
             }
         }
@@ -352,7 +352,7 @@ public class Auto extends SubCommand {
             if (!force && mergeEvent.getEventResult() == Result.DENY) {
                 player.sendMessage(
                         TranslatableCaption.of("events.event_denied"),
-                        Template.of("value", "Auto merge")
+                        Template.template("value", "Auto merge")
                 );
                 return false;
             }

--- a/Core/src/main/java/com/plotsquared/core/command/Backup.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Backup.java
@@ -74,7 +74,7 @@ public final class Backup extends Command {
     private static boolean sendMessage(PlotPlayer<?> player) {
         player.sendMessage(
                 TranslatableCaption.of("commandconfig.command_syntax"),
-                Template.of("value", "/plot backup <save | list | load>")
+                Template.template("value", "/plot backup <save | list | load>")
         );
         return true;
     }
@@ -142,34 +142,34 @@ public final class Backup extends Command {
         } else if (!plot.hasOwner()) {
             player.sendMessage(
                     TranslatableCaption.of("backups.backup_impossible"),
-                    Template.of("plot", TranslatableCaption.of("generic.generic_unowned").getComponent(player))
+                    Template.template("plot", TranslatableCaption.of("generic.generic_unowned").getComponent(player))
             );
         } else if (plot.getVolume() > Integer.MAX_VALUE) {
             player.sendMessage(TranslatableCaption.of("schematics.schematic_too_large"));
         } else if (plot.isMerged()) {
             player.sendMessage(
                     TranslatableCaption.of("backups.backup_impossible"),
-                    Template.of("plot", TranslatableCaption.of("generic.generic_merged").getComponent(player))
+                    Template.template("plot", TranslatableCaption.of("generic.generic_merged").getComponent(player))
             );
         } else if (!plot.isOwner(player.getUUID()) && !Permissions
                 .hasPermission(player, Permission.PERMISSION_ADMIN_BACKUP_OTHER)) {
             player.sendMessage(
                     TranslatableCaption.of("permission.no_permission"),
-                    Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BACKUP_OTHER))
+                    Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BACKUP_OTHER))
             );
         } else {
             final BackupProfile backupProfile = Objects.requireNonNull(this.backupManager.getProfile(plot));
             if (backupProfile instanceof NullBackupProfile) {
                 player.sendMessage(
                         TranslatableCaption.of("backups.backup_impossible"),
-                        Template.of("plot", TranslatableCaption.of("generic.generic_other").getComponent(player))
+                        Template.template("plot", TranslatableCaption.of("generic.generic_other").getComponent(player))
                 );
             } else {
                 backupProfile.createBackup().whenComplete((backup, throwable) -> {
                     if (throwable != null) {
                         player.sendMessage(
                                 TranslatableCaption.of("backups.backup_save_failed"),
-                                Template.of("reason", throwable.getMessage())
+                                Template.template("reason", throwable.getMessage())
                         );
                         throwable.printStackTrace();
                     } else {
@@ -196,12 +196,12 @@ public final class Backup extends Command {
         } else if (!plot.hasOwner()) {
             player.sendMessage(
                     TranslatableCaption.of("backups.backup_impossible"),
-                    Template.of("plot", TranslatableCaption.of("generic.generic_unowned").getComponent(player))
+                    Template.template("plot", TranslatableCaption.of("generic.generic_unowned").getComponent(player))
             );
         } else if (plot.isMerged()) {
             player.sendMessage(
                     TranslatableCaption.of("backups.backup_impossible"),
-                    Template.of("plot", TranslatableCaption.of("generic.generic_merged").getComponent(player))
+                    Template.template("plot", TranslatableCaption.of("generic.generic_merged").getComponent(player))
             );
         } else if (plot.getVolume() > Integer.MAX_VALUE) {
             player.sendMessage(TranslatableCaption.of("schematics.schematic_too_large"));
@@ -209,34 +209,34 @@ public final class Backup extends Command {
                 .hasPermission(player, Permission.PERMISSION_ADMIN_BACKUP_OTHER)) {
             player.sendMessage(
                     TranslatableCaption.of("permission.no_permission"),
-                    Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BACKUP_OTHER))
+                    Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BACKUP_OTHER))
             );
         } else {
             final BackupProfile backupProfile = Objects.requireNonNull(this.backupManager.getProfile(plot));
             if (backupProfile instanceof NullBackupProfile) {
                 player.sendMessage(
                         TranslatableCaption.of("backups.backup_impossible"),
-                        Template.of("plot", TranslatableCaption.of("generic.generic_other").getComponent(player))
+                        Template.template("plot", TranslatableCaption.of("generic.generic_other").getComponent(player))
                 );
             } else {
                 backupProfile.listBackups().whenComplete((backups, throwable) -> {
                     if (throwable != null) {
                         player.sendMessage(
                                 TranslatableCaption.of("backups.backup_list_failed"),
-                                Template.of("reason", throwable.getMessage())
+                                Template.template("reason", throwable.getMessage())
                         );
                         throwable.printStackTrace();
                     } else {
                         player.sendMessage(
                                 TranslatableCaption.of("backups.backup_list_header"),
-                                Template.of("plot", plot.getId().toCommaSeparatedString())
+                                Template.template("plot", plot.getId().toCommaSeparatedString())
                         );
                         try {
                             for (int i = 0; i < backups.size(); i++) {
                                 player.sendMessage(
                                         TranslatableCaption.of("backups.backup_list_entry"),
-                                        Template.of("number", Integer.toString(i + 1)),
-                                        Template.of("value", DateTimeFormatter.RFC_1123_DATE_TIME.format(ZonedDateTime.ofInstant(
+                                        Template.template("number", Integer.toString(i + 1)),
+                                        Template.template("value", DateTimeFormatter.RFC_1123_DATE_TIME.format(ZonedDateTime.ofInstant(
                                                 Instant.ofEpochMilli(backups.get(i).getCreationTime()),
                                                 ZoneId.systemDefault()
                                         )))
@@ -267,12 +267,12 @@ public final class Backup extends Command {
         } else if (!plot.hasOwner()) {
             player.sendMessage(
                     TranslatableCaption.of("backups.backup_impossible"),
-                    Template.of("plot", TranslatableCaption.of("generic.generic_unowned").getComponent(player))
+                    Template.template("plot", TranslatableCaption.of("generic.generic_unowned").getComponent(player))
             );
         } else if (plot.isMerged()) {
             player.sendMessage(
                     TranslatableCaption.of("backups.backup_impossible"),
-                    Template.of("plot", TranslatableCaption.of("generic.generic_merged").getComponent(player))
+                    Template.template("plot", TranslatableCaption.of("generic.generic_merged").getComponent(player))
             );
         } else if (plot.getVolume() > Integer.MAX_VALUE) {
             player.sendMessage(TranslatableCaption.of("schematics.schematic_too_large"));
@@ -280,12 +280,12 @@ public final class Backup extends Command {
                 .hasPermission(player, Permission.PERMISSION_ADMIN_BACKUP_OTHER)) {
             player.sendMessage(
                     TranslatableCaption.of("permission.no_permission"),
-                    Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BACKUP_OTHER))
+                    Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_BACKUP_OTHER))
             );
         } else if (args.length == 0) {
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", "Usage: /plot backup save/list/load")
+                    Template.template("value", "Usage: /plot backup save/list/load")
             );
         } else {
             final int number;
@@ -294,7 +294,7 @@ public final class Backup extends Command {
             } catch (final Exception e) {
                 player.sendMessage(
                         TranslatableCaption.of("invalid.not_a_number"),
-                        Template.of("value", args[0])
+                        Template.template("value", args[0])
                 );
                 return;
             }
@@ -302,21 +302,21 @@ public final class Backup extends Command {
             if (backupProfile instanceof NullBackupProfile) {
                 player.sendMessage(
                         TranslatableCaption.of("backups.backup_impossible"),
-                        Template.of("plot", TranslatableCaption.of("generic.generic_other").getComponent(player))
+                        Template.template("plot", TranslatableCaption.of("generic.generic_other").getComponent(player))
                 );
             } else {
                 backupProfile.listBackups().whenComplete((backups, throwable) -> {
                     if (throwable != null) {
                         player.sendMessage(
                                 TranslatableCaption.of("backups.backup_load_failure"),
-                                Template.of("reason", throwable.getMessage())
+                                Template.template("reason", throwable.getMessage())
                         );
                         throwable.printStackTrace();
                     } else {
                         if (number < 1 || number > backups.size()) {
                             player.sendMessage(
                                     TranslatableCaption.of("backups.backup_impossible"),
-                                    Template.of(
+                                    Template.template(
                                             "plot",
                                             TranslatableCaption.of("generic.generic_invalid_choice").getComponent(player)
                                     )
@@ -328,7 +328,7 @@ public final class Backup extends Command {
                                     .exists(backup.getFile())) {
                                 player.sendMessage(
                                         TranslatableCaption.of("backups.backup_impossible"),
-                                        Template.of(
+                                        Template.template(
                                                 "plot",
                                                 TranslatableCaption.of("generic.generic_invalid_choice").getComponent(player)
                                         )
@@ -340,7 +340,7 @@ public final class Backup extends Command {
                                                     if (error != null) {
                                                         player.sendMessage(
                                                                 TranslatableCaption.of("backups.backup_load_failure"),
-                                                                Template.of("reason", error.getMessage())
+                                                                Template.template("reason", error.getMessage())
                                                         );
                                                     } else {
                                                         player.sendMessage(TranslatableCaption.of("backups.backup_load_success"));

--- a/Core/src/main/java/com/plotsquared/core/command/Biome.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Biome.java
@@ -63,7 +63,7 @@ public class Biome extends SetCommand {
             player.sendMessage(TranslatableCaption.of("biome.need_biome"));
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.subcommand_set_options_header"),
-                    Template.of("values", biomes)
+                    Template.template("values", biomes)
             );
             return false;
         }
@@ -80,7 +80,7 @@ public class Biome extends SetCommand {
             plot.removeRunning();
             player.sendMessage(
                     TranslatableCaption.of("biome.biome_set_to"),
-                    Template.of("value", value.toLowerCase())
+                    Template.template("value", value.toLowerCase())
             );
         });
         return true;

--- a/Core/src/main/java/com/plotsquared/core/command/Buy.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Buy.java
@@ -91,7 +91,7 @@ public class Buy extends Command {
         checkTrue(
                 player.getPlotCount() + plots.size() <= player.getAllowedPlots(),
                 TranslatableCaption.of("permission.cant_claim_more_plots"),
-                Template.of("amount", String.valueOf(player.getAllowedPlots()))
+                Template.template("amount", String.valueOf(player.getAllowedPlots()))
         );
         double price = plot.getFlag(PriceFlag.class);
         if (price <= 0) {
@@ -104,8 +104,8 @@ public class Buy extends Command {
         checkTrue(
                 this.econHandler.getMoney(player) >= price,
                 TranslatableCaption.of("economy.cannot_afford_plot"),
-                Template.of("money", this.econHandler.format(price)),
-                Template.of("balance", this.econHandler.format(this.econHandler.getMoney(player)))
+                Template.template("money", this.econHandler.format(price)),
+                Template.template("balance", this.econHandler.format(this.econHandler.getMoney(player)))
         );
         this.econHandler.withdrawMoney(player, price);
         // Failure
@@ -113,7 +113,7 @@ public class Buy extends Command {
         confirm.run(this, () -> {
             player.sendMessage(
                     TranslatableCaption.of("economy.removed_balance"),
-                    Template.of("money", this.econHandler.format(price))
+                    Template.template("money", this.econHandler.format(price))
             );
 
             this.econHandler.depositMoney(PlotSquared.platform().playerManager().getOfflinePlayer(plot.getOwnerAbs()), price);
@@ -122,9 +122,9 @@ public class Buy extends Command {
             if (owner != null) {
                 owner.sendMessage(
                         TranslatableCaption.of("economy.plot_sold"),
-                        Template.of("plot", plot.getId().toString()),
-                        Template.of("player", player.getName()),
-                        Template.of("price", this.econHandler.format(price))
+                        Template.template("plot", plot.getId().toString()),
+                        Template.template("player", player.getName()),
+                        Template.template("price", this.econHandler.format(price))
                 );
             }
             PlotFlag<?, ?> plotFlag = plot.getFlagContainer().getFlag(PriceFlag.class);
@@ -135,7 +135,7 @@ public class Buy extends Command {
             plot.setOwner(player.getUUID());
             player.sendMessage(
                     TranslatableCaption.of("working.claimed"),
-                    Template.of("plot", plot.getId().toString())
+                    Template.template("plot", plot.getId().toString())
             );
             whenDone.run(Buy.this, CommandResult.SUCCESS);
         }, () -> {

--- a/Core/src/main/java/com/plotsquared/core/command/Caps.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Caps.java
@@ -62,7 +62,7 @@ public class Caps extends SubCommand {
                 .hasPermission(player, Permission.PERMISSION_ADMIN_CAPS_OTHER)) {
             player.sendMessage(
                     TranslatableCaption.of("permission.no_permission"),
-                    Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_CAPS_OTHER))
+                    Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_CAPS_OTHER))
             );
             return false;
         }
@@ -94,10 +94,10 @@ public class Caps extends SubCommand {
                 : String.valueOf(max);
         player.sendMessage(
                 TranslatableCaption.of("info.plot_caps_format"),
-                Template.of("cap", name),
-                Template.of("current", String.valueOf(current)),
-                Template.of("limit", maxBeautified),
-                Template.of("percentage", percentage)
+                Template.template("cap", name),
+                Template.template("current", String.valueOf(current)),
+                Template.template("limit", maxBeautified),
+                Template.template("percentage", percentage)
         );
     }
 

--- a/Core/src/main/java/com/plotsquared/core/command/Chat.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Chat.java
@@ -32,7 +32,7 @@ import net.kyori.adventure.text.minimessage.Template;
 
 /**
  * @deprecated In favor of "/plot toggle chat" and
- *         scheduled for removal within the next major release.
+ * scheduled for removal within the next major release.
  */
 @Deprecated(forRemoval = true)
 @CommandDeclaration(command = "chat",

--- a/Core/src/main/java/com/plotsquared/core/command/Chat.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Chat.java
@@ -48,7 +48,7 @@ public class Chat extends SubCommand {
         check(area, TranslatableCaption.of("errors.not_in_plot_world"));
         player.sendMessage(
                 TranslatableCaption.of("errors.deprecated_commands"),
-                Template.of("replacement", "/plot toggle chat")
+                Template.template("replacement", "/plot toggle chat")
         );
         if (player.getPlotAreaAbs().isForcingPlotChat()) {
             player.sendMessage(TranslatableCaption.of("chat.plot_chat_forced"));

--- a/Core/src/main/java/com/plotsquared/core/command/Claim.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Claim.java
@@ -89,7 +89,7 @@ public class Claim extends SubCommand {
         if (event.getEventResult() == Result.DENY) {
             player.sendMessage(
                     TranslatableCaption.of("events.event_denied"),
-                    Template.of("value", "Claim")
+                    Template.template("value", "Claim")
             );
             return true;
         }
@@ -108,14 +108,14 @@ public class Claim extends SubCommand {
                     if (grants <= 0) {
                         player.sendMessage(
                                 TranslatableCaption.of("permission.cant_claim_more_plots"),
-                                Template.of("amount", String.valueOf(grants))
+                                Template.template("amount", String.valueOf(grants))
                         );
                         metaDataAccess.remove();
                     }
                 } else {
                     player.sendMessage(
                             TranslatableCaption.of("permission.cant_claim_more_plots"),
-                            Template.of("amount", String.valueOf(player.getAllowedPlots()))
+                            Template.template("amount", String.valueOf(player.getAllowedPlots()))
                     );
                     return false;
                 }
@@ -130,8 +130,8 @@ public class Claim extends SubCommand {
                     if (!area.hasSchematic(schematic)) {
                         player.sendMessage(
                                 TranslatableCaption.of("schematics.schematic_invalid_named"),
-                                Template.of("schemname", schematic),
-                                Template.of("reason", "non-existent")
+                                Template.template("schemname", schematic),
+                                Template.template("reason", "non-existent")
                         );
                     }
                     if (!Permissions.hasPermission(player, Permission.PERMISSION_CLAIM_SCHEMATIC
@@ -141,7 +141,7 @@ public class Claim extends SubCommand {
                     ) && !force) {
                         player.sendMessage(
                                 TranslatableCaption.of("permission.no_schematic_permission"),
-                                Template.of("value", schematic)
+                                Template.template("value", schematic)
                         );
                     }
                 }
@@ -157,16 +157,16 @@ public class Claim extends SubCommand {
                     if (this.econHandler.getMoney(player) < cost) {
                         player.sendMessage(
                                 TranslatableCaption.of("economy.cannot_afford_plot"),
-                                Template.of("money", this.econHandler.format(cost)),
-                                Template.of("balance", this.econHandler.format(this.econHandler.getMoney(player)))
+                                Template.template("money", this.econHandler.format(cost)),
+                                Template.template("balance", this.econHandler.format(this.econHandler.getMoney(player)))
                         );
                         return false;
                     }
                     this.econHandler.withdrawMoney(player, cost);
                     player.sendMessage(
                             TranslatableCaption.of("economy.removed_balance"),
-                            Template.of("money", this.econHandler.format(cost)),
-                            Template.of("balance", this.econHandler.format(this.econHandler.getMoney(player)))
+                            Template.template("money", this.econHandler.format(cost)),
+                            Template.template("balance", this.econHandler.format(this.econHandler.getMoney(player)))
                     );
                 }
             }
@@ -178,8 +178,8 @@ public class Claim extends SubCommand {
                 }
                 player.sendMessage(
                         TranslatableCaption.of("economy.removed_granted_plot"),
-                        Template.of("usedGrants", String.valueOf((grants - 1))),
-                        Template.of("remainingGrants", String.valueOf(grants))
+                        Template.template("usedGrants", String.valueOf((grants - 1))),
+                        Template.template("remainingGrants", String.valueOf(grants))
                 );
             }
         }
@@ -205,7 +205,7 @@ public class Claim extends SubCommand {
                         if (mergeEvent.getEventResult() == Result.DENY) {
                             player.sendMessage(
                                     TranslatableCaption.of("events.event_denied"),
-                                    Template.of("value", "Auto merge on claim")
+                                    Template.template("value", "Auto merge on claim")
                             );
                         } else {
                             plot.getPlotModificationManager().autoMerge(

--- a/Core/src/main/java/com/plotsquared/core/command/Clear.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Clear.java
@@ -85,7 +85,7 @@ public class Clear extends Command {
         if (eventResult == Result.DENY) {
             player.sendMessage(
                     TranslatableCaption.of("events.event_denied"),
-                    Template.of("value", "Clear")
+                    Template.template("value", "Clear")
             );
             return CompletableFuture.completedFuture(true);
         }
@@ -136,8 +136,8 @@ public class Clear extends Command {
                         }
                         player.sendMessage(
                                 TranslatableCaption.of("working.clearing_done"),
-                                Template.of("amount", String.valueOf(System.currentTimeMillis() - start)),
-                                Template.of("plot", plot.getId().toString())
+                                Template.template("amount", String.valueOf(System.currentTimeMillis() - start)),
+                                Template.template("plot", plot.getId().toString())
                         );
                     });
                 });

--- a/Core/src/main/java/com/plotsquared/core/command/Cluster.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Cluster.java
@@ -69,7 +69,7 @@ public class Cluster extends SubCommand {
             // return arguments
             player.sendMessage(
                     TranslatableCaption.of("cluster.cluster_available_args"),
-                    Template.of(
+                    Template.template(
                             "list",
                             "<dark_aqua>list</dark_aqua><gray>, </gray><dark_aqua>create</dark_aqua><gray>, </gray><dark_aqua>delete</dark_aqua><gray>, </gray><dark_aqua>resize</dark_aqua><gray>, </gray><dark_aqua>invite</dark_aqua><gray>, </gray><dark_aqua>kick</dark_aqua><gray>, </gray><dark_aqua>leave</dark_aqua><gray>, </gray><dark_aqua>members</dark_aqua><gray>, </gray><dark_aqua>info</dark_aqua><gray>, </gray><dark_aqua>tp</dark_aqua><gray>, </gray><dark_aqua>sethome</dark_aqua>"
                     )
@@ -83,14 +83,14 @@ public class Cluster extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_CLUSTER_LIST)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_CLUSTER_LIST))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_CLUSTER_LIST))
                     );
                     return false;
                 }
                 if (args.length != 1) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "/plot cluster list")
+                            Template.template("value", "/plot cluster list")
                     );
                     return false;
                 }
@@ -102,7 +102,7 @@ public class Cluster extends SubCommand {
                 Set<PlotCluster> clusters = area.getClusters();
                 player.sendMessage(
                         TranslatableCaption.of("cluster.cluster_list_heading"),
-                        Template.of("amount", clusters.size() + "")
+                        Template.template("amount", clusters.size() + "")
                 );
                 for (PlotCluster cluster : clusters) {
                     // Ignore unmanaged clusters
@@ -110,22 +110,22 @@ public class Cluster extends SubCommand {
                     if (player.getUUID().equals(cluster.owner)) {
                         player.sendMessage(
                                 TranslatableCaption.of("cluster.cluster_list_element_owner"),
-                                Template.of("cluster", name)
+                                Template.template("cluster", name)
                         );
                     } else if (cluster.helpers.contains(player.getUUID())) {
                         player.sendMessage(
                                 TranslatableCaption.of("cluster.cluster_list_element_helpers"),
-                                Template.of("cluster", name)
+                                Template.template("cluster", name)
                         );
                     } else if (cluster.invited.contains(player.getUUID())) {
                         player.sendMessage(
                                 TranslatableCaption.of("cluster.cluster_list_element_invited"),
-                                Template.of("cluster", name)
+                                Template.template("cluster", name)
                         );
                     } else {
                         player.sendMessage(
                                 TranslatableCaption.of("cluster.cluster_list_element"),
-                                Template.of("cluster", cluster.toString())
+                                Template.template("cluster", cluster.toString())
                         );
                     }
                 }
@@ -136,7 +136,7 @@ public class Cluster extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_CLUSTER_CREATE)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_CLUSTER_CREATE))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_CLUSTER_CREATE))
                     );
                     return false;
                 }
@@ -148,7 +148,7 @@ public class Cluster extends SubCommand {
                 if (args.length != 4) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "/plot cluster create <name> <id-bot> <id-top>")
+                            Template.template("value", "/plot cluster create <name> <id-bot> <id-top>")
                     );
                     return false;
                 }
@@ -158,7 +158,7 @@ public class Cluster extends SubCommand {
                 if (currentClusters >= player.getAllowedPlots()) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.cant_claim_more_clusters"),
-                            Template.of("amount", String.valueOf(player.getAllowedPlots()))
+                            Template.template("amount", String.valueOf(player.getAllowedPlots()))
                     );
                 }
                 PlotId pos1;
@@ -176,7 +176,7 @@ public class Cluster extends SubCommand {
                 if (area.getCluster(name) != null) {
                     player.sendMessage(
                             TranslatableCaption.of("alias.alias_is_taken"),
-                            Template.of("alias", name)
+                            Template.template("alias", name)
                     );
                     return false;
                 }
@@ -190,7 +190,7 @@ public class Cluster extends SubCommand {
                 if (cluster != null) {
                     player.sendMessage(
                             TranslatableCaption.of("cluster.cluster_intersection"),
-                            Template.of("cluster", cluster.getName())
+                            Template.template("cluster", cluster.getName())
                     );
                     return false;
                 }
@@ -198,7 +198,7 @@ public class Cluster extends SubCommand {
                 if (!area.contains(pos1) || !area.contains(pos2)) {
                     player.sendMessage(
                             TranslatableCaption.of("cluster.cluster_outside"),
-                            Template.of("area", String.valueOf(area))
+                            Template.template("area", String.valueOf(area))
                     );
                     return false;
                 }
@@ -211,7 +211,7 @@ public class Cluster extends SubCommand {
                             if (!plot.isOwner(uuid)) {
                                 player.sendMessage(
                                         TranslatableCaption.of("permission.no_permission"),
-                                        Template.of("node", String.valueOf(Permission.PERMISSION_CLUSTER_CREATE_OTHER))
+                                        Template.template("node", String.valueOf(Permission.PERMISSION_CLUSTER_CREATE_OTHER))
                                 );
                                 return false;
                             }
@@ -233,7 +233,7 @@ public class Cluster extends SubCommand {
                 if (current + cluster.getArea() > allowed) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", Permission.PERMISSION_CLUSTER_SIZE + "." + (current + cluster.getArea()))
+                            Template.template("node", Permission.PERMISSION_CLUSTER_SIZE + "." + (current + cluster.getArea()))
                     );
                     return false;
                 }
@@ -252,7 +252,7 @@ public class Cluster extends SubCommand {
                 }
                 player.sendMessage(
                         TranslatableCaption.of("cluster.cluster_created"),
-                        Template.of("name", name)
+                        Template.template("name", name)
                 );
                 return true;
             }
@@ -262,14 +262,14 @@ public class Cluster extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_CLUSTER_DELETE)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_CLUSTER_DELETE))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_CLUSTER_DELETE))
                     );
                     return false;
                 }
                 if (args.length != 1 && args.length != 2) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "/plot cluster delete [name]")
+                            Template.template("value", "/plot cluster delete [name]")
                     );
                     return false;
                 }
@@ -284,7 +284,7 @@ public class Cluster extends SubCommand {
                     if (cluster == null) {
                         player.sendMessage(
                                 TranslatableCaption.of("cluster.invalid_cluster_name"),
-                                Template.of("cluster", args[1])
+                                Template.template("cluster", args[1])
                         );
                         return false;
                     }
@@ -300,13 +300,13 @@ public class Cluster extends SubCommand {
                             .hasPermission(player, Permission.PERMISSION_CLUSTER_DELETE_OTHER)) {
                         player.sendMessage(
                                 TranslatableCaption.of("permission.no_permission"),
-                                Template.of("node", String.valueOf(Permission.PERMISSION_CLUSTER_DELETE_OTHER))
+                                Template.template("node", String.valueOf(Permission.PERMISSION_CLUSTER_DELETE_OTHER))
                         );
                         return false;
                     }
                 }
                 DBFunc.delete(cluster);
-                player.sendMessage(TranslatableCaption.of("cluster.cluster_deleted"), Template.of(
+                player.sendMessage(TranslatableCaption.of("cluster.cluster_deleted"), Template.template(
                         "cluster",
                         String.valueOf(cluster)
                 ));
@@ -317,14 +317,14 @@ public class Cluster extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_CLUSTER_RESIZE)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_CLUSTER_RESIZE))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_CLUSTER_RESIZE))
                     );
                     return false;
                 }
                 if (args.length != 3) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "/plot cluster resize [name]")
+                            Template.template("value", "/plot cluster resize [name]")
                     );
                     return false;
                 }
@@ -358,7 +358,7 @@ public class Cluster extends SubCommand {
                             .hasPermission(player, Permission.PERMISSION_CLUSTER_RESIZE_OTHER)) {
                         player.sendMessage(
                                 TranslatableCaption.of("permission.no_permission"),
-                                Template.of("node", String.valueOf(Permission.PERMISSION_CLUSTER_RESIZE_OTHER))
+                                Template.template("node", String.valueOf(Permission.PERMISSION_CLUSTER_RESIZE_OTHER))
                         );
                         return false;
                     }
@@ -368,7 +368,7 @@ public class Cluster extends SubCommand {
                 if (intersect != null) {
                     player.sendMessage(
                             TranslatableCaption.of("cluster.cluster_intersection"),
-                            Template.of("cluster", intersect.getName())
+                            Template.template("cluster", intersect.getName())
                     );
                     return false;
                 }
@@ -384,7 +384,7 @@ public class Cluster extends SubCommand {
                             .hasPermission(player, Permission.PERMISSION_CLUSTER_RESIZE_SHRINK)) {
                         player.sendMessage(
                                 TranslatableCaption.of("permission.no_permission"),
-                                Template.of("node", String.valueOf(Permission.PERMISSION_CLUSTER_RESIZE_SHRINK))
+                                Template.template("node", String.valueOf(Permission.PERMISSION_CLUSTER_RESIZE_SHRINK))
                         );
                         return false;
                     }
@@ -395,7 +395,7 @@ public class Cluster extends SubCommand {
                             .hasPermission(player, Permission.PERMISSION_CLUSTER_RESIZE_EXPAND)) {
                         player.sendMessage(
                                 TranslatableCaption.of("permission.no_permission"),
-                                Template.of("node", String.valueOf(Permission.PERMISSION_CLUSTER_RESIZE_EXPAND))
+                                Template.template("node", String.valueOf(Permission.PERMISSION_CLUSTER_RESIZE_EXPAND))
                         );
                         return false;
                     }
@@ -414,7 +414,7 @@ public class Cluster extends SubCommand {
                 if (current + cluster.getArea() > allowed) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", Permission.PERMISSION_CLUSTER + "." + (current + cluster.getArea()))
+                            Template.template("node", Permission.PERMISSION_CLUSTER + "." + (current + cluster.getArea()))
                     );
                     return false;
                 }
@@ -429,14 +429,14 @@ public class Cluster extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_CLUSTER_INVITE)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_CLUSTER_INVITE))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_CLUSTER_INVITE))
                     );
                     return false;
                 }
                 if (args.length != 2) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "/plot cluster invite <player>")
+                            Template.template("value", "/plot cluster invite <player>")
                     );
                     return false;
                 }
@@ -455,7 +455,7 @@ public class Cluster extends SubCommand {
                             .hasPermission(player, Permission.PERMISSION_CLUSTER_INVITE_OTHER)) {
                         player.sendMessage(
                                 TranslatableCaption.of("permission.no_permission"),
-                                Template.of("node", Permission.PERMISSION_CLUSTER_INVITE_OTHER.toString())
+                                Template.template("node", Permission.PERMISSION_CLUSTER_INVITE_OTHER.toString())
                         );
                         return false;
                     }
@@ -468,7 +468,7 @@ public class Cluster extends SubCommand {
                             } else if (throwable != null) {
                                 player.sendMessage(
                                         TranslatableCaption.of("errors.invalid_player"),
-                                        Template.of("value", args[1])
+                                        Template.template("value", args[1])
                                 );
                             } else {
                                 if (!cluster.isAdded(uuid)) {
@@ -480,7 +480,7 @@ public class Cluster extends SubCommand {
                                     if (otherPlayer != null) {
                                         player.sendMessage(
                                                 TranslatableCaption.of("cluster.cluster_invited"),
-                                                Template.of("cluster", cluster.getName())
+                                                Template.template("cluster", cluster.getName())
                                         );
                                     }
                                 }
@@ -495,14 +495,14 @@ public class Cluster extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_CLUSTER_KICK)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", Permission.PERMISSION_CLUSTER_KICK.toString())
+                            Template.template("node", Permission.PERMISSION_CLUSTER_KICK.toString())
                     );
                     return false;
                 }
                 if (args.length != 2) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "/plot cluster kick <player>")
+                            Template.template("value", "/plot cluster kick <player>")
                     );
                     return false;
                 }
@@ -520,7 +520,7 @@ public class Cluster extends SubCommand {
                             .hasPermission(player, Permission.PERMISSION_CLUSTER_KICK_OTHER)) {
                         player.sendMessage(
                                 TranslatableCaption.of("permission.no_permission"),
-                                Template.of("node", Permission.PERMISSION_CLUSTER_KICK_OTHER.toString())
+                                Template.template("node", Permission.PERMISSION_CLUSTER_KICK_OTHER.toString())
                         );
                         return false;
                     }
@@ -533,7 +533,7 @@ public class Cluster extends SubCommand {
                             } else if (throwable != null) {
                                 player.sendMessage(
                                         TranslatableCaption.of("errors.invalid_player"),
-                                        Template.of("value", args[1])
+                                        Template.template("value", args[1])
                                 );
                             } else {
                                 // Can't kick if the player is yourself, the owner, or not added to the cluster
@@ -541,7 +541,7 @@ public class Cluster extends SubCommand {
                                         || !cluster.isAdded(uuid)) {
                                     player.sendMessage(
                                             TranslatableCaption.of("cluster.cannot_kick_player"),
-                                            Template.of("value", cluster.getName())
+                                            Template.template("value", cluster.getName())
                                     );
                                 } else {
                                     if (cluster.helpers.contains(uuid)) {
@@ -556,7 +556,7 @@ public class Cluster extends SubCommand {
                                     if (player2 != null) {
                                         player.sendMessage(
                                                 TranslatableCaption.of("cluster.cluster_removed"),
-                                                Template.of("cluster", cluster.getName())
+                                                Template.template("cluster", cluster.getName())
                                         );
                                     }
                                     for (final Plot plot : PlotQuery.newQuery().inWorld(player2.getLocation()
@@ -577,14 +577,14 @@ public class Cluster extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_CLUSTER_LEAVE)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", Permission.PERMISSION_CLUSTER_LEAVE.toString())
+                            Template.template("node", Permission.PERMISSION_CLUSTER_LEAVE.toString())
                     );
                     return false;
                 }
                 if (args.length != 1 && args.length != 2) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "/plot cluster leave [name]")
+                            Template.template("value", "/plot cluster leave [name]")
                     );
                     return false;
                 }
@@ -598,7 +598,7 @@ public class Cluster extends SubCommand {
                     if (cluster == null) {
                         player.sendMessage(
                                 TranslatableCaption.of("cluster.invalid_cluster_name"),
-                                Template.of("cluster", args[1])
+                                Template.template("cluster", args[1])
                         );
                         return false;
                     }
@@ -626,7 +626,7 @@ public class Cluster extends SubCommand {
                 DBFunc.removeInvited(cluster, uuid);
                 player.sendMessage(
                         TranslatableCaption.of("cluster.cluster_removed"),
-                        Template.of("cluster", cluster.getName())
+                        Template.template("cluster", cluster.getName())
                 );
                 for (final Plot plot : PlotQuery.newQuery().inWorld(player.getLocation().getWorldName())
                         .ownedBy(uuid)) {
@@ -641,14 +641,14 @@ public class Cluster extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_CLUSTER_HELPERS)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", Permission.PERMISSION_CLUSTER_HELPERS.toString())
+                            Template.template("node", Permission.PERMISSION_CLUSTER_HELPERS.toString())
                     );
                     return false;
                 }
                 if (args.length != 3) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "/plot cluster members <add | remove> <player>")
+                            Template.template("value", "/plot cluster members <add | remove> <player>")
                     );
                     return false;
                 }
@@ -669,7 +669,7 @@ public class Cluster extends SubCommand {
                             } else if (throwable != null) {
                                 player.sendMessage(
                                         TranslatableCaption.of("errors.invalid_player"),
-                                        Template.of("value", args[2])
+                                        Template.template("value", args[2])
                                 );
                             } else {
                                 if (args[1].equalsIgnoreCase("add")) {
@@ -683,7 +683,7 @@ public class Cluster extends SubCommand {
                                 } else {
                                     player.sendMessage(
                                             TranslatableCaption.of("commandconfig.command_syntax"),
-                                            Template.of("value", "/plot cluster members <add | remove> <player>")
+                                            Template.template("value", "/plot cluster members <add | remove> <player>")
                                     );
                                 }
                             }
@@ -696,14 +696,14 @@ public class Cluster extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_CLUSTER_TP)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", Permission.PERMISSION_CLUSTER_TP.toString())
+                            Template.template("node", Permission.PERMISSION_CLUSTER_TP.toString())
                     );
                     return false;
                 }
                 if (args.length != 2) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "/plot cluster tp <name>")
+                            Template.template("value", "/plot cluster tp <name>")
                     );
                     return false;
                 }
@@ -716,7 +716,7 @@ public class Cluster extends SubCommand {
                 if (cluster == null) {
                     player.sendMessage(
                             TranslatableCaption.of("cluster.invalid_cluster_name"),
-                            Template.of("cluster", args[1])
+                            Template.template("cluster", args[1])
                     );
                     return false;
                 }
@@ -725,7 +725,7 @@ public class Cluster extends SubCommand {
                     if (!Permissions.hasPermission(player, Permission.PERMISSION_CLUSTER_TP_OTHER)) {
                         player.sendMessage(
                                 TranslatableCaption.of("permission.no_permission"),
-                                Template.of("node", Permission.PERMISSION_CLUSTER_TP_OTHER.toString())
+                                Template.template("node", Permission.PERMISSION_CLUSTER_TP_OTHER.toString())
                         );
                         return false;
                     }
@@ -741,14 +741,14 @@ public class Cluster extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_CLUSTER_INFO)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", Permission.PERMISSION_CLUSTER_TP.toString())
+                            Template.template("node", Permission.PERMISSION_CLUSTER_TP.toString())
                     );
                     return false;
                 }
                 if (args.length != 1 && args.length != 2) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "/plot cluster info [name]")
+                            Template.template("value", "/plot cluster info [name]")
                     );
                 }
                 PlotArea area = player.getApplicablePlotArea();
@@ -762,7 +762,7 @@ public class Cluster extends SubCommand {
                     if (cluster == null) {
                         player.sendMessage(
                                 TranslatableCaption.of("cluster.invalid_cluster_name"),
-                                Template.of("cluster", args[1])
+                                Template.template("cluster", args[1])
                         );
                         return false;
                     }
@@ -791,11 +791,11 @@ public class Cluster extends SubCommand {
                                         cluster.getP2().getY() - cluster.getP1().getY() + 1);
                                 String rights = cluster.isAdded(player.getUUID()) + "";
                                 Caption message = TranslatableCaption.of("cluster.cluster_info");
-                                Template idTemplate = Template.of("id", id);
-                                Template ownerTemplate = Template.of("owner", owner);
-                                Template nameTemplate = Template.of("name", name);
-                                Template sizeTemplate = Template.of("size", size);
-                                Template rightsTemplate = Template.of("rights", rights);
+                                Template idTemplate = Template.template("id", id);
+                                Template ownerTemplate = Template.template("owner", owner);
+                                Template nameTemplate = Template.template("name", name);
+                                Template sizeTemplate = Template.template("size", size);
+                                Template rightsTemplate = Template.template("rights", rights);
                                 player.sendMessage(
                                         message,
                                         idTemplate,
@@ -814,14 +814,14 @@ public class Cluster extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_CLUSTER_SETHOME)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", Permission.PERMISSION_CLUSTER_SETHOME.toString())
+                            Template.template("node", Permission.PERMISSION_CLUSTER_SETHOME.toString())
                     );
                     return false;
                 }
                 if (args.length != 1 && args.length != 2) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "/plot cluster sethome")
+                            Template.template("value", "/plot cluster sethome")
                     );
                     return false;
                 }
@@ -839,7 +839,7 @@ public class Cluster extends SubCommand {
                             .hasPermission(player, Permission.PERMISSION_CLUSTER_SETHOME_OTHER)) {
                         player.sendMessage(
                                 TranslatableCaption.of("permission.no_permission"),
-                                Template.of("node", Permission.PERMISSION_CLUSTER_SETHOME_OTHER.toString())
+                                Template.template("node", Permission.PERMISSION_CLUSTER_SETHOME_OTHER.toString())
                         );
                         return false;
                     }
@@ -858,7 +858,7 @@ public class Cluster extends SubCommand {
         }
         player.sendMessage(
                 TranslatableCaption.of("cluster.cluster_available_args"),
-                Template.of(
+                Template.template(
                         "list",
                         "<dark_aqua>list</dark_aqua><gray>, </gray><dark_aqua>create</dark_aqua><gray>, </gray><dark_aqua>delete</dark_aqua><gray>, </gray><dark_aqua>resize</dark_aqua><gray>, </gray><dark_aqua>invite</dark_aqua><gray>, </gray><dark_aqua>kick</dark_aqua><gray>, </gray><dark_aqua>leave</dark_aqua><gray>, </gray><dark_aqua>members</dark_aqua><gray>, </gray><dark_aqua>info</dark_aqua><gray>, </gray><dark_aqua>tp</dark_aqua><gray>, </gray><dark_aqua>sethome</dark_aqua>"
                 )

--- a/Core/src/main/java/com/plotsquared/core/command/CmdConfirm.java
+++ b/Core/src/main/java/com/plotsquared/core/command/CmdConfirm.java
@@ -59,9 +59,9 @@ public class CmdConfirm {
         if (commandStr != null) {
             player.sendMessage(
                     TranslatableCaption.of("confirm.requires_confirm"),
-                    Template.of("command", commandStr),
-                    Template.of("timeout", String.valueOf(Settings.Confirmation.CONFIRMATION_TIMEOUT_SECONDS)),
-                    Template.of("value", "/plot confirm")
+                    Template.template("command", commandStr),
+                    Template.template("timeout", String.valueOf(Settings.Confirmation.CONFIRMATION_TIMEOUT_SECONDS)),
+                    Template.template("value", "/plot confirm")
             );
         }
         TaskManager.runTaskLater(() -> {

--- a/Core/src/main/java/com/plotsquared/core/command/Command.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Command.java
@@ -263,9 +263,9 @@ public abstract class Command {
             max = c.size();
         }
         // Send the header
-        Template curTemplate = Template.of("cur", String.valueOf(page + 1));
-        Template maxTemplate = Template.of("max", String.valueOf(totalPages + 1));
-        Template amountTemplate = Template.of("amount", String.valueOf(c.size()));
+        Template curTemplate = Template.template("cur", String.valueOf(page + 1));
+        Template maxTemplate = Template.template("max", String.valueOf(totalPages + 1));
+        Template amountTemplate = Template.template("amount", String.valueOf(c.size()));
         player.sendMessage(header, curTemplate, maxTemplate, amountTemplate);
         // Send the page content
         List<T> subList = c.subList(page * size, max);
@@ -277,9 +277,9 @@ public abstract class Command {
             player.sendMessage(msg.get(), msg.getTemplates());
         }
         // Send the footer
-        Template command1 = Template.of("command1", baseCommand + " " + page);
-        Template command2 = Template.of("command2", baseCommand + " " + (page + 2));
-        Template clickable = Template.of("clickable", TranslatableCaption.of("list.clickable").getComponent(player));
+        Template command1 = Template.template("command1", baseCommand + " " + page);
+        Template command2 = Template.template("command2", baseCommand + " " + (page + 2));
+        Template clickable = Template.template("clickable", TranslatableCaption.of("list.clickable").getComponent(player));
         player.sendMessage(TranslatableCaption.of("list.page_turn"), command1, command2, clickable);
     }
 
@@ -332,7 +332,7 @@ public abstract class Command {
             if (commands.isEmpty()) {
                 player.sendMessage(
                         TranslatableCaption.of("commandconfig.did_you_mean"),
-                        Template.of("value", MainCommand.getInstance().help.getUsage())
+                        Template.template("value", MainCommand.getInstance().help.getUsage())
                 );
                 return CompletableFuture.completedFuture(false);
             }
@@ -353,7 +353,7 @@ public abstract class Command {
             }
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.did_you_mean"),
-                    Template.of("value", cmd.getUsage())
+                    Template.template("value", cmd.getUsage())
             );
             return CompletableFuture.completedFuture(false);
         }
@@ -389,7 +389,7 @@ public abstract class Command {
                 // TODO improve or remove the Argument system
                 player.sendMessage(
                         TranslatableCaption.of("commandconfig.command_syntax"),
-                        Template.of("value", StringMan.join(fullSplit, " "))
+                        Template.template("value", StringMan.join(fullSplit, " "))
                 );
                 return false;
             }
@@ -478,7 +478,7 @@ public abstract class Command {
             if (message) {
                 player.sendMessage(
                         TranslatableCaption.of("permission.no_permission"),
-                        Template.of("node", getPermission())
+                        Template.template("node", getPermission())
                 );
             }
         } else {
@@ -503,7 +503,7 @@ public abstract class Command {
     public void sendUsage(PlotPlayer<?> player) {
         player.sendMessage(
                 TranslatableCaption.of("commandconfig.command_syntax"),
-                Template.of("value", getUsage())
+                Template.template("value", getUsage())
         );
     }
 

--- a/Core/src/main/java/com/plotsquared/core/command/Command.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Command.java
@@ -289,7 +289,7 @@ public abstract class Command {
      * @param confirm  Instance, Success, Failure
      * @param whenDone task to run when done
      * @return CompletableFuture true if the command executed fully, false in
-     *         any other case
+     * any other case
      */
     public CompletableFuture<Boolean> execute(
             PlotPlayer<?> player, String[] args,

--- a/Core/src/main/java/com/plotsquared/core/command/Comment.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Comment.java
@@ -51,8 +51,8 @@ public class Comment extends SubCommand {
         if (args.length < 2) {
             player.sendMessage(
                     TranslatableCaption.of("comment.comment_syntax"),
-                    Template.of("command", "/plot comment [X;Z]"),
-                    Template.of("list", StringMan.join(CommentManager.inboxes.keySet(), "|"))
+                    Template.template("command", "/plot comment [X;Z]"),
+                    Template.template("list", StringMan.join(CommentManager.inboxes.keySet(), "|"))
             );
             return false;
         }
@@ -71,8 +71,8 @@ public class Comment extends SubCommand {
             if (args.length < 3) {
                 player.sendMessage(
                         TranslatableCaption.of("comment.comment_syntax"),
-                        Template.of("command", "/plot comment [X;Z]"),
-                        Template.of("list", StringMan.join(CommentManager.inboxes.keySet(), "|"))
+                        Template.template("command", "/plot comment [X;Z]"),
+                        Template.template("list", StringMan.join(CommentManager.inboxes.keySet(), "|"))
                 );
                 return false;
             }
@@ -83,8 +83,8 @@ public class Comment extends SubCommand {
         if (inbox == null) {
             player.sendMessage(
                     TranslatableCaption.of("comment.comment_syntax"),
-                    Template.of("command", "/plot comment [X;Z]"),
-                    Template.of("list", StringMan.join(CommentManager.inboxes.keySet(), "|"))
+                    Template.template("command", "/plot comment [X;Z]"),
+                    Template.template("list", StringMan.join(CommentManager.inboxes.keySet(), "|"))
             );
             return false;
         }
@@ -104,8 +104,8 @@ public class Comment extends SubCommand {
             player.sendMessage(TranslatableCaption.of("comment.no_plot_inbox"));
             player.sendMessage(
                     TranslatableCaption.of("comment.comment_syntax"),
-                    Template.of("command", "/plot comment [X;Z]"),
-                    Template.of("list", StringMan.join(CommentManager.inboxes.keySet(), "|"))
+                    Template.template("command", "/plot comment [X;Z]"),
+                    Template.template("list", StringMan.join(CommentManager.inboxes.keySet(), "|"))
             );
             return false;
         }

--- a/Core/src/main/java/com/plotsquared/core/command/Condense.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Condense.java
@@ -74,7 +74,7 @@ public class Condense extends SubCommand {
         if (args.length != 2 && args.length != 3) {
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", "/plot condense <area> <start | stop | info> [radius]")
+                    Template.template("value", "/plot condense <area> <start | stop | info> [radius]")
             );
             return false;
         }
@@ -88,7 +88,7 @@ public class Condense extends SubCommand {
                 if (args.length == 2) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "/plot condense" + area + " start <radius>")
+                            Template.template("value", "/plot condense" + area + " start <radius>")
                     );
                     return false;
                 }
@@ -187,8 +187,8 @@ public class Condense extends SubCommand {
                                     if (result.get()) {
                                         player.sendMessage(
                                                 TranslatableCaption.of("condense.moving"),
-                                                Template.of("origin", String.valueOf(origin)),
-                                                Template.of("possible", String.valueOf(possible))
+                                                Template.template("origin", String.valueOf(origin)),
+                                                Template.template("possible", String.valueOf(possible))
                                         );
                                         TaskManager.runTaskLater(task, TaskTime.ticks(1L));
                                     }
@@ -208,7 +208,7 @@ public class Condense extends SubCommand {
                         if (i >= free.size()) {
                             player.sendMessage(
                                     TranslatableCaption.of("condense.skipping"),
-                                    Template.of("plot", String.valueOf(origin))
+                                    Template.template("plot", String.valueOf(origin))
                             );
                         }
                     }
@@ -229,7 +229,7 @@ public class Condense extends SubCommand {
                 if (args.length == 2) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "/plot condense " + area + " info <radius>")
+                            Template.template("value", "/plot condense " + area + " info <radius>")
                     );
                     return false;
                 }
@@ -250,20 +250,20 @@ public class Condense extends SubCommand {
                 player.sendMessage(TranslatableCaption.of("condense.default_eval"));
                 player.sendMessage(
                         TranslatableCaption.of("condense.minimum_radius"),
-                        Template.of("minimumRadius", String.valueOf(minimumRadius))
+                        Template.template("minimumRadius", String.valueOf(minimumRadius))
                 );
                 player.sendMessage(
                         TranslatableCaption.of("condense.minimum_radius"),
-                        Template.of("maxMove", String.valueOf(maxMove))
+                        Template.template("maxMove", String.valueOf(maxMove))
                 );
                 player.sendMessage(TranslatableCaption.of("condense.input_eval"));
                 player.sendMessage(
                         TranslatableCaption.of("condense.input_radius"),
-                        Template.of("radius", String.valueOf(radius))
+                        Template.template("radius", String.valueOf(radius))
                 );
                 player.sendMessage(
                         TranslatableCaption.of("condense.estimated_moves"),
-                        Template.of("userMove", String.valueOf(userMove))
+                        Template.template("userMove", String.valueOf(userMove))
                 );
                 player.sendMessage(TranslatableCaption.of("condense.eta"));
                 player.sendMessage(TranslatableCaption.of("condense.radius_measured"));
@@ -272,7 +272,7 @@ public class Condense extends SubCommand {
         }
         player.sendMessage(
                 TranslatableCaption.of("commandconfig.command_syntax"),
-                Template.of("value", "/plot condense " + area.getWorldName() + " <start | stop | info> [radius]")
+                Template.template("value", "/plot condense " + area.getWorldName() + " <start | stop | info> [radius]")
         );
         return false;
     }

--- a/Core/src/main/java/com/plotsquared/core/command/Continue.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Continue.java
@@ -64,7 +64,7 @@ public class Continue extends SubCommand {
                 .hasPermission(player, Permission.PERMISSION_ADMIN_COMMAND_CONTINUE)) {
             player.sendMessage(
                     TranslatableCaption.of("permission.no_permission"),
-                    Template.of("node", TranslatableCaption.of("permission.no_plot_perms").getComponent(player))
+                    Template.template("node", TranslatableCaption.of("permission.no_plot_perms").getComponent(player))
             );
             return false;
         }
@@ -77,7 +77,7 @@ public class Continue extends SubCommand {
                 < player.getPlotCount() + size)) {
             player.sendMessage(
                     TranslatableCaption.of("permission.cant_claim_more_plots"),
-                    Template.of("amount", String.valueOf(player.getAllowedPlots()))
+                    Template.template("amount", String.valueOf(player.getAllowedPlots()))
             );
             return false;
         }
@@ -91,7 +91,7 @@ public class Continue extends SubCommand {
         if (event.getEventResult() == Result.DENY) {
             player.sendMessage(
                     TranslatableCaption.of("events.event_denied"),
-                    Template.of("value", "Done flag removal")
+                    Template.template("value", "Done flag removal")
             );
             return true;
         }

--- a/Core/src/main/java/com/plotsquared/core/command/Copy.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Copy.java
@@ -57,7 +57,7 @@ public class Copy extends SubCommand {
         if (args.length != 1) {
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", "/plot copy <X;Z>")
+                    Template.template("value", "/plot copy <X;Z>")
             );
             return false;
         }
@@ -76,8 +76,8 @@ public class Copy extends SubCommand {
 
         plot1.getPlotModificationManager().copy(plot2, player).thenAccept(result -> {
             if (result) {
-                player.sendMessage(TranslatableCaption.of("move.copy_success"), Template.of("origin", String.valueOf(plot1)),
-                        Template.of("target", String.valueOf(plot2))
+                player.sendMessage(TranslatableCaption.of("move.copy_success"), Template.template("origin", String.valueOf(plot1)),
+                        Template.template("target", String.valueOf(plot2))
                 );
             } else {
                 player.sendMessage(TranslatableCaption.of("move.requires_unowned"));

--- a/Core/src/main/java/com/plotsquared/core/command/CreateRoadSchematic.java
+++ b/Core/src/main/java/com/plotsquared/core/command/CreateRoadSchematic.java
@@ -68,7 +68,7 @@ public class CreateRoadSchematic extends SubCommand {
         this.hybridUtils.setupRoadSchematic(plot);
         player.sendMessage(
                 TranslatableCaption.of("schematics.schematic_road_created"),
-                Template.of("command", "/plot debugroadregen")
+                Template.template("command", "/plot debugroadregen")
         );
         return true;
     }

--- a/Core/src/main/java/com/plotsquared/core/command/DatabaseCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DatabaseCommand.java
@@ -108,7 +108,7 @@ public class DatabaseCommand extends SubCommand {
         if (args.length < 1) {
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", "/plot database [area] <sqlite | mysql | import>")
+                    Template.template("value", "/plot database [area] <sqlite | mysql | import>")
             );
             return false;
         }
@@ -123,7 +123,7 @@ public class DatabaseCommand extends SubCommand {
         if (args.length < 1) {
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", "/plot database [area] <sqlite|mysql|import>")
+                    Template.template("value", "/plot database [area] <sqlite|mysql|import>")
             );
             player.sendMessage(TranslatableCaption.of("database.arg"));
             return false;
@@ -136,7 +136,7 @@ public class DatabaseCommand extends SubCommand {
                     if (args.length < 2) {
                         player.sendMessage(
                                 TranslatableCaption.of("commandconfig.command_syntax"),
-                                Template.of("value", "/plot database import <sqlite file> [prefix]")
+                                Template.template("value", "/plot database import <sqlite file> [prefix]")
                         );
                         return false;
                     }
@@ -147,7 +147,7 @@ public class DatabaseCommand extends SubCommand {
                     if (!file.exists()) {
                         player.sendMessage(
                                 TranslatableCaption.of("database.does_not_exist"),
-                                Template.of("value", String.valueOf(file))
+                                Template.template("value", String.valueOf(file))
                         );
                         return false;
                     }
@@ -191,8 +191,8 @@ public class DatabaseCommand extends SubCommand {
                                     }
                                     player.sendMessage(
                                             TranslatableCaption.of("database.skipping_duplicated_plot"),
-                                            Template.of("plot", String.valueOf(plot)),
-                                            Template.of("id", String.valueOf(plot.temp))
+                                            Template.template("plot", String.valueOf(plot)),
+                                            Template.template("id", String.valueOf(plot.temp))
                                     );
                                     continue;
                                 }

--- a/Core/src/main/java/com/plotsquared/core/command/Debug.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Debug.java
@@ -42,6 +42,7 @@ import com.sk89q.worldedit.world.entity.EntityType;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Collection;
@@ -148,25 +149,29 @@ public class Debug extends SubCommand {
         String line = TranslatableCaption.of("debug.debug_line").getComponent(player) + "\n";
         String section = TranslatableCaption.of("debug.debug_section").getComponent(player) + "\n";
         information.append(header);
-        information.append(MINI_MESSAGE.parse(section, Template.template("val", "PlotArea")));
+        information.append(MINI_MESSAGE.deserialize(section, TemplateResolver.templates(Template.template("val", "PlotArea"))));
         information.append(MINI_MESSAGE
-                .parse(
+                .deserialize(
                         line,
-                        Template.template("var", "Plot Worlds"),
-                        Template.template("val", StringMan.join(this.plotAreaManager.getAllPlotAreas(), ", "))
-                ));
+                        TemplateResolver.templates(
+                                Template.template("var", "Plot Worlds"),
+                                Template.template("val", StringMan.join(this.plotAreaManager.getAllPlotAreas(), ", "))
+                )));
         information.append(
-                MINI_MESSAGE.parse(
+                MINI_MESSAGE.deserialize(
                         line,
-                        Template.template("var", "Owned Plots"),
-                        Template.template("val", String.valueOf(PlotQuery.newQuery().allPlots().count()))
-                ));
-        information.append(MINI_MESSAGE.parse(section, Template.template("val", "Messages")));
-        information.append(MINI_MESSAGE.parse(
+                        TemplateResolver.templates(
+                                Template.template("var", "Owned Plots"),
+                                Template.template("val", String.valueOf(PlotQuery.newQuery().allPlots().count()))
+                )));
+        information.append(MINI_MESSAGE.deserialize(section,
+                TemplateResolver.templates(Template.template("val", "Messages"))));
+        information.append(MINI_MESSAGE.deserialize(
                 line,
-                Template.template("var", "Total Messages"),
-                Template.template("val", String.valueOf(captions.size()))
-        ));
+                TemplateResolver.templates(
+                        Template.template("var", "Total Messages"),
+                        Template.template("val", String.valueOf(captions.size()))
+        )));
         player.sendMessage(StaticCaption.of(MINI_MESSAGE.serialize(information.build())));
         return true;
     }

--- a/Core/src/main/java/com/plotsquared/core/command/Debug.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Debug.java
@@ -156,14 +156,14 @@ public class Debug extends SubCommand {
                         TemplateResolver.templates(
                                 Template.template("var", "Plot Worlds"),
                                 Template.template("val", StringMan.join(this.plotAreaManager.getAllPlotAreas(), ", "))
-                )));
+                        )));
         information.append(
                 MINI_MESSAGE.deserialize(
                         line,
                         TemplateResolver.templates(
                                 Template.template("var", "Owned Plots"),
                                 Template.template("val", String.valueOf(PlotQuery.newQuery().allPlots().count()))
-                )));
+                        )));
         information.append(MINI_MESSAGE.deserialize(section,
                 TemplateResolver.templates(Template.template("val", "Messages"))));
         information.append(MINI_MESSAGE.deserialize(
@@ -171,7 +171,7 @@ public class Debug extends SubCommand {
                 TemplateResolver.templates(
                         Template.template("var", "Total Messages"),
                         Template.template("val", String.valueOf(captions.size()))
-        )));
+                )));
         player.sendMessage(StaticCaption.of(MINI_MESSAGE.serialize(information.build())));
         return true;
     }

--- a/Core/src/main/java/com/plotsquared/core/command/Debug.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Debug.java
@@ -75,7 +75,7 @@ public class Debug extends SubCommand {
         if (args.length == 0) {
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", "/plot debug <loadedchunks | player | debug-players | entitytypes | msg>")
+                    Template.template("value", "/plot debug <loadedchunks | player | debug-players | entitytypes | msg>")
             );
         }
         if (args.length > 0) {
@@ -102,7 +102,7 @@ public class Debug extends SubCommand {
             final Collection<UUIDMapping> mappings = PlotSquared.get().getImpromptuUUIDPipeline().getAllImmediately();
             player.sendMessage(
                     TranslatableCaption.of("debug.cached_uuids"),
-                    Template.of("value", String.valueOf(mappings.size()))
+                    Template.template("value", String.valueOf(mappings.size()))
             );
             return true;
         }
@@ -111,7 +111,7 @@ public class Debug extends SubCommand {
             for (final PlotPlayer<?> pp : PlotPlayer.getDebugModePlayers()) {
                 player.sendMessage(
                         TranslatableCaption.of("debug.player_in_debugmode_list"),
-                        Template.of("value", pp.getName())
+                        Template.template("value", pp.getName())
                 );
             }
             return true;
@@ -148,24 +148,24 @@ public class Debug extends SubCommand {
         String line = TranslatableCaption.of("debug.debug_line").getComponent(player) + "\n";
         String section = TranslatableCaption.of("debug.debug_section").getComponent(player) + "\n";
         information.append(header);
-        information.append(MINI_MESSAGE.parse(section, Template.of("val", "PlotArea")));
+        information.append(MINI_MESSAGE.parse(section, Template.template("val", "PlotArea")));
         information.append(MINI_MESSAGE
                 .parse(
                         line,
-                        Template.of("var", "Plot Worlds"),
-                        Template.of("val", StringMan.join(this.plotAreaManager.getAllPlotAreas(), ", "))
+                        Template.template("var", "Plot Worlds"),
+                        Template.template("val", StringMan.join(this.plotAreaManager.getAllPlotAreas(), ", "))
                 ));
         information.append(
                 MINI_MESSAGE.parse(
                         line,
-                        Template.of("var", "Owned Plots"),
-                        Template.of("val", String.valueOf(PlotQuery.newQuery().allPlots().count()))
+                        Template.template("var", "Owned Plots"),
+                        Template.template("val", String.valueOf(PlotQuery.newQuery().allPlots().count()))
                 ));
-        information.append(MINI_MESSAGE.parse(section, Template.of("val", "Messages")));
+        information.append(MINI_MESSAGE.parse(section, Template.template("val", "Messages")));
         information.append(MINI_MESSAGE.parse(
                 line,
-                Template.of("var", "Total Messages"),
-                Template.of("val", String.valueOf(captions.size()))
+                Template.template("var", "Total Messages"),
+                Template.template("val", String.valueOf(captions.size()))
         ));
         player.sendMessage(StaticCaption.of(MINI_MESSAGE.serialize(information.build())));
         return true;

--- a/Core/src/main/java/com/plotsquared/core/command/DebugExec.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DebugExec.java
@@ -102,7 +102,7 @@ public class DebugExec extends SubCommand {
                     if (analysis != null) {
                         player.sendMessage(
                                 TranslatableCaption.of("debugexec.changes_column"),
-                                Template.of("value", String.valueOf(analysis.changes))
+                                Template.template("value", String.valueOf(analysis.changes))
                         );
                         return true;
                     }
@@ -112,7 +112,7 @@ public class DebugExec extends SubCommand {
                         public void run(PlotAnalysis value) {
                             player.sendMessage(
                                     TranslatableCaption.of("debugexec.analyze_done"),
-                                    Template.of("command", "/plot debugexec analyze")
+                                    Template.template("command", "/plot debugexec analyze")
                             );
                         }
                     });
@@ -122,7 +122,7 @@ public class DebugExec extends SubCommand {
                     if (args.length != 2) {
                         player.sendMessage(
                                 TranslatableCaption.of("commandconfig.command_syntax"),
-                                Template.of("value", "/plot debugexec analyze <threshold>")
+                                Template.template("value", "/plot debugexec analyze <threshold>")
                         );
                         player.sendMessage(TranslatableCaption.of("debugexec.threshold_default"));
                         return false;
@@ -133,7 +133,7 @@ public class DebugExec extends SubCommand {
                     } catch (NumberFormatException ignored) {
                         player.sendMessage(
                                 TranslatableCaption.of("debugexec.invalid_threshold"),
-                                Template.of("value", args[1])
+                                Template.template("value", args[1])
                         );
                         player.sendMessage(TranslatableCaption.of("debugexec.threshold_default_double"));
                         return false;
@@ -167,7 +167,7 @@ public class DebugExec extends SubCommand {
                     if (args.length != 2) {
                         player.sendMessage(
                                 TranslatableCaption.of("commandconfig.command_syntax"),
-                                Template.of("value", "/plot debugexec remove-flag <flag>")
+                                Template.template("value", "/plot debugexec remove-flag <flag>")
                         );
                         return false;
                     }
@@ -185,7 +185,7 @@ public class DebugExec extends SubCommand {
                     }
                     player.sendMessage(
                             TranslatableCaption.of("debugexec.cleared_flag"),
-                            Template.of("value", flag)
+                            Template.template("value", flag)
                     );
                     return true;
                 }
@@ -193,7 +193,7 @@ public class DebugExec extends SubCommand {
                     if (args.length != 2) {
                         player.sendMessage(
                                 TranslatableCaption.of("commandconfig.command_syntax"),
-                                Template.of("value", "Invalid syntax: /plot debugexec start-rgar <world>")
+                                Template.template("value", "Invalid syntax: /plot debugexec start-rgar <world>")
                         );
                         return false;
                     }
@@ -201,7 +201,7 @@ public class DebugExec extends SubCommand {
                     if (area == null) {
                         player.sendMessage(
                                 TranslatableCaption.of("errors.not_valid_plot_world"),
-                                Template.of("value", args[1])
+                                Template.template("value", args[1])
                         );
                         return false;
                     }

--- a/Core/src/main/java/com/plotsquared/core/command/DebugPaste.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DebugPaste.java
@@ -133,8 +133,8 @@ public class DebugPaste extends SubCommand {
                 } catch (IOException ignored) {
                     player.sendMessage(
                             TranslatableCaption.of("debugpaste.latest_log"),
-                            Template.of("file", "latest.log"),
-                            Template.of("size", "14MB")
+                            Template.template("file", "latest.log"),
+                            Template.template("size", "14MB")
                     );
                 }
 
@@ -143,7 +143,7 @@ public class DebugPaste extends SubCommand {
                 } catch (final IllegalArgumentException ignored) {
                     player.sendMessage(
                             TranslatableCaption.of("debugpaste.empty_file"),
-                            Template.of("file", "settings.yml")
+                            Template.template("file", "settings.yml")
                     );
                 }
                 try {
@@ -151,7 +151,7 @@ public class DebugPaste extends SubCommand {
                 } catch (final IllegalArgumentException ignored) {
                     player.sendMessage(
                             TranslatableCaption.of("debugpaste.empty_file"),
-                            Template.of("file", "worlds.yml")
+                            Template.template("file", "worlds.yml")
                     );
                 }
 
@@ -164,7 +164,7 @@ public class DebugPaste extends SubCommand {
                 } catch (final IOException ignored) {
                     player.sendMessage(
                             TranslatableCaption.of("debugpaste.skip_multiverse"),
-                            Template.of("file", "worlds.yml")
+                            Template.template("file", "worlds.yml")
                     );
                 }
 
@@ -179,20 +179,20 @@ public class DebugPaste extends SubCommand {
                                 String.format("https://athion.net/ISPaster/paste/view/%s", pasteId);
                         player.sendMessage(
                                 TranslatableCaption.of("debugpaste.debug_report_created"),
-                                Template.of("url", link)
+                                Template.template("url", link)
                         );
                     } else {
                         final String responseMessage = jsonObject.get("response").getAsString();
                         player.sendMessage(
                                 TranslatableCaption.of("debugpaste.creation_failed"),
-                                Template.of("value", responseMessage)
+                                Template.template("value", responseMessage)
                         );
                     }
                 } catch (final Throwable throwable) {
                     throwable.printStackTrace();
                     player.sendMessage(
                             TranslatableCaption.of("debugpaste.creation_failed"),
-                            Template.of("value", throwable.getMessage())
+                            Template.template("value", throwable.getMessage())
                     );
                 }
             } catch (IOException e) {

--- a/Core/src/main/java/com/plotsquared/core/command/DebugRoadRegen.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DebugRoadRegen.java
@@ -67,7 +67,7 @@ public class DebugRoadRegen extends SubCommand {
         if (args.length < 1) {
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", DebugRoadRegen.USAGE)
+                    Template.template("value", DebugRoadRegen.USAGE)
             );
             return false;
         }
@@ -87,7 +87,7 @@ public class DebugRoadRegen extends SubCommand {
             default:
                 player.sendMessage(
                         TranslatableCaption.of("commandconfig.command_syntax"),
-                        Template.of("value", DebugRoadRegen.USAGE)
+                        Template.template("value", DebugRoadRegen.USAGE)
                 );
                 return false;
         }
@@ -110,11 +110,11 @@ public class DebugRoadRegen extends SubCommand {
             queue.setCompleteTask(() -> {
                 player.sendMessage(
                         TranslatableCaption.of("debugroadregen.regen_done"),
-                        Template.of("value", plot.getId().toString())
+                        Template.template("value", plot.getId().toString())
                 );
                 player.sendMessage(
                         TranslatableCaption.of("debugroadregen.regen_all"),
-                        Template.of("value", "/plot regenallroads")
+                        Template.template("value", "/plot regenallroads")
                 );
             });
             manager.createRoadEast(plot, queue);
@@ -133,18 +133,18 @@ public class DebugRoadRegen extends SubCommand {
             } catch (NumberFormatException ignored) {
                 player.sendMessage(
                         TranslatableCaption.of("invalid.not_valid_number"),
-                        Template.of("value", "0, 256")
+                        Template.template("value", "0, 256")
                 );
                 player.sendMessage(
                         TranslatableCaption.of("commandconfig.command_syntax"),
-                        Template.of("value", DebugRoadRegen.USAGE)
+                        Template.template("value", DebugRoadRegen.USAGE)
                 );
                 return false;
             }
         } else if (args.length != 0) {
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", DebugRoadRegen.USAGE)
+                    Template.template("value", DebugRoadRegen.USAGE)
             );
             return false;
         }
@@ -162,11 +162,11 @@ public class DebugRoadRegen extends SubCommand {
         }
         player.sendMessage(
                 TranslatableCaption.of("debugroadregen.schematic"),
-                Template.of("command", "/plot createroadschematic")
+                Template.template("command", "/plot createroadschematic")
         );
         player.sendMessage(
                 TranslatableCaption.of("debugroadregen.regenallroads"),
-                Template.of("command", "/plot regenallroads")
+                Template.template("command", "/plot regenallroads")
         );
         boolean result = this.hybridUtils.scheduleSingleRegionRoadUpdate(plot, height);
         if (!result) {

--- a/Core/src/main/java/com/plotsquared/core/command/Delete.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Delete.java
@@ -85,7 +85,7 @@ public class Delete extends SubCommand {
         if (eventResult == Result.DENY) {
             player.sendMessage(
                     TranslatableCaption.of("events.event_denied"),
-                    Template.of("value", "Delete")
+                    Template.template("value", "Delete")
             );
             return true;
         }
@@ -121,14 +121,14 @@ public class Delete extends SubCommand {
                         this.econHandler.depositMoney(player, value);
                         player.sendMessage(
                                 TranslatableCaption.of("economy.added_balance"),
-                                Template.of("money", this.econHandler.format(value))
+                                Template.template("money", this.econHandler.format(value))
                         );
                     }
                 }
                 player.sendMessage(
                         TranslatableCaption.of("working.deleting_done"),
-                        Template.of("amount", String.valueOf(System.currentTimeMillis() - start)),
-                        Template.of("plot", plot.getId().toString())
+                        Template.template("amount", String.valueOf(System.currentTimeMillis() - start)),
+                        Template.template("plot", plot.getId().toString())
                 );
             });
             if (result) {

--- a/Core/src/main/java/com/plotsquared/core/command/Deny.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Deny.java
@@ -97,7 +97,7 @@ public class Deny extends SubCommand {
         if (size >= maxDenySize) {
             player.sendMessage(
                     TranslatableCaption.of("members.plot_max_members_denied"),
-                    Template.of("amount", String.valueOf(size))
+                    Template.template("amount", String.valueOf(size))
             );
             return false;
         }
@@ -108,7 +108,7 @@ public class Deny extends SubCommand {
             } else if (throwable != null || uuids.isEmpty()) {
                 player.sendMessage(
                         TranslatableCaption.of("errors.invalid_player"),
-                        Template.of("value", args[0])
+                        Template.template("value", args[0])
                 );
             } else {
                 for (UUID uuid : uuids) {
@@ -117,7 +117,7 @@ public class Deny extends SubCommand {
                                     .hasPermission(player, Permission.PERMISSION_ADMIN_COMMAND_DENY))) {
                         player.sendMessage(
                                 TranslatableCaption.of("errors.invalid_player"),
-                                Template.of("value", args[0])
+                                Template.template("value", args[0])
                         );
                     } else if (plot.isOwner(uuid)) {
                         player.sendMessage(TranslatableCaption.of("deny.cant_remove_owner"));
@@ -125,7 +125,7 @@ public class Deny extends SubCommand {
                     } else if (plot.getDenied().contains(uuid)) {
                         player.sendMessage(
                                 TranslatableCaption.of("member.already_added"),
-                                Template.of("player", PlayerManager.getName(uuid))
+                                Template.template("player", PlayerManager.getName(uuid))
                         );
                         return;
                     } else {

--- a/Core/src/main/java/com/plotsquared/core/command/Desc.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Desc.java
@@ -61,7 +61,7 @@ public class Desc extends SetCommand {
             if (event.getEventResult() == Result.DENY) {
                 player.sendMessage(
                         TranslatableCaption.of("events.event_denied"),
-                        Template.of("value", "Description removal")
+                        Template.template("value", "Description removal")
                 );
                 return false;
             }
@@ -76,7 +76,7 @@ public class Desc extends SetCommand {
         if (event.getEventResult() == Result.DENY) {
             player.sendMessage(
                     TranslatableCaption.of("events.event_denied"),
-                    Template.of("value", "Description set")
+                    Template.template("value", "Description set")
             );
             return false;
         }

--- a/Core/src/main/java/com/plotsquared/core/command/Done.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Done.java
@@ -77,7 +77,7 @@ public class Done extends SubCommand {
         if (event.getEventResult() == Result.DENY) {
             player.sendMessage(
                     TranslatableCaption.of("events.event_denied"),
-                    Template.of("value", "Done")
+                    Template.template("value", "Done")
             );
             return true;
         }
@@ -98,7 +98,7 @@ public class Done extends SubCommand {
         plot.addRunning();
         player.sendMessage(
                 TranslatableCaption.of("web.generating_link"),
-                Template.of("plot", plot.getId().toString())
+                Template.template("plot", plot.getId().toString())
         );
         final Settings.Auto_Clear doneRequirements = Settings.AUTO_CLEAR.get("done");
         if (ExpireManager.IMP == null || doneRequirements == null) {

--- a/Core/src/main/java/com/plotsquared/core/command/Download.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Download.java
@@ -121,7 +121,7 @@ public class Download extends SubCommand {
             if (!Permissions.hasPermission(player, Permission.PERMISSION_DOWNLOAD_WORLD)) {
                 player.sendMessage(
                         TranslatableCaption.of("permission.no_permission"),
-                        Template.of("node", Permission.PERMISSION_DOWNLOAD_WORLD.toString())
+                        Template.template("node", Permission.PERMISSION_DOWNLOAD_WORLD.toString())
                 );
                 return false;
             }
@@ -135,18 +135,18 @@ public class Download extends SubCommand {
                     if (url == null) {
                         player.sendMessage(
                                 TranslatableCaption.of("web.generating_link_failed"),
-                                Template.of("plot", plot.getId().toString())
+                                Template.template("plot", plot.getId().toString())
                         );
                         return;
                     }
-                    player.sendMessage(TranslatableCaption.of("web.generation_link_success_legacy_world"), Template.of("url", url.toString()));
+                    player.sendMessage(TranslatableCaption.of("web.generation_link_success_legacy_world"), Template.template("url", url.toString()));
                 }
             });
         } else {
             sendUsage(player);
             return false;
         }
-        player.sendMessage(TranslatableCaption.of("web.generating_link"), Template.of("plot", plot.getId().toString()));
+        player.sendMessage(TranslatableCaption.of("web.generating_link"), Template.template("plot", plot.getId().toString()));
         return true;
     }
 
@@ -190,8 +190,8 @@ public class Download extends SubCommand {
                             public void run(URL value) {
                                 player.sendMessage(
                                         TranslatableCaption.of("web.generation_link_success"),
-                                        Template.of("download", value.toString()),
-                                        Template.of("delete", "Not available")
+                                        Template.template("download", value.toString()),
+                                        Template.template("delete", "Not available")
                                 );
                                 player.sendMessage(StaticCaption.of(value.toString()));
                             }
@@ -205,13 +205,13 @@ public class Download extends SubCommand {
                     if (throwable != null || !result.isSuccess()) {
                         player.sendMessage(
                                 TranslatableCaption.of("web.generating_link_failed"),
-                                Template.of("plot", plot.getId().toString())
+                                Template.template("plot", plot.getId().toString())
                         );
                     } else {
                         player.sendMessage(
                                 TranslatableCaption.of("web.generation_link_success"),
-                                Template.of("download", result.getDownloadUrl()),
-                                Template.of("delete", result.getDeletionUrl())
+                                Template.template("download", result.getDownloadUrl()),
+                                Template.template("delete", result.getDeletionUrl())
                         );
                     }
                 });

--- a/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
@@ -86,7 +86,7 @@ public final class FlagCommand extends Command {
     private static boolean sendMessage(PlotPlayer<?> player) {
         player.sendMessage(
                 TranslatableCaption.of("commandconfig.command_syntax"),
-                Template.of("value", "/plot flag <set | remove | add | list | info> <flag> <value>")
+                Template.template("value", "/plot flag <set | remove | add | list | info> <flag> <value>")
         );
         return true;
     }
@@ -112,7 +112,7 @@ public final class FlagCommand extends Command {
                 if (!result) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of(
+                            Template.template(
                                     "node",
                                     perm
                             )
@@ -131,16 +131,16 @@ public final class FlagCommand extends Command {
                     );
                     final boolean result = Permissions.hasPermission(player, permission);
                     if (!result) {
-                        player.sendMessage(TranslatableCaption.of("permission.no_permission"), Template.of("node", permission));
+                        player.sendMessage(TranslatableCaption.of("permission.no_permission"), Template.template("node", permission));
                         return false;
                     }
                 }
             } catch (final FlagParseException e) {
                 player.sendMessage(
                         TranslatableCaption.of("flag.flag_parse_error"),
-                        Template.of("flag_name", flag.getName()),
-                        Template.of("flag_value", e.getValue()),
-                        Template.of("error", e.getErrorMessage().getComponent(player))
+                        Template.template("flag_name", flag.getName()),
+                        Template.template("flag_value", e.getValue()),
+                        Template.template("error", e.getErrorMessage().getComponent(player))
                 );
                 return false;
             } catch (final Exception e) {
@@ -157,7 +157,7 @@ public final class FlagCommand extends Command {
             perm = basePerm;
         }
         if (!result) {
-            player.sendMessage(TranslatableCaption.of("permission.no_permission"), Template.of("node", perm));
+            player.sendMessage(TranslatableCaption.of("permission.no_permission"), Template.template("node", perm));
         }
         return result;
     }
@@ -182,7 +182,7 @@ public final class FlagCommand extends Command {
                 .hasPermission(player, Permission.PERMISSION_SET_FLAG_OTHER)) {
             player.sendMessage(
                     TranslatableCaption.of("permission.no_permission"),
-                    Template.of("node", String.valueOf(Permission.PERMISSION_SET_FLAG_OTHER))
+                    Template.template("node", String.valueOf(Permission.PERMISSION_SET_FLAG_OTHER))
             );
             return false;
         }
@@ -217,7 +217,7 @@ public final class FlagCommand extends Command {
                     if (best != null) {
                         player.sendMessage(
                                 TranslatableCaption.of("flag.not_valid_flag_suggested"),
-                                Template.of("value", best)
+                                Template.template("value", best)
                         );
                         suggested = true;
                     }
@@ -326,7 +326,7 @@ public final class FlagCommand extends Command {
         if (args.length < 2) {
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", "/plot flag set <flag> <value>")
+                    Template.template("value", "/plot flag set <flag> <value>")
             );
             return;
         }
@@ -339,7 +339,7 @@ public final class FlagCommand extends Command {
         if (event.getEventResult() == Result.DENY) {
             player.sendMessage(
                     TranslatableCaption.of("events.event_denied"),
-                    Template.of("value", "Flag set")
+                    Template.template("value", "Flag set")
             );
             return;
         }
@@ -355,15 +355,15 @@ public final class FlagCommand extends Command {
         } catch (final FlagParseException e) {
             player.sendMessage(
                     TranslatableCaption.of("flag.flag_parse_error"),
-                    Template.of("flag_name", plotFlag.getName()),
-                    Template.of("flag_value", e.getValue()),
-                    Template.of("error", e.getErrorMessage().getComponent(player))
+                    Template.template("flag_name", plotFlag.getName()),
+                    Template.template("flag_value", e.getValue()),
+                    Template.template("error", e.getErrorMessage().getComponent(player))
             );
             return;
         }
         plot.setFlag(parsed);
-        player.sendMessage(TranslatableCaption.of("flag.flag_added"), Template.of("flag", String.valueOf(args[0])),
-                Template.of("value", String.valueOf(parsed))
+        player.sendMessage(TranslatableCaption.of("flag.flag_added"), Template.template("flag", String.valueOf(args[0])),
+                Template.template("value", String.valueOf(parsed))
         );
     }
 
@@ -384,7 +384,7 @@ public final class FlagCommand extends Command {
         if (args.length < 2) {
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", "/plot flag add <flag> <values>")
+                    Template.template("value", "/plot flag add <flag> <values>")
             );
             return;
         }
@@ -397,7 +397,7 @@ public final class FlagCommand extends Command {
         if (event.getEventResult() == Result.DENY) {
             player.sendMessage(
                     TranslatableCaption.of("events.event_denied"),
-                    Template.of("value", "Flag add")
+                    Template.template("value", "Flag add")
             );
             return;
         }
@@ -418,9 +418,9 @@ public final class FlagCommand extends Command {
         } catch (FlagParseException e) {
             player.sendMessage(
                     TranslatableCaption.of("flag.flag_parse_error"),
-                    Template.of("flag_name", plotFlag.getName()),
-                    Template.of("flag_value", e.getValue()),
-                    Template.of("error", e.getErrorMessage().getComponent(player))
+                    Template.template("flag_name", plotFlag.getName()),
+                    Template.template("flag_value", e.getValue()),
+                    Template.template("error", e.getErrorMessage().getComponent(player))
             );
             return;
         }
@@ -430,8 +430,8 @@ public final class FlagCommand extends Command {
             player.sendMessage(TranslatableCaption.of("flag.flag_not_added"));
             return;
         }
-        player.sendMessage(TranslatableCaption.of("flag.flag_added"), Template.of("flag", String.valueOf(args[0])),
-                Template.of("value", String.valueOf(parsed))
+        player.sendMessage(TranslatableCaption.of("flag.flag_added"), Template.template("flag", String.valueOf(args[0])),
+                Template.template("value", String.valueOf(parsed))
         );
     }
 
@@ -452,7 +452,7 @@ public final class FlagCommand extends Command {
         if (args.length != 1 && args.length != 2) {
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", "/plot flag remove <flag> [values]")
+                    Template.template("value", "/plot flag remove <flag> [values]")
             );
             return;
         }
@@ -465,7 +465,7 @@ public final class FlagCommand extends Command {
         if (event.getEventResult() == Result.DENY) {
             player.sendMessage(
                     TranslatableCaption.of("events.event_denied"),
-                    Template.of("value", "Flag remove")
+                    Template.template("value", "Flag remove")
             );
             return;
         }
@@ -475,7 +475,7 @@ public final class FlagCommand extends Command {
             if (args.length != 2) {
                 player.sendMessage(
                         TranslatableCaption.of("permission.no_permission"),
-                        Template.of("node", Permission.PERMISSION_SET_FLAG_KEY.format(args[0].toLowerCase()))
+                        Template.template("node", Permission.PERMISSION_SET_FLAG_KEY.format(args[0].toLowerCase()))
                 );
                 return;
             }
@@ -490,9 +490,9 @@ public final class FlagCommand extends Command {
             } catch (final FlagParseException e) {
                 player.sendMessage(
                         TranslatableCaption.of("flag.flag_parse_error"),
-                        Template.of("flag_name", flag.getName()),
-                        Template.of("flag_value", e.getValue()),
-                        Template.of("error", String.valueOf(e.getErrorMessage()))
+                        Template.template("flag_name", flag.getName()),
+                        Template.template("flag_value", e.getValue()),
+                        Template.template("error", String.valueOf(e.getErrorMessage()))
                 );
                 return;
             }
@@ -503,7 +503,7 @@ public final class FlagCommand extends Command {
             if (list.removeAll((List) parsedFlag.getValue())) {
                 if (list.isEmpty()) {
                     if (plot.removeFlag(flag)) {
-                        player.sendMessage(TranslatableCaption.of("flag.flag_removed"), Template.of("flag", args[0]), Template.of(
+                        player.sendMessage(TranslatableCaption.of("flag.flag_removed"), Template.template("flag", args[0]), Template.template(
                                 "value",
                                 String.valueOf(flag)
                         ));
@@ -518,7 +518,7 @@ public final class FlagCommand extends Command {
                     if (addEvent.getEventResult() == Result.DENY) {
                         player.sendMessage(
                                 TranslatableCaption.of("events.event_denied"),
-                                Template.of("value", "Re-addition of " + plotFlag.getName())
+                                Template.template("value", "Re-addition of " + plotFlag.getName())
                         );
                         return;
                     }
@@ -541,7 +541,7 @@ public final class FlagCommand extends Command {
                 return;
             }
         }
-        player.sendMessage(TranslatableCaption.of("flag.flag_removed"), Template.of("flag", args[0]), Template.of(
+        player.sendMessage(TranslatableCaption.of("flag.flag_removed"), Template.template("flag", args[0]), Template.template(
                 "value",
                 String.valueOf(flag)
         ));
@@ -578,7 +578,7 @@ public final class FlagCommand extends Command {
             Component category =
                     MINI_MESSAGE.parse(
                             TranslatableCaption.of("flag.flag_list_categories").getComponent(player),
-                            Template.of("category", entry.getKey())
+                            Template.template("category", entry.getKey())
                     );
             TextComponent.Builder builder = Component.text().append(category);
             final Iterator<String> flagIterator = entry.getValue().iterator();
@@ -587,9 +587,9 @@ public final class FlagCommand extends Command {
                 builder.append(MINI_MESSAGE
                         .parse(
                                 TranslatableCaption.of("flag.flag_list_flag").getComponent(player),
-                                Template.of("command", "/plot flag info " + flag),
-                                Template.of("flag", flag),
-                                Template.of("suffix", flagIterator.hasNext() ? ", " : "")
+                                Template.template("command", "/plot flag info " + flag),
+                                Template.template("flag", flag),
+                                Template.template("suffix", flagIterator.hasNext() ? ", " : "")
                         ));
             }
             player.sendMessage(StaticCaption.of(MINI_MESSAGE.serialize(builder.build())));
@@ -613,7 +613,7 @@ public final class FlagCommand extends Command {
         if (args.length < 1) {
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", "/plot flag info <flag>")
+                    Template.template("value", "/plot flag info <flag>")
             );
             return;
         }
@@ -621,7 +621,7 @@ public final class FlagCommand extends Command {
         if (plotFlag != null) {
             player.sendMessage(TranslatableCaption.of("flag.flag_info_header"));
             // Flag name
-            player.sendMessage(TranslatableCaption.of("flag.flag_info_name"), Template.of("flag", plotFlag.getName()));
+            player.sendMessage(TranslatableCaption.of("flag.flag_info_name"), Template.template("flag", plotFlag.getName()));
             // Flag category
             player.sendMessage(
                     TranslatableCaption.of("flag.flag_info_category"),
@@ -634,16 +634,16 @@ public final class FlagCommand extends Command {
             // Flag example
             player.sendMessage(
                     TranslatableCaption.of("flag.flag_info_example"),
-                    Template.of("command", "/plot flag set"),
-                    Template.of("flag", plotFlag.getName()),
-                    Template.of("value", plotFlag.getExample())
+                    Template.template("command", "/plot flag set"),
+                    Template.template("flag", plotFlag.getName()),
+                    Template.template("value", plotFlag.getExample())
             );
             // Default value
             final String defaultValue = player.getLocation().getPlotArea().getFlagContainer()
                     .getFlagErased(plotFlag.getClass()).toString();
             player.sendMessage(
                     TranslatableCaption.of("flag.flag_info_default_value"),
-                    Template.of("value", defaultValue)
+                    Template.template("value", defaultValue)
             );
             // Footer. Done this way to prevent the duplicate-message-thingy from catching it
             player.sendMessage(TranslatableCaption.of("flag.flag_info_footer"));

--- a/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
@@ -54,6 +54,7 @@ import com.plotsquared.core.util.task.RunnableVal3;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -576,20 +577,22 @@ public final class FlagCommand extends Command {
         for (final Map.Entry<String, ArrayList<String>> entry : flags.entrySet()) {
             Collections.sort(entry.getValue());
             Component category =
-                    MINI_MESSAGE.parse(
+                    MINI_MESSAGE.deserialize(
                             TranslatableCaption.of("flag.flag_list_categories").getComponent(player),
-                            Template.template("category", entry.getKey())
+                            TemplateResolver.templates(Template.template("category", entry.getKey()))
                     );
             TextComponent.Builder builder = Component.text().append(category);
             final Iterator<String> flagIterator = entry.getValue().iterator();
             while (flagIterator.hasNext()) {
                 final String flag = flagIterator.next();
                 builder.append(MINI_MESSAGE
-                        .parse(
+                        .deserialize(
                                 TranslatableCaption.of("flag.flag_list_flag").getComponent(player),
-                                Template.template("command", "/plot flag info " + flag),
-                                Template.template("flag", flag),
-                                Template.template("suffix", flagIterator.hasNext() ? ", " : "")
+                                TemplateResolver.templates(
+                                        Template.template("command", "/plot flag info " + flag),
+                                        Template.template("flag", flag),
+                                        Template.template("suffix", flagIterator.hasNext() ? ", " : "")
+                                )
                         ));
             }
             player.sendMessage(StaticCaption.of(MINI_MESSAGE.serialize(builder.build())));

--- a/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
@@ -628,7 +628,7 @@ public final class FlagCommand extends Command {
             // Flag category
             player.sendMessage(
                     TranslatableCaption.of("flag.flag_info_category"),
-                    Templates.of(player, "value", plotFlag.getFlagCategory())
+                    Templates.template(player, "value", plotFlag.getFlagCategory())
             );
             // Flag description
             // TODO maybe merge and \n instead?

--- a/Core/src/main/java/com/plotsquared/core/command/Grant.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Grant.java
@@ -71,7 +71,7 @@ public class Grant extends Command {
         checkTrue(
                 args.length >= 1 && args.length <= 2,
                 TranslatableCaption.of("commandconfig.command_syntax"),
-                Template.of("value", "/plot grant <check | add> [player]")
+                Template.template("value", "/plot grant <check | add> [player]")
         );
         final String arg0 = args[0].toLowerCase();
         switch (arg0) {
@@ -79,7 +79,7 @@ public class Grant extends Command {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_GRANT.format(arg0))) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", Permission.PERMISSION_GRANT.format(arg0))
+                            Template.template("node", Permission.PERMISSION_GRANT.format(arg0))
                     );
                     return CompletableFuture.completedFuture(false);
                 }
@@ -92,7 +92,7 @@ public class Grant extends Command {
                     } else if (throwable != null || uuids.size() != 1) {
                         player.sendMessage(
                                 TranslatableCaption.of("errors.invalid_player"),
-                                Template.of("value", String.valueOf(uuids))
+                                Template.template("value", String.valueOf(uuids))
                         );
                     } else {
                         final UUIDMapping uuid = uuids.toArray(new UUIDMapping[0])[0];
@@ -103,7 +103,7 @@ public class Grant extends Command {
                                 if (args[0].equalsIgnoreCase("check")) {
                                     player.sendMessage(
                                             TranslatableCaption.of("grants.granted_plots"),
-                                            Template.of("amount", String.valueOf(access.get().orElse(0)))
+                                            Template.template("amount", String.valueOf(access.get().orElse(0)))
                                     );
                                 } else {
                                     access.set(access.get().orElse(0) + 1);
@@ -123,7 +123,7 @@ public class Grant extends Command {
                                         }
                                         player.sendMessage(
                                                 TranslatableCaption.of("grants.granted_plots"),
-                                                Template.of("amount", String.valueOf(granted))
+                                                Template.template("amount", String.valueOf(granted))
                                         );
                                     } else { // add
                                         int amount;
@@ -138,7 +138,7 @@ public class Grant extends Command {
                                         DBFunc.addPersistentMeta(uuid.getUuid(), key, rawData, replace);
                                         player.sendMessage(
                                                 TranslatableCaption.of("grants.added"),
-                                                Template.of("grants", String.valueOf(amount))
+                                                Template.template("grants", String.valueOf(amount))
                                         );
                                     }
                                 }

--- a/Core/src/main/java/com/plotsquared/core/command/Help.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Help.java
@@ -36,6 +36,7 @@ import com.plotsquared.core.util.task.RunnableVal3;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 
 import java.util.Collection;
 import java.util.Locale;
@@ -120,19 +121,23 @@ public class Help extends Command {
                 builder.append(MINI_MESSAGE.parse(TranslatableCaption.of("help.help_header").getComponent(player)));
                 for (CommandCategory c : CommandCategory.values()) {
                     builder.append(Component.newline()).append(MINI_MESSAGE
-                            .parse(
+                            .deserialize(
                                     TranslatableCaption.of("help.help_info_item").getComponent(player),
-                                    Template.template("command", "/plot help"),
-                                    Template.template("category", c.name().toLowerCase()),
-                                    Template.template("category_desc", c.getComponent(player))
+                                    TemplateResolver.templates(
+                                            Template.template("command", "/plot help"),
+                                            Template.template("category", c.name().toLowerCase()),
+                                            Template.template("category_desc", c.getComponent(player))
+                                    )
                             ));
                 }
                 builder.append(Component.newline()).append(MINI_MESSAGE
-                        .parse(
+                        .deserialize(
                                 TranslatableCaption.of("help.help_info_item").getComponent(player),
-                                Template.template("command", "/plot help"),
-                                Template.template("category", "all"),
-                                Template.template("category_desc", "Display all commands")
+                                TemplateResolver.templates(
+                                        Template.template("command", "/plot help"),
+                                        Template.template("category", "all"),
+                                        Template.template("category_desc", "Display all commands")
+                                )
                         ));
                 builder.append(Component.newline()).append(MINI_MESSAGE.parse(TranslatableCaption
                         .of("help.help_footer")

--- a/Core/src/main/java/com/plotsquared/core/command/Help.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Help.java
@@ -122,17 +122,17 @@ public class Help extends Command {
                     builder.append(Component.newline()).append(MINI_MESSAGE
                             .parse(
                                     TranslatableCaption.of("help.help_info_item").getComponent(player),
-                                    Template.of("command", "/plot help"),
-                                    Template.of("category", c.name().toLowerCase()),
-                                    Template.of("category_desc", c.getComponent(player))
+                                    Template.template("command", "/plot help"),
+                                    Template.template("category", c.name().toLowerCase()),
+                                    Template.template("category_desc", c.getComponent(player))
                             ));
                 }
                 builder.append(Component.newline()).append(MINI_MESSAGE
                         .parse(
                                 TranslatableCaption.of("help.help_info_item").getComponent(player),
-                                Template.of("command", "/plot help"),
-                                Template.of("category", "all"),
-                                Template.of("category_desc", "Display all commands")
+                                Template.template("command", "/plot help"),
+                                Template.template("category", "all"),
+                                Template.template("category_desc", "Display all commands")
                         ));
                 builder.append(Component.newline()).append(MINI_MESSAGE.parse(TranslatableCaption
                         .of("help.help_footer")

--- a/Core/src/main/java/com/plotsquared/core/command/HomeCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/HomeCommand.java
@@ -79,8 +79,8 @@ public class HomeCommand extends Command {
         } else if (plots.size() < page || page < 1) {
             player.sendMessage(
                     TranslatableCaption.of("invalid.number_not_in_range"),
-                    Template.of("min", "1"),
-                    Template.of("max", String.valueOf(plots.size()))
+                    Template.template("min", "1"),
+                    Template.template("max", String.valueOf(plots.size()))
             );
             return;
         }
@@ -115,7 +115,7 @@ public class HomeCommand extends Command {
                 .hasPermission(player, Permission.PERMISSION_HOME)) {
             player.sendMessage(
                     TranslatableCaption.of("permission.no_permission"),
-                    Template.of("node", Permission.PERMISSION_VISIT_OWNED.toString())
+                    Template.template("node", Permission.PERMISSION_VISIT_OWNED.toString())
             );
             return CompletableFuture.completedFuture(false);
         }
@@ -137,7 +137,7 @@ public class HomeCommand extends Command {
                     } catch (NumberFormatException ignored) {
                         player.sendMessage(
                                 TranslatableCaption.of("invalid.not_a_number"),
-                                Template.of("value", identifier)
+                                Template.template("value", identifier)
                         );
                         return CompletableFuture.completedFuture(false);
                     }
@@ -178,7 +178,7 @@ public class HomeCommand extends Command {
                     } catch (NumberFormatException ignored) {
                         player.sendMessage(
                                 TranslatableCaption.of("invalid.not_a_number"),
-                                Template.of("value", identifier)
+                                Template.template("value", identifier)
                         );
                         return CompletableFuture.completedFuture(false);
                     }

--- a/Core/src/main/java/com/plotsquared/core/command/Inbox.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Inbox.java
@@ -44,6 +44,7 @@ import com.plotsquared.core.util.task.RunnableVal;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -79,9 +80,9 @@ public class Inbox extends SubCommand {
             max = comments.length;
         }
         TextComponent.Builder builder = Component.text();
-        builder.append(MINI_MESSAGE.parse(TranslatableCaption.of("list.comment_list_header_paged").getComponent(player) + '\n',
-                Template.template("amount", String.valueOf(comments.length)), Template.template("cur", String.valueOf(page + 1)),
-                Template.template("max", String.valueOf(totalPages + 1)), Template.template("word", "all")
+        builder.append(MINI_MESSAGE.deserialize(TranslatableCaption.of("list.comment_list_header_paged").getComponent(player) + '\n',
+                TemplateResolver.templates(Template.template("amount", String.valueOf(comments.length)), Template.template("cur", String.valueOf(page + 1)),
+                        Template.template("max", String.valueOf(totalPages + 1)), Template.template("word", "all"))
         ));
 
         // This might work xD
@@ -90,15 +91,15 @@ public class Inbox extends SubCommand {
             Component commentColored;
             if (player.getName().equals(comment.senderName)) {
                 commentColored = MINI_MESSAGE
-                        .parse(
+                        .deserialize(
                                 TranslatableCaption.of("list.comment_list_by_lister").getComponent(player),
-                                Template.template("comment", comment.comment)
+                                TemplateResolver.templates(Template.template("comment", comment.comment))
                         );
             } else {
                 commentColored = MINI_MESSAGE
-                        .parse(
+                        .deserialize(
                                 TranslatableCaption.of("list.comment_list_by_other").getComponent(player),
-                                Template.template("comment", comment.comment)
+                                TemplateResolver.templates(Template.template("comment", comment.comment))
                         );
             }
             Template number = Template.template("number", String.valueOf(x));
@@ -107,13 +108,15 @@ public class Inbox extends SubCommand {
             Template commenter = Template.template("commenter", comment.senderName);
             Template commentTemplate = Template.template("comment", commentColored);
             builder.append(MINI_MESSAGE
-                    .parse(
+                    .deserialize(
                             TranslatableCaption.of("list.comment_list_comment").getComponent(player),
-                            number,
-                            world,
-                            plot_id,
-                            commenter,
-                            commentTemplate
+                            TemplateResolver.templates(
+                                    number,
+                                    world,
+                                    plot_id,
+                                    commenter,
+                                    commentTemplate
+                            )
                     ));
         }
         player.sendMessage(StaticCaption.of(MINI_MESSAGE.serialize(builder.build())));

--- a/Core/src/main/java/com/plotsquared/core/command/Inbox.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Inbox.java
@@ -80,8 +80,8 @@ public class Inbox extends SubCommand {
         }
         TextComponent.Builder builder = Component.text();
         builder.append(MINI_MESSAGE.parse(TranslatableCaption.of("list.comment_list_header_paged").getComponent(player) + '\n',
-                Template.of("amount", String.valueOf(comments.length)), Template.of("cur", String.valueOf(page + 1)),
-                Template.of("max", String.valueOf(totalPages + 1)), Template.of("word", "all")
+                Template.template("amount", String.valueOf(comments.length)), Template.template("cur", String.valueOf(page + 1)),
+                Template.template("max", String.valueOf(totalPages + 1)), Template.template("word", "all")
         ));
 
         // This might work xD
@@ -92,20 +92,20 @@ public class Inbox extends SubCommand {
                 commentColored = MINI_MESSAGE
                         .parse(
                                 TranslatableCaption.of("list.comment_list_by_lister").getComponent(player),
-                                Template.of("comment", comment.comment)
+                                Template.template("comment", comment.comment)
                         );
             } else {
                 commentColored = MINI_MESSAGE
                         .parse(
                                 TranslatableCaption.of("list.comment_list_by_other").getComponent(player),
-                                Template.of("comment", comment.comment)
+                                Template.template("comment", comment.comment)
                         );
             }
-            Template number = Template.of("number", String.valueOf(x));
-            Template world = Template.of("world", comment.world);
-            Template plot_id = Template.of("plot_id", comment.id.getX() + ";" + comment.id.getY());
-            Template commenter = Template.of("commenter", comment.senderName);
-            Template commentTemplate = Template.of("comment", commentColored);
+            Template number = Template.template("number", String.valueOf(x));
+            Template world = Template.template("world", comment.world);
+            Template plot_id = Template.template("plot_id", comment.id.getX() + ";" + comment.id.getY());
+            Template commenter = Template.template("commenter", comment.senderName);
+            Template commentTemplate = Template.template("comment", commentColored);
             builder.append(MINI_MESSAGE
                     .parse(
                             TranslatableCaption.of("list.comment_list_comment").getComponent(player),
@@ -150,20 +150,20 @@ public class Inbox extends SubCommand {
                                 if (total != 0) {
                                     player.sendMessage(
                                             TranslatableCaption.of("comment.inbox_item"),
-                                            Template.of("value", inbox + " (" + total + '/' + unread + ')')
+                                            Template.template("value", inbox + " (" + total + '/' + unread + ')')
                                     );
                                     return;
                                 }
                             }
                             player.sendMessage(
                                     TranslatableCaption.of("comment.inbox_item"),
-                                    Template.of("value", inbox.toString())
+                                    Template.template("value", inbox.toString())
                             );
                         }
                     })) {
                         player.sendMessage(
                                 TranslatableCaption.of("comment.inbox_item"),
-                                Template.of("value", inbox.toString())
+                                Template.template("value", inbox.toString())
                         );
                     }
                 }
@@ -174,7 +174,7 @@ public class Inbox extends SubCommand {
         if (inbox == null) {
             player.sendMessage(
                     TranslatableCaption.of("comment.invalid_inbox"),
-                    Template.of("list", StringMan.join(CommentManager.inboxes.keySet(), ", "))
+                    Template.template("list", StringMan.join(CommentManager.inboxes.keySet(), ", "))
             );
             return false;
         }
@@ -197,7 +197,7 @@ public class Inbox extends SubCommand {
                     if (args.length != 3) {
                         player.sendMessage(
                                 TranslatableCaption.of("commandconfig.command_syntax"),
-                                Template.of("value", "/plot inbox " + inbox + " delete <index>")
+                                Template.template("value", "/plot inbox " + inbox + " delete <index>")
                         );
                         return true;
                     }
@@ -214,7 +214,7 @@ public class Inbox extends SubCommand {
                     } catch (NumberFormatException ignored) {
                         player.sendMessage(
                                 TranslatableCaption.of("commandconfig.command_syntax"),
-                                Template.of("value", "/plot inbox " + inbox + " delete <index>")
+                                Template.template("value", "/plot inbox " + inbox + " delete <index>")
                         );
                         return false;
                     }
@@ -235,7 +235,7 @@ public class Inbox extends SubCommand {
                             if (success) {
                                 player.sendMessage(
                                         TranslatableCaption.of("comment.comment_removed_success"),
-                                        Template.of("value", comment.comment)
+                                        Template.template("value", comment.comment)
                                 );
                             } else {
                                 player.sendMessage(
@@ -256,7 +256,7 @@ public class Inbox extends SubCommand {
                     if (!comments.isEmpty()) {
                         player.sendMessage(
                                 TranslatableCaption.of("comment.comment_removed_success"),
-                                Template.of("value", String.valueOf(comments))
+                                Template.template("value", String.valueOf(comments))
                         );
                         plot.getPlotCommentContainer().removeComments(comments);
                     }

--- a/Core/src/main/java/com/plotsquared/core/command/Info.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Info.java
@@ -97,7 +97,7 @@ public class Info extends SubCommand {
                             .hasPermission(Permission.PERMISSION_AREA_INFO_FORCE.toString())) {
                         player.sendMessage(
                                 TranslatableCaption.of("permission.no_permission"),
-                                Template.of("node", Permission.PERMISSION_AREA_INFO_FORCE.toString())
+                                Template.template("node", Permission.PERMISSION_AREA_INFO_FORCE.toString())
                         );
                         return true;
                     }
@@ -119,7 +119,7 @@ public class Info extends SubCommand {
         if (!hasOwner && !containsEveryone && !trustedEveryone) {
             player.sendMessage(
                     TranslatableCaption.of("info.plot_info_unclaimed"),
-                    Template.of("plot", plot.getId().getX() + ";" + plot.getId().getY())
+                    Template.template("plot", plot.getId().getX() + ";" + plot.getId().getY())
             );
             return true;
         }

--- a/Core/src/main/java/com/plotsquared/core/command/Kick.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Kick.java
@@ -89,7 +89,7 @@ public class Kick extends SubCommand {
             } else if (throwable != null || uuids.isEmpty()) {
                 player.sendMessage(
                         TranslatableCaption.of("errors.invalid_player"),
-                        Template.of("value", args[0])
+                        Template.template("value", args[0])
                 );
             } else {
                 Set<PlotPlayer<?>> players = new HashSet<>();
@@ -113,7 +113,7 @@ public class Kick extends SubCommand {
                 if (players.isEmpty()) {
                     player.sendMessage(
                             TranslatableCaption.of("errors.invalid_player"),
-                            Template.of("value", args[0])
+                            Template.template("value", args[0])
                     );
                     return;
                 }
@@ -121,14 +121,14 @@ public class Kick extends SubCommand {
                     if (!plot.equals(player2.getCurrentPlot())) {
                         player.sendMessage(
                                 TranslatableCaption.of("errors.invalid_player"),
-                                Template.of("value", args[0])
+                                Template.template("value", args[0])
                         );
                         return;
                     }
                     if (Permissions.hasPermission(player2, Permission.PERMISSION_ADMIN_ENTRY_DENIED)) {
                         player.sendMessage(
                                 TranslatableCaption.of("cluster.cannot_kick_player"),
-                                Template.of("name", player2.getName())
+                                Template.template("name", player2.getName())
                         );
                         return;
                     }

--- a/Core/src/main/java/com/plotsquared/core/command/Leave.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Leave.java
@@ -74,7 +74,7 @@ public class Leave extends Command {
                 }
                 player.sendMessage(
                         TranslatableCaption.of("member.plot_left"),
-                        Template.of("player", player.getName())
+                        Template.template("player", player.getName())
                 );
             } else {
                 player.sendMessage(

--- a/Core/src/main/java/com/plotsquared/core/command/Like.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Like.java
@@ -160,7 +160,7 @@ public class Like extends SubCommand {
             if (oldRating != null) {
                 player.sendMessage(
                         TranslatableCaption.of("ratings.rating_already_exists"),
-                        Template.of("plot", plot.getId().toString())
+                        Template.template("plot", plot.getId().toString())
                 );
                 return;
             }
@@ -178,12 +178,12 @@ public class Like extends SubCommand {
                 if (like) {
                     player.sendMessage(
                             TranslatableCaption.of("ratings.rating_liked"),
-                            Template.of("plot", plot.getId().toString())
+                            Template.template("plot", plot.getId().toString())
                     );
                 } else {
                     player.sendMessage(
                             TranslatableCaption.of("ratings.rating_disliked"),
-                            Template.of("plot", plot.getId().toString())
+                            Template.template("plot", plot.getId().toString())
                     );
                 }
             }

--- a/Core/src/main/java/com/plotsquared/core/command/ListCmd.java
+++ b/Core/src/main/java/com/plotsquared/core/command/ListCmd.java
@@ -166,7 +166,7 @@ public class ListCmd extends SubCommand {
             if (query == null) {
                 player.sendMessage(
                         TranslatableCaption.of("commandconfig.did_you_mean"),
-                        Template.of(
+                        Template.template(
                                 "value",
                                 new StringComparison<>(args[0], new String[]{"mine", "shared", "world", "all"}).getBestMatch()
                         )
@@ -428,16 +428,16 @@ public class ListCmd extends SubCommand {
                 }
                 Component trusted = MINI_MESSAGE.parse(
                         TranslatableCaption.of("info.plot_info_trusted").getComponent(player),
-                        Template.of("trusted", PlayerManager.getPlayerList(plot.getTrusted(), player))
+                        Template.template("trusted", PlayerManager.getPlayerList(plot.getTrusted(), player))
                 );
                 Component members = MINI_MESSAGE.parse(
                         TranslatableCaption.of("info.plot_info_members").getComponent(player),
-                        Template.of("members", PlayerManager.getPlayerList(plot.getMembers(), player))
+                        Template.template("members", PlayerManager.getPlayerList(plot.getMembers(), player))
                 );
-                Template command_tp = Template.of("command_tp", "/plot visit " + plot.getArea() + ";" + plot.getId());
-                Template command_info = Template.of("command_info", "/plot info " + plot.getArea() + ";" + plot.getId());
+                Template command_tp = Template.template("command_tp", "/plot visit " + plot.getArea() + ";" + plot.getId());
+                Template command_info = Template.template("command_info", "/plot info " + plot.getArea() + ";" + plot.getId());
                 Template hover_info =
-                        Template.of(
+                        Template.template(
                                 "hover_info",
                                 MINI_MESSAGE.serialize(Component
                                         .text()
@@ -446,10 +446,10 @@ public class ListCmd extends SubCommand {
                                         .append(members)
                                         .asComponent())
                         );
-                Template numberTemplate = Template.of("number", String.valueOf(i));
-                Template plotTemplate = Template.of(
+                Template numberTemplate = Template.template("number", String.valueOf(i));
+                Template plotTemplate = Template.template(
                         "plot",
-                        MINI_MESSAGE.parse(color.getComponent(player), Template.of("plot", plot.toString()))
+                        MINI_MESSAGE.parse(color.getComponent(player), Template.template("plot", plot.toString()))
                 );
 
                 String prefix = "";
@@ -461,8 +461,8 @@ public class ListCmd extends SubCommand {
                             .get(Settings.UUID.BLOCKING_TIMEOUT, TimeUnit.MILLISECONDS);
                     for (final UUIDMapping uuidMapping : names) {
                         PlotPlayer<?> pp = PlotSquared.platform().playerManager().getPlayerIfExists(uuidMapping.getUuid());
-                        Template prefixTemplate = Template.of("prefix", prefix);
-                        Template playerTemplate = Template.of("player", uuidMapping.getUsername());
+                        Template prefixTemplate = Template.template("prefix", prefix);
+                        Template playerTemplate = Template.template("player", uuidMapping.getUsername());
                         if (pp != null) {
                             builder.append(MINI_MESSAGE.parse(online, prefixTemplate, playerTemplate));
                         } else {
@@ -487,7 +487,7 @@ public class ListCmd extends SubCommand {
                 } catch (TimeoutException e) {
                     player.sendMessage(TranslatableCaption.of("players.fetching_players_timeout"));
                 }
-                Template players = Template.of("players", builder.asComponent());
+                Template players = Template.template("players", builder.asComponent());
                 caption.set(TranslatableCaption.of("info.plot_list_item"));
                 caption.setTemplates(command_tp, command_info, hover_info, numberTemplate, plotTemplate, players);
             }

--- a/Core/src/main/java/com/plotsquared/core/command/ListCmd.java
+++ b/Core/src/main/java/com/plotsquared/core/command/ListCmd.java
@@ -54,6 +54,7 @@ import com.plotsquared.core.uuid.UUIDMapping;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.ArrayList;
@@ -426,13 +427,13 @@ public class ListCmd extends SubCommand {
                 } else {
                     color = TranslatableCaption.of("info.plot_list_default");
                 }
-                Component trusted = MINI_MESSAGE.parse(
+                Component trusted = MINI_MESSAGE.deserialize(
                         TranslatableCaption.of("info.plot_info_trusted").getComponent(player),
-                        Template.template("trusted", PlayerManager.getPlayerList(plot.getTrusted(), player))
+                        TemplateResolver.templates(Template.template("trusted", PlayerManager.getPlayerList(plot.getTrusted(), player)))
                 );
-                Component members = MINI_MESSAGE.parse(
+                Component members = MINI_MESSAGE.deserialize(
                         TranslatableCaption.of("info.plot_info_members").getComponent(player),
-                        Template.template("members", PlayerManager.getPlayerList(plot.getMembers(), player))
+                        TemplateResolver.templates(Template.template("members", PlayerManager.getPlayerList(plot.getMembers(), player)))
                 );
                 Template command_tp = Template.template("command_tp", "/plot visit " + plot.getArea() + ";" + plot.getId());
                 Template command_info = Template.template("command_info", "/plot info " + plot.getArea() + ";" + plot.getId());
@@ -449,7 +450,7 @@ public class ListCmd extends SubCommand {
                 Template numberTemplate = Template.template("number", String.valueOf(i));
                 Template plotTemplate = Template.template(
                         "plot",
-                        MINI_MESSAGE.parse(color.getComponent(player), Template.template("plot", plot.toString()))
+                        MINI_MESSAGE.deserialize(color.getComponent(player), TemplateResolver.templates(Template.template("plot", plot.toString())))
                 );
 
                 String prefix = "";
@@ -464,9 +465,9 @@ public class ListCmd extends SubCommand {
                         Template prefixTemplate = Template.template("prefix", prefix);
                         Template playerTemplate = Template.template("player", uuidMapping.getUsername());
                         if (pp != null) {
-                            builder.append(MINI_MESSAGE.parse(online, prefixTemplate, playerTemplate));
+                            builder.append(MINI_MESSAGE.deserialize(online, TemplateResolver.templates(prefixTemplate, playerTemplate)));
                         } else {
-                            builder.append(MINI_MESSAGE.parse(offline, prefixTemplate, playerTemplate));
+                            builder.append(MINI_MESSAGE.deserialize(offline, TemplateResolver.templates(prefixTemplate, playerTemplate)));
                         }
                         prefix = ", ";
                     }

--- a/Core/src/main/java/com/plotsquared/core/command/Load.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Load.java
@@ -105,7 +105,7 @@ public class Load extends SubCommand {
                         // No schematics found:
                         player.sendMessage(
                                 TranslatableCaption.of("web.load_null"),
-                                Template.of("command", "/plot load")
+                                Template.template("command", "/plot load")
                         );
                         return false;
                     }
@@ -116,7 +116,7 @@ public class Load extends SubCommand {
                         // use /plot load <index>
                         player.sendMessage(
                                 TranslatableCaption.of("invalid.not_valid_number"),
-                                Template.of("value", "(1, " + schematics.size() + ')')
+                                Template.template("value", "(1, " + schematics.size() + ')')
                         );
                         return false;
                     }
@@ -136,7 +136,7 @@ public class Load extends SubCommand {
                             plot.removeRunning();
                             player.sendMessage(
                                     TranslatableCaption.of("schematics.schematic_invalid"),
-                                    Template.of("reason", "non-existent or not in gzip format")
+                                    Template.template("reason", "non-existent or not in gzip format")
                             );
                             return;
                         }
@@ -167,7 +167,7 @@ public class Load extends SubCommand {
                 plot.removeRunning();
                 player.sendMessage(
                         TranslatableCaption.of("commandconfig.command_syntax"),
-                        Template.of("value", "/plot load <index>")
+                        Template.template("value", "/plot load <index>")
                 );
                 return false;
             }
@@ -218,7 +218,7 @@ public class Load extends SubCommand {
             }
             player.sendMessage(
                     TranslatableCaption.of("web.load_list"),
-                    Template.of("command", "/plot load #")
+                    Template.template("command", "/plot load #")
             );
         }
     }

--- a/Core/src/main/java/com/plotsquared/core/command/MainCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/MainCommand.java
@@ -318,7 +318,7 @@ public class MainCommand extends Command {
             if (message != null) {
                 player.sendMessage(
                         TranslatableCaption.of("errors.error"),
-                        net.kyori.adventure.text.minimessage.Template.of("value", message)
+                        net.kyori.adventure.text.minimessage.Template.template("value", message)
                 );
             } else {
                 player.sendMessage(

--- a/Core/src/main/java/com/plotsquared/core/command/Merge.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Merge.java
@@ -122,11 +122,11 @@ public class Merge extends SubCommand {
         if (direction == null) {
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", "/plot merge <" + StringMan.join(values, " | ") + "> [removeroads]")
+                    Template.template("value", "/plot merge <" + StringMan.join(values, " | ") + "> [removeroads]")
             );
             player.sendMessage(
                     TranslatableCaption.of("help.direction"),
-                    Template.of("dir", direction(location.getYaw()))
+                    Template.template("dir", direction(location.getYaw()))
             );
             return false;
         }
@@ -137,7 +137,7 @@ public class Merge extends SubCommand {
         if (event.getEventResult() == Result.DENY) {
             player.sendMessage(
                     TranslatableCaption.of("events.event_denied"),
-                    Template.of("value", "Merge")
+                    Template.template("value", "Merge")
             );
             return false;
         }
@@ -148,7 +148,7 @@ public class Merge extends SubCommand {
         if (!force && size - 1 > maxSize) {
             player.sendMessage(
                     TranslatableCaption.of("permission.no_permission"),
-                    Template.of("node", Permission.PERMISSION_MERGE + "." + (size + 1))
+                    Template.template("node", Permission.PERMISSION_MERGE + "." + (size + 1))
             );
             return false;
         }
@@ -175,7 +175,7 @@ public class Merge extends SubCommand {
                     .hasPermission(player, Permission.PERMISSION_MERGE_KEEP_ROAD)) {
                 player.sendMessage(
                         TranslatableCaption.of("permission.no_permission"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_MERGE_KEEP_ROAD))
+                        Template.template("node", String.valueOf(Permission.PERMISSION_MERGE_KEEP_ROAD))
                 );
                 return true;
             }
@@ -184,8 +184,8 @@ public class Merge extends SubCommand {
                     this.econHandler.withdrawMoney(player, price);
                     player.sendMessage(
                             TranslatableCaption.of("economy.removed_balance"),
-                            Template.of("money", this.econHandler.format(price)),
-                            Template.of("balance", this.econHandler.format(this.econHandler.getMoney(player)))
+                            Template.template("money", this.econHandler.format(price)),
+                            Template.template("balance", this.econHandler.format(this.econHandler.getMoney(player)))
                     );
                 }
                 player.sendMessage(TranslatableCaption.of("merge.success_merge"));
@@ -198,7 +198,7 @@ public class Merge extends SubCommand {
                 && this.econHandler.getMoney(player) < price) {
             player.sendMessage(
                     TranslatableCaption.of("economy.cannot_afford_merge"),
-                    Template.of("money", this.econHandler.format(price))
+                    Template.template("money", this.econHandler.format(price))
             );
             return false;
         }
@@ -212,7 +212,7 @@ public class Merge extends SubCommand {
                 .hasPermission(player, Permission.PERMISSION_MERGE_KEEP_ROAD)) {
             player.sendMessage(
                     TranslatableCaption.of("permission.no_permission"),
-                    Template.of("node", String.valueOf(Permission.PERMISSION_MERGE_KEEP_ROAD))
+                    Template.template("node", String.valueOf(Permission.PERMISSION_MERGE_KEEP_ROAD))
             );
             return true;
         }
@@ -221,7 +221,7 @@ public class Merge extends SubCommand {
                 this.econHandler.withdrawMoney(player, price);
                 player.sendMessage(
                         TranslatableCaption.of("economy.removed_balance"),
-                        Template.of("money", this.econHandler.format(price))
+                        Template.template("money", this.econHandler.format(price))
                 );
             }
             player.sendMessage(TranslatableCaption.of("merge.success_merge"));
@@ -236,7 +236,7 @@ public class Merge extends SubCommand {
         if (!force && !Permissions.hasPermission(player, Permission.PERMISSION_MERGE_OTHER)) {
             player.sendMessage(
                     TranslatableCaption.of("permission.no_permission"),
-                    Template.of("node", String.valueOf(Permission.PERMISSION_MERGE_OTHER))
+                    Template.template("node", String.valueOf(Permission.PERMISSION_MERGE_OTHER))
             );
             return false;
         }
@@ -261,14 +261,14 @@ public class Merge extends SubCommand {
                     if (!force && this.econHandler.getMoney(player) < price) {
                         player.sendMessage(
                                 TranslatableCaption.of("economy.cannot_afford_merge"),
-                                Template.of("money", this.econHandler.format(price))
+                                Template.template("money", this.econHandler.format(price))
                         );
                         return;
                     }
                     this.econHandler.withdrawMoney(player, price);
                     player.sendMessage(
                             TranslatableCaption.of("economy.removed_balance"),
-                            Template.of("money", this.econHandler.format(price))
+                            Template.template("money", this.econHandler.format(price))
                     );
                 }
                 player.sendMessage(TranslatableCaption.of("merge.success_merge"));
@@ -277,8 +277,8 @@ public class Merge extends SubCommand {
                 CmdConfirm.addPending(accepter, MINI_MESSAGE.serialize(MINI_MESSAGE
                                 .parse(
                                         TranslatableCaption.of("merge.merge_request_confirm").getComponent(player),
-                                        Template.of("player", player.getName()),
-                                        Template.of("location", plot.getWorldName() + ";" + plot.getId())
+                                        Template.template("player", player.getName()),
+                                        Template.template("location", plot.getWorldName() + ";" + plot.getId())
                                 )),
                         run
                 );

--- a/Core/src/main/java/com/plotsquared/core/command/Merge.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Merge.java
@@ -43,6 +43,7 @@ import com.plotsquared.core.util.Permissions;
 import com.plotsquared.core.util.PlotExpression;
 import com.plotsquared.core.util.StringMan;
 import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.UUID;
@@ -275,10 +276,12 @@ public class Merge extends SubCommand {
             };
             if (!force && hasConfirmation(player)) {
                 CmdConfirm.addPending(accepter, MINI_MESSAGE.serialize(MINI_MESSAGE
-                                .parse(
+                                .deserialize(
                                         TranslatableCaption.of("merge.merge_request_confirm").getComponent(player),
-                                        Template.template("player", player.getName()),
-                                        Template.template("location", plot.getWorldName() + ";" + plot.getId())
+                                        TemplateResolver.templates(
+                                                Template.template("player", player.getName()),
+                                                Template.template("location", plot.getWorldName() + ";" + plot.getId())
+                                        )
                                 )),
                         run
                 );

--- a/Core/src/main/java/com/plotsquared/core/command/Move.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Move.java
@@ -110,8 +110,8 @@ public class Move extends SubCommand {
             if (result) {
                 player.sendMessage(
                         TranslatableCaption.of("move.move_success"),
-                        Template.of("origin", plot1.toString()),
-                        Template.of("target", plot2.toString())
+                        Template.template("origin", plot1.toString()),
+                        Template.template("target", plot2.toString())
                 );
                 return true;
             } else {

--- a/Core/src/main/java/com/plotsquared/core/command/Music.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Music.java
@@ -80,7 +80,7 @@ public class Music extends SubCommand {
                 .hasPermission(player, Permission.PERMISSION_ADMIN_MUSIC_OTHER)) {
             player.sendMessage(
                     TranslatableCaption.of("permission.no_permission"),
-                    Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_MUSIC_OTHER))
+                    Template.template("node", String.valueOf(Permission.PERMISSION_ADMIN_MUSIC_OTHER))
             );
             return true;
         }
@@ -103,15 +103,15 @@ public class Music extends SubCommand {
                     if (event.getEventResult() == Result.DENY) {
                         getPlayer().sendMessage(
                                 TranslatableCaption.of("events.event_denied"),
-                                Template.of("value", "Music removal")
+                                Template.template("value", "Music removal")
                         );
                         return true;
                     }
                     plot.removeFlag(event.getFlag());
                     getPlayer().sendMessage(
                             TranslatableCaption.of("flag.flag_removed"),
-                            Template.of("flag", "music"),
-                            Template.of("value", "music_disc")
+                            Template.template("flag", "music"),
+                            Template.template("value", "music_disc")
                     );
                 } else if (item.getName().toLowerCase(Locale.ENGLISH).contains("disc")) {
                     PlotFlag<?, ?> plotFlag = plot.getFlagContainer().getFlag(MusicFlag.class)
@@ -120,13 +120,13 @@ public class Music extends SubCommand {
                     if (event.getEventResult() == Result.DENY) {
                         getPlayer().sendMessage(
                                 TranslatableCaption.of("events.event_denied"),
-                                Template.of("value", "Music addition")
+                                Template.template("value", "Music addition")
                         );
                         return true;
                     }
                     plot.setFlag(event.getFlag());
-                    getPlayer().sendMessage(TranslatableCaption.of("flag.flag_added"), Template.of("flag", "music"),
-                            Template.of("value", String.valueOf(event.getFlag().getValue()))
+                    getPlayer().sendMessage(TranslatableCaption.of("flag.flag_added"), Template.template("flag", "music"),
+                            Template.template("value", String.valueOf(event.getFlag().getValue()))
                     );
                 } else {
                     getPlayer().sendMessage(TranslatableCaption.of("flag.flag_not_added"));

--- a/Core/src/main/java/com/plotsquared/core/command/Near.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Near.java
@@ -55,7 +55,7 @@ public class Near extends Command {
         final Plot plot = check(player.getCurrentPlot(), TranslatableCaption.of("errors.not_in_plot"));
         player.sendMessage(
                 TranslatableCaption.of("near.plot_near"),
-                Template.of("list", StringMan.join(plot.getPlayersInPlot(), ", "))
+                Template.template("list", StringMan.join(plot.getPlayersInPlot(), ", "))
         );
         return CompletableFuture.completedFuture(true);
     }

--- a/Core/src/main/java/com/plotsquared/core/command/Owner.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Owner.java
@@ -72,7 +72,7 @@ public class Owner extends SetCommand {
         if (value == null || value.isEmpty()) {
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", "/plot setowner <owner>")
+                    Template.template("value", "/plot setowner <owner>")
             );
             return false;
         }
@@ -83,7 +83,7 @@ public class Owner extends SetCommand {
                     && !value.equalsIgnoreCase("-")) {
                 player.sendMessage(
                         TranslatableCaption.of("errors.invalid_player"),
-                        Template.of("value", value)
+                        Template.template("value", value)
                 );
                 return;
             }
@@ -97,7 +97,7 @@ public class Owner extends SetCommand {
             if (event.getEventResult() == Result.DENY) {
                 player.sendMessage(
                         TranslatableCaption.of("events.event_denied"),
-                        Template.of("value", "Owner change")
+                        Template.template("value", "Owner change")
                 );
                 return;
             }
@@ -120,7 +120,7 @@ public class Owner extends SetCommand {
                 if (unlinkEvent.getEventResult() == Result.DENY) {
                     player.sendMessage(
                             TranslatableCaption.of("events.event_denied"),
-                            Template.of("value", "Unlink on owner change")
+                            Template.template("value", "Unlink on owner change")
                     );
                     return;
                 }
@@ -137,7 +137,7 @@ public class Owner extends SetCommand {
             if (plot.isOwner(uuid)) {
                 player.sendMessage(
                         TranslatableCaption.of("member.already_owner"),
-                        Template.of("player", PlayerManager.getName(uuid, false))
+                        Template.template("player", PlayerManager.getName(uuid, false))
                 );
                 return;
             }
@@ -146,7 +146,7 @@ public class Owner extends SetCommand {
                 if (other == null) {
                     player.sendMessage(
                             TranslatableCaption.of("errors.invalid_player_offline"),
-                            Template.of("player", PlayerManager.getName(uuid))
+                            Template.template("player", PlayerManager.getName(uuid))
                     );
                     return;
                 }
@@ -181,7 +181,7 @@ public class Owner extends SetCommand {
                         if (other != null) {
                             other.sendMessage(
                                     TranslatableCaption.of("owner.now_owner"),
-                                    Template.of("plot", plot.getArea() + ";" + plot.getId())
+                                    Template.template("plot", plot.getArea() + ";" + plot.getId())
                             );
                         }
                     } else {

--- a/Core/src/main/java/com/plotsquared/core/command/PluginCmd.java
+++ b/Core/src/main/java/com/plotsquared/core/command/PluginCmd.java
@@ -46,7 +46,7 @@ public class PluginCmd extends SubCommand {
                     StaticCaption.of("<gray>>> </gray><gold><bold>" + PlotSquared
                             .platform()
                             .pluginName() + " <reset><gray>(<gold>Version</gold><gray>: </gray><gold><version></gold><gray>)</gray>"),
-                    Template.of("version", String.valueOf(PlotSquared.get().getVersion()))
+                    Template.template("version", String.valueOf(PlotSquared.get().getVersion()))
             );
             player.sendMessage(StaticCaption.of(
                     "<gray>>> </gray><gold><bold>Authors<reset><gray>: </gray><gold>Citymonstret </gold><gray>& </gray><gold>Empire92 </gold><gray>& </gray><gold>MattBDev </gold><gray>& </gray><gold>dordsor21 </gold><gray>& </gray><gold>NotMyFault </gold><gray>& </gray><gold>SirYwell</gold>"));
@@ -56,7 +56,7 @@ public class PluginCmd extends SubCommand {
                     "<gray>>> </gray><gold><bold>Discord<reset><gray>: </gray><gold><click:open_url:https://discord.gg/intellectualsites>https://discord.gg/intellectualsites</gold>"));
             player.sendMessage(
                     StaticCaption.of("<gray>>> </gray><gold><bold>Premium<reset><gray>: <gold><value></gold>"),
-                    Template.of("value", String.valueOf(PremiumVerification.isPremium()))
+                    Template.template("value", String.valueOf(PremiumVerification.isPremium()))
             );
         });
         return true;

--- a/Core/src/main/java/com/plotsquared/core/command/Purge.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Purge.java
@@ -103,7 +103,7 @@ public class Purge extends SubCommand {
                     if (area == null) {
                         player.sendMessage(
                                 TranslatableCaption.of("errors.not_valid_plot_world"),
-                                Template.of("value", split[1])
+                                Template.template("value", split[1])
                         );
                         return false;
                     }
@@ -115,7 +115,7 @@ public class Purge extends SubCommand {
                     } catch (IllegalArgumentException ignored) {
                         player.sendMessage(
                                 TranslatableCaption.of("invalid.not_valid_plot_id"),
-                                Template.of("value", split[1])
+                                Template.template("value", split[1])
                         );
                         return false;
                     }
@@ -126,7 +126,7 @@ public class Purge extends SubCommand {
                     if (ownerMapping == null) {
                         player.sendMessage(
                                 TranslatableCaption.of("errors.invalid_player"),
-                                Template.of("value", split[1])
+                                Template.template("value", split[1])
                         );
                         return false;
                     }
@@ -138,7 +138,7 @@ public class Purge extends SubCommand {
                     if (addedMapping == null) {
                         player.sendMessage(
                                 TranslatableCaption.of("errors.invalid_player"),
-                                Template.of("value", split[1])
+                                Template.template("value", split[1])
                         );
                         return false;
                     }
@@ -243,7 +243,7 @@ public class Purge extends SubCommand {
                             DBFunc.purgeIds(ids);
                             player.sendMessage(
                                     TranslatableCaption.of("purge.purge_success"),
-                                    Template.of("amount", ids.size() + "/" + toDelete.size())
+                                    Template.template("amount", ids.size() + "/" + toDelete.size())
                             );
                         });
                     }

--- a/Core/src/main/java/com/plotsquared/core/command/Rate.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Rate.java
@@ -155,7 +155,7 @@ public class Rate extends SubCommand {
                     if (plot.getRatings().containsKey(player.getUUID())) {
                         player.sendMessage(
                                 TranslatableCaption.of("ratings.rating_already_exists"),
-                                Template.of("plot", plot.getId().toString())
+                                Template.template("plot", plot.getId().toString())
                         );
                         return;
                     }
@@ -175,7 +175,7 @@ public class Rate extends SubCommand {
                                     plot.addRating(this.getPlayer().getUUID(), event.getRating());
                                     getPlayer().sendMessage(
                                             TranslatableCaption.of("ratings.rating_applied"),
-                                            Template.of("plot", plot.getId().toString())
+                                            Template.template("plot", plot.getId().toString())
                                     );
                                 }
                                 return false;
@@ -248,7 +248,7 @@ public class Rate extends SubCommand {
             if (plot.getRatings().containsKey(uuid)) {
                 player.sendMessage(
                         TranslatableCaption.of("ratings.rating_already_exists"),
-                        Template.of("plot", plot.getId().toString())
+                        Template.template("plot", plot.getId().toString())
                 );
                 return;
             }
@@ -258,7 +258,7 @@ public class Rate extends SubCommand {
                 plot.addRating(uuid, event.getRating());
                 player.sendMessage(
                         TranslatableCaption.of("ratings.rating_applied"),
-                        Template.of("plot", plot.getId().toString())
+                        Template.template("plot", plot.getId().toString())
                 );
             }
         };

--- a/Core/src/main/java/com/plotsquared/core/command/RegenAllRoads.java
+++ b/Core/src/main/java/com/plotsquared/core/command/RegenAllRoads.java
@@ -65,18 +65,18 @@ public class RegenAllRoads extends SubCommand {
             } catch (NumberFormatException ignored) {
                 player.sendMessage(
                         TranslatableCaption.of("invalid.not_valid_number"),
-                        Template.of("value", "(0, 256)")
+                        Template.template("value", "(0, 256)")
                 );
                 player.sendMessage(
                         TranslatableCaption.of("commandconfig.command_syntax"),
-                        Template.of("value", "/plot regenallroads <world> [height]")
+                        Template.template("value", "/plot regenallroads <world> [height]")
                 );
                 return false;
             }
         } else if (args.length != 1) {
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", "/plot regenallroads <world> [height]")
+                    Template.template("value", "/plot regenallroads <world> [height]")
             );
             return false;
         }
@@ -84,7 +84,7 @@ public class RegenAllRoads extends SubCommand {
         if (area == null) {
             player.sendMessage(
                     TranslatableCaption.of("errors.not_valid_plot_world"),
-                    Template.of("value", args[0])
+                    Template.template("value", args[0])
             );
             return false;
         }
@@ -96,7 +96,7 @@ public class RegenAllRoads extends SubCommand {
         }
         player.sendMessage(
                 TranslatableCaption.of("debugroadregen.schematic"),
-                Template.of("command", "/plot createroadschematic")
+                Template.template("command", "/plot createroadschematic")
         );
         player.sendMessage(TranslatableCaption.of("debugroadregen.regenallroads_started"));
         boolean result = this.hybridUtils.scheduleRoadUpdate(area, height);

--- a/Core/src/main/java/com/plotsquared/core/command/Remove.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Remove.java
@@ -86,7 +86,7 @@ public class Remove extends SubCommand {
             } else if (throwable != null) {
                 player.sendMessage(
                         TranslatableCaption.of("errors.invalid_player"),
-                        Template.of("value", args[0])
+                        Template.template("value", args[0])
                 );
                 return;
             } else if (!uuids.isEmpty()) {
@@ -123,12 +123,12 @@ public class Remove extends SubCommand {
             if (count == 0) {
                 player.sendMessage(
                         TranslatableCaption.of("errors.invalid_player"),
-                        Template.of("value", args[0])
+                        Template.template("value", args[0])
                 );
             } else {
                 player.sendMessage(
                         TranslatableCaption.of("member.removed_players"),
-                        Template.of("amount", count + "")
+                        Template.template("amount", count + "")
                 );
             }
         });

--- a/Core/src/main/java/com/plotsquared/core/command/Save.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Save.java
@@ -48,7 +48,7 @@ import java.util.UUID;
 
 /**
  * @deprecated In favor of "/plot download" (Arkitektonika) and scheduled
- *         for removal within the next major release.
+ * for removal within the next major release.
  */
 @Deprecated(forRemoval = true)
 @CommandDeclaration(command = "save",

--- a/Core/src/main/java/com/plotsquared/core/command/Save.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Save.java
@@ -123,7 +123,7 @@ public class Save extends SubCommand {
                                 player.sendMessage(TranslatableCaption.of("web.save_success"));
                                 player.sendMessage(
                                         TranslatableCaption.of("errors.deprecated_commands"),
-                                        Template.of("replacement", "/plot download")
+                                        Template.template("replacement", "/plot download")
                                 );
                                 try (final MetaDataAccess<List<String>> schematicAccess =
                                              player.accessTemporaryMetaData(PlayerMetaDataKeys.TEMPORARY_SCHEMATICS)) {

--- a/Core/src/main/java/com/plotsquared/core/command/SchematicCmd.java
+++ b/Core/src/main/java/com/plotsquared/core/command/SchematicCmd.java
@@ -80,7 +80,7 @@ public class SchematicCmd extends SubCommand {
         if (args.length < 1) {
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", "Possible values: save, paste, exportall, list")
+                    Template.template("value", "Possible values: save, paste, exportall, list")
             );
             return true;
         }
@@ -90,14 +90,14 @@ public class SchematicCmd extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_SCHEMATIC_PASTE)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_SCHEMATIC_PASTE))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_SCHEMATIC_PASTE))
                     );
                     return false;
                 }
                 if (args.length < 2) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "Possible values: save, paste, exportall, list")
+                            Template.template("value", "Possible values: save, paste, exportall, list")
                     );
                     break;
                 }
@@ -138,7 +138,7 @@ public class SchematicCmd extends SubCommand {
                             e.printStackTrace();
                             player.sendMessage(
                                     TranslatableCaption.of("schematics.schematic_invalid"),
-                                    Template.of("reason", "non-existent url: " + location)
+                                    Template.template("reason", "non-existent url: " + location)
                             );
                             SchematicCmd.this.running = false;
                             return;
@@ -154,7 +154,7 @@ public class SchematicCmd extends SubCommand {
                         SchematicCmd.this.running = false;
                         player.sendMessage(
                                 TranslatableCaption.of("schematics.schematic_invalid"),
-                                Template.of("reason", "non-existent or not in gzip format")
+                                Template.template("reason", "non-existent or not in gzip format")
                         );
                         return;
                     }
@@ -191,7 +191,7 @@ public class SchematicCmd extends SubCommand {
                     player.sendMessage(TranslatableCaption.of("schematics.schematic_exportall_world_args"));
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "Use /plot schematic exportall <area>")
+                            Template.template("value", "Use /plot schematic exportall <area>")
                     );
                     return false;
                 }
@@ -199,7 +199,7 @@ public class SchematicCmd extends SubCommand {
                 if (area == null) {
                     player.sendMessage(
                             TranslatableCaption.of("errors.not_valid_plot_world"),
-                            Template.of("value", args[1])
+                            Template.template("value", args[1])
                     );
                     return false;
                 }
@@ -208,7 +208,7 @@ public class SchematicCmd extends SubCommand {
                     player.sendMessage(TranslatableCaption.of("schematic.schematic_exportall_world"));
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "Use /plot sch exportall <area>")
+                            Template.template("value", "Use /plot sch exportall <area>")
                     );
                     return false;
                 }
@@ -222,7 +222,7 @@ public class SchematicCmd extends SubCommand {
                     player.sendMessage(TranslatableCaption.of("schematics.schematic_exportall_started"));
                     player.sendMessage(
                             TranslatableCaption.of("schematics.plot_to_schem"),
-                            Template.of("amount", String.valueOf(plots.size()))
+                            Template.template("amount", String.valueOf(plots.size()))
                     );
                 }
             }
@@ -230,7 +230,7 @@ public class SchematicCmd extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_SCHEMATIC_SAVE)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_SCHEMATIC_SAVE))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_SCHEMATIC_SAVE))
                     );
                     return false;
                 }
@@ -273,19 +273,19 @@ public class SchematicCmd extends SubCommand {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_SCHEMATIC_LIST)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_SCHEMATIC_LIST))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_SCHEMATIC_LIST))
                     );
                     return false;
                 }
                 final String string = StringMan.join(this.schematicHandler.getSchematicNames(), "$2, $1");
                 player.sendMessage(
                         TranslatableCaption.of("schematics.schematic_list"),
-                        Template.of("list", string)
+                        Template.template("list", string)
                 );
             }
             default -> player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", "Possible values: save, paste, exportall, list")
+                    Template.template("value", "Possible values: save, paste, exportall, list")
             );
         }
         return true;

--- a/Core/src/main/java/com/plotsquared/core/command/Set.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Set.java
@@ -130,7 +130,7 @@ public class Set extends SubCommand {
                             }
                             player.sendMessage(
                                     TranslatableCaption.of("invalid.component_illegal_block"),
-                                    Template.of("value", forbiddenType)
+                                    Template.template("value", forbiddenType)
                             );
                             return true;
                         }
@@ -142,7 +142,7 @@ public class Set extends SubCommand {
                         if (!Permissions.hasPermission(player, Permission.PERMISSION_SET_COMPONENT.format(component))) {
                             player.sendMessage(
                                     TranslatableCaption.of("permission.no_permission"),
-                                    Template.of("node", Permission.PERMISSION_SET_COMPONENT.format(component))
+                                    Template.template("node", Permission.PERMISSION_SET_COMPONENT.format(component))
                             );
                             return false;
                         }
@@ -165,7 +165,7 @@ public class Set extends SubCommand {
                                 plot.removeRunning();
                                 player.sendMessage(
                                         TranslatableCaption.of("working.component_complete"),
-                                        Template.of("plot", plot.getId().toString())
+                                        Template.template("plot", plot.getId().toString())
                                 );
                             });
                             if (Settings.QUEUE.NOTIFY_PROGRESS) {

--- a/Core/src/main/java/com/plotsquared/core/command/SetCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/SetCommand.java
@@ -48,7 +48,7 @@ public abstract class SetCommand extends SubCommand {
             if (!Permissions.hasPermission(player, Permission.PERMISSION_ADMIN_COMMAND.format(getFullId()))) {
                 player.sendMessage(
                         TranslatableCaption.of("permission.no_permission"),
-                        Template.of("node", Permission.PERMISSION_ADMIN_COMMAND.format(getFullId()))
+                        Template.template("node", Permission.PERMISSION_ADMIN_COMMAND.format(getFullId()))
                 );
                 player.sendMessage(TranslatableCaption.of("working.plot_not_claimed"));
                 return false;
@@ -58,7 +58,7 @@ public abstract class SetCommand extends SubCommand {
             if (!Permissions.hasPermission(player, Permission.PERMISSION_ADMIN_COMMAND.format(getFullId()))) {
                 player.sendMessage(
                         TranslatableCaption.of("permission.no_permission"),
-                        Template.of("node", Permission.PERMISSION_ADMIN_COMMAND.format(getFullId()))
+                        Template.template("node", Permission.PERMISSION_ADMIN_COMMAND.format(getFullId()))
                 );
                 player.sendMessage(TranslatableCaption.of("permission.no_plot_perms"));
                 return false;

--- a/Core/src/main/java/com/plotsquared/core/command/SetHome.java
+++ b/Core/src/main/java/com/plotsquared/core/command/SetHome.java
@@ -67,7 +67,7 @@ public class SetHome extends SetCommand {
             default -> {
                 player.sendMessage(
                         TranslatableCaption.of("commandconfig.command_syntax"),
-                        Template.of("value", "Use /plot set home [none]")
+                        Template.template("value", "Use /plot set home [none]")
                 );
                 return false;
             }

--- a/Core/src/main/java/com/plotsquared/core/command/Setup.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Setup.java
@@ -85,7 +85,7 @@ public class Setup extends SubCommand {
                     player.sendMessage(TranslatableCaption.of("setup.setup_not_started"));
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            Template.of("value", "Use /plot setup to start a setup process.")
+                            Template.template("value", "Use /plot setup to start a setup process.")
                     );
                     return true;
                 }

--- a/Core/src/main/java/com/plotsquared/core/command/Swap.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Swap.java
@@ -85,8 +85,8 @@ public class Swap extends SubCommand {
         return plot1.getPlotModificationManager().move(plot2, player, () -> {
         }, true).thenApply(result -> {
             if (result) {
-                player.sendMessage(TranslatableCaption.of("swap.swap_success"), Template.of("origin", String.valueOf(plot1)),
-                        Template.of("target", String.valueOf(plot2))
+                player.sendMessage(TranslatableCaption.of("swap.swap_success"), Template.template("origin", String.valueOf(plot1)),
+                        Template.template("target", String.valueOf(plot2))
                 );
                 return true;
             } else {

--- a/Core/src/main/java/com/plotsquared/core/command/Target.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Target.java
@@ -59,7 +59,7 @@ public class Target extends SubCommand {
         if (args.length == 0) {
             player.sendMessage(
                     TranslatableCaption.of("commandconfig.command_syntax"),
-                    Template.of("value", "/plot target <<X;Z> | nearest>")
+                    Template.template("value", "/plot target <<X;Z> | nearest>")
             );
             return false;
         }
@@ -83,7 +83,7 @@ public class Target extends SubCommand {
         target.getCenter(player::setCompassTarget);
         player.sendMessage(
                 TranslatableCaption.of("compass.compass_target"),
-                Template.of("target", target.toString())
+                Template.template("target", target.toString())
         );
         return true;
     }

--- a/Core/src/main/java/com/plotsquared/core/command/Template.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Template.java
@@ -176,13 +176,13 @@ public class Template extends SubCommand {
                 if (args[0].equalsIgnoreCase("export")) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            net.kyori.adventure.text.minimessage.Template.of("value", "/plot template export <world>")
+                            net.kyori.adventure.text.minimessage.Template.template("value", "/plot template export <world>")
                     );
                     return true;
                 } else if (args[0].equalsIgnoreCase("import")) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            net.kyori.adventure.text.minimessage.Template.of("value", "/plot template import <world> <template>")
+                            net.kyori.adventure.text.minimessage.Template.template("value", "/plot template import <world> <template>")
                     );
                     return true;
                 }
@@ -196,14 +196,14 @@ public class Template extends SubCommand {
                 if (args.length != 3) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            net.kyori.adventure.text.minimessage.Template.of("value", "/plot template import <world> <template>")
+                            net.kyori.adventure.text.minimessage.Template.template("value", "/plot template import <world> <template>")
                     );
                     return false;
                 }
                 if (this.plotAreaManager.hasPlotArea(world)) {
                     player.sendMessage(
                             TranslatableCaption.of("setup.setup_world_taken"),
-                            net.kyori.adventure.text.minimessage.Template.of("value", world)
+                            net.kyori.adventure.text.minimessage.Template.template("value", world)
                     );
                     return false;
                 }
@@ -211,7 +211,7 @@ public class Template extends SubCommand {
                 if (!result) {
                     player.sendMessage(
                             TranslatableCaption.of("template.invalid_template"),
-                            net.kyori.adventure.text.minimessage.Template.of("value", args[2])
+                            net.kyori.adventure.text.minimessage.Template.template("value", args[2])
                     );
                     return false;
                 }
@@ -249,7 +249,7 @@ public class Template extends SubCommand {
                 if (args.length != 2) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.command_syntax"),
-                            net.kyori.adventure.text.minimessage.Template.of("value", "/plot template export <world>")
+                            net.kyori.adventure.text.minimessage.Template.template("value", "/plot template export <world>")
                     );
                     return false;
                 }
@@ -257,7 +257,7 @@ public class Template extends SubCommand {
                 if (area == null) {
                     player.sendMessage(
                             TranslatableCaption.of("errors.not_valid_plot_world"),
-                            net.kyori.adventure.text.minimessage.Template.of("value", args[1])
+                            net.kyori.adventure.text.minimessage.Template.template("value", args[1])
                     );
                     return false;
                 }
@@ -269,7 +269,7 @@ public class Template extends SubCommand {
                         e.printStackTrace();
                         player.sendMessage(
                                 TranslatableCaption.of("template.template_failed"),
-                                net.kyori.adventure.text.minimessage.Template.of("value", e.getMessage())
+                                net.kyori.adventure.text.minimessage.Template.template("value", e.getMessage())
                         );
                         return;
                     }

--- a/Core/src/main/java/com/plotsquared/core/command/Toggle.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Toggle.java
@@ -54,12 +54,12 @@ public class Toggle extends Command {
         if (toggle(player, "chatspy")) {
             player.sendMessage(
                     TranslatableCaption.of("toggle.toggle_disabled"),
-                    Template.of("setting", command.toString())
+                    Template.template("setting", command.toString())
             );
         } else {
             player.sendMessage(
                     TranslatableCaption.of("toggle.toggle_enabled"),
-                    Template.of("setting", command.toString())
+                    Template.template("setting", command.toString())
             );
         }
     }
@@ -75,12 +75,12 @@ public class Toggle extends Command {
         if (toggle(player, "worldedit")) {
             player.sendMessage(
                     TranslatableCaption.of("toggle.toggle_disabled"),
-                    Template.of("setting", command.toString())
+                    Template.template("setting", command.toString())
             );
         } else {
             player.sendMessage(
                     TranslatableCaption.of("toggle.toggle_enabled"),
-                    Template.of("setting", command.toString())
+                    Template.template("setting", command.toString())
             );
         }
     }
@@ -95,12 +95,12 @@ public class Toggle extends Command {
         if (toggle(player, "chat")) {
             player.sendMessage(
                     TranslatableCaption.of("toggle.toggle_disabled"),
-                    Template.of("setting", command.toString())
+                    Template.template("setting", command.toString())
             );
         } else {
             player.sendMessage(
                     TranslatableCaption.of("toggle.toggle_enabled"),
-                    Template.of("setting", command.toString())
+                    Template.template("setting", command.toString())
             );
         }
     }
@@ -115,12 +115,12 @@ public class Toggle extends Command {
         if (toggle(player, "ignoreExpireTask")) {
             player.sendMessage(
                     TranslatableCaption.of("toggle.toggle_enabled"),
-                    Template.of("setting", command.toString())
+                    Template.template("setting", command.toString())
             );
         } else {
             player.sendMessage(
                     TranslatableCaption.of("toggle.toggle_disabled"),
-                    Template.of("setting", command.toString())
+                    Template.template("setting", command.toString())
             );
         }
     }
@@ -135,12 +135,12 @@ public class Toggle extends Command {
         if (toggle(player, "disabletitles")) {
             player.sendMessage(
                     TranslatableCaption.of("toggle.toggle_enabled"),
-                    Template.of("setting", command.toString())
+                    Template.template("setting", command.toString())
             );
         } else {
             player.sendMessage(
                     TranslatableCaption.of("toggle.toggle_disabled"),
-                    Template.of("setting", command.toString())
+                    Template.template("setting", command.toString())
             );
         }
     }
@@ -155,12 +155,12 @@ public class Toggle extends Command {
         if (toggle(player, "disabletime")) {
             player.sendMessage(
                     TranslatableCaption.of("toggle.toggle_enabled"),
-                    Template.of("setting", command.toString())
+                    Template.template("setting", command.toString())
             );
         } else {
             player.sendMessage(
                     TranslatableCaption.of("toggle.toggle_disabled"),
-                    Template.of("setting", command.toString())
+                    Template.template("setting", command.toString())
             );
         }
     }
@@ -175,12 +175,12 @@ public class Toggle extends Command {
         if (toggle(player, "debug")) {
             player.sendMessage(
                     TranslatableCaption.of("toggle.toggle_disabled"),
-                    Template.of("setting", command.toString())
+                    Template.template("setting", command.toString())
             );
         } else {
             player.sendMessage(
                     TranslatableCaption.of("toggle.toggle_enabled"),
-                    Template.of("setting", command.toString())
+                    Template.template("setting", command.toString())
             );
         }
         player.refreshDebug();

--- a/Core/src/main/java/com/plotsquared/core/command/Trust.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Trust.java
@@ -93,7 +93,7 @@ public class Trust extends Command {
                 } else {
                     player.sendMessage(
                             TranslatableCaption.of("errors.invalid_player"),
-                            Template.of("value", args[0])
+                            Template.template("value", args[0])
                     );
                 }
                 future.completeExceptionally(throwable);
@@ -112,7 +112,7 @@ public class Trust extends Command {
                                     .hasPermission(player, Permission.PERMISSION_ADMIN_COMMAND_TRUST))) {
                         player.sendMessage(
                                 TranslatableCaption.of("errors.invalid_player"),
-                                Template.of("value", PlayerManager.getName(uuid))
+                                Template.template("value", PlayerManager.getName(uuid))
                         );
                         iterator.remove();
                         continue;
@@ -120,7 +120,7 @@ public class Trust extends Command {
                     if (currentPlot.isOwner(uuid)) {
                         player.sendMessage(
                                 TranslatableCaption.of("member.already_added"),
-                                Template.of("value", PlayerManager.getName(uuid))
+                                Template.template("value", PlayerManager.getName(uuid))
                         );
                         iterator.remove();
                         continue;
@@ -128,7 +128,7 @@ public class Trust extends Command {
                     if (currentPlot.getTrusted().contains(uuid)) {
                         player.sendMessage(
                                 TranslatableCaption.of("member.already_added"),
-                                Template.of("value", PlayerManager.getName(uuid))
+                                Template.template("value", PlayerManager.getName(uuid))
                         );
                         iterator.remove();
                         continue;
@@ -141,7 +141,7 @@ public class Trust extends Command {
                 if (localTrustSize >= maxTrustSize) {
                     player.sendMessage(
                             TranslatableCaption.of("members.plot_max_members_trusted"),
-                            Template.of("amount", String.valueOf(localTrustSize))
+                            Template.template("amount", String.valueOf(localTrustSize))
                     );
                     return;
                 }

--- a/Core/src/main/java/com/plotsquared/core/command/Unlink.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Unlink.java
@@ -93,7 +93,7 @@ public class Unlink extends SubCommand {
         if (event.getEventResult() == Result.DENY) {
             player.sendMessage(
                     TranslatableCaption.of("events.event_denied"),
-                    Template.of("value", "Unlink")
+                    Template.template("value", "Unlink")
             );
             return true;
         }

--- a/Core/src/main/java/com/plotsquared/core/command/Visit.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Visit.java
@@ -107,8 +107,8 @@ public class Visit extends Command {
         } else if (plots.size() < page || page < 1) {
             player.sendMessage(
                     TranslatableCaption.of("invalid.number_not_in_range"),
-                    Template.of("min", "1"),
-                    Template.of("max", String.valueOf(plots.size()))
+                    Template.template("min", "1"),
+                    Template.template("max", String.valueOf(plots.size()))
             );
             return;
         }
@@ -154,7 +154,7 @@ public class Visit extends Command {
                 if (!Permissions.hasPermission(player, Permission.PERMISSION_VISIT_DENIED)) {
                     player.sendMessage(
                             TranslatableCaption.of("permission.no_permission"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_VISIT_DENIED))
+                            Template.template("node", String.valueOf(Permission.PERMISSION_VISIT_DENIED))
                     );
                     return;
                 }
@@ -257,7 +257,7 @@ public class Visit extends Command {
                 } catch (NumberFormatException ignored) {
                     player.sendMessage(
                             TranslatableCaption.of("invalid.not_a_number"),
-                            Template.of("value", args[1])
+                            Template.template("value", args[1])
                     );
                     return CompletableFuture.completedFuture(false);
                 }
@@ -290,7 +290,7 @@ public class Visit extends Command {
                             } else {
                                 player.sendMessage(
                                         TranslatableCaption.of("errors.invalid_player"),
-                                        Template.of("value", finalArgs[0])
+                                        Template.template("value", finalArgs[0])
                                 );
                             }
                         } else {

--- a/Core/src/main/java/com/plotsquared/core/command/Visit.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Visit.java
@@ -143,7 +143,7 @@ public class Visit extends Command {
             // allow visit, if UntrustedVisit flag is set, or if the player has either the plot.visit.other or
             // plot.admin.visit.untrusted permission
             if (!plot.getFlag(UntrustedVisitFlag.class) && !Permissions.hasPermission(player, Permission.PERMISSION_VISIT_OTHER)
-                && !Permissions.hasPermission(player, Permission.PERMISSION_ADMIN_VISIT_UNTRUSTED)) {
+                    && !Permissions.hasPermission(player, Permission.PERMISSION_ADMIN_VISIT_UNTRUSTED)) {
                 player.sendMessage(
                         TranslatableCaption.of("permission.no_permission"),
                         Templates.of("node", "plots.visit.other")

--- a/Core/src/main/java/com/plotsquared/core/components/ComponentPresetManager.java
+++ b/Core/src/main/java/com/plotsquared/core/components/ComponentPresetManager.java
@@ -217,7 +217,7 @@ public class ComponentPresetManager {
                         econHandler.withdrawMoney(getPlayer(), componentPreset.getCost());
                         getPlayer().sendMessage(
                                 TranslatableCaption.of("economy.removed_balance"),
-                                Template.of("money", econHandler.format(componentPreset.getCost()))
+                                Template.template("money", econHandler.format(componentPreset.getCost()))
                         );
                     }
                 }
@@ -248,13 +248,13 @@ public class ComponentPresetManager {
             if (preset.getCost() > 0 && this.econHandler.isEnabled(plot.getArea())) {
                 lore.add(MINI_MESSAGE.serialize(MINI_MESSAGE.parse(
                         TranslatableCaption.of("preset.preset_lore_cost").getComponent(player),
-                        Template.of("cost", String.format("%.2f", preset.getCost()))
+                        Template.template("cost", String.format("%.2f", preset.getCost()))
                 )));
             }
             lore.add(MINI_MESSAGE.serialize(MINI_MESSAGE.parse(
                     TranslatableCaption.of("preset.preset_lore_component").getComponent(player),
-                    Template.of("component", preset.getComponent().name().toLowerCase()),
-                    Template.of("prefix", TranslatableCaption.of("core.prefix").getComponent(player))
+                    Template.template("component", preset.getComponent().name().toLowerCase()),
+                    Template.template("prefix", TranslatableCaption.of("core.prefix").getComponent(player))
             )));
             lore.removeIf(String::isEmpty);
             lore.addAll(preset.getDescription());

--- a/Core/src/main/java/com/plotsquared/core/components/ComponentPresetManager.java
+++ b/Core/src/main/java/com/plotsquared/core/components/ComponentPresetManager.java
@@ -47,6 +47,7 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.item.ItemTypes;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -246,15 +247,15 @@ public class ComponentPresetManager {
             final ComponentPreset preset = allowedPresets.get(i);
             final List<String> lore = new ArrayList<>();
             if (preset.getCost() > 0 && this.econHandler.isEnabled(plot.getArea())) {
-                lore.add(MINI_MESSAGE.serialize(MINI_MESSAGE.parse(
+                lore.add(MINI_MESSAGE.serialize(MINI_MESSAGE.deserialize(
                         TranslatableCaption.of("preset.preset_lore_cost").getComponent(player),
-                        Template.template("cost", String.format("%.2f", preset.getCost()))
+                        TemplateResolver.templates(Template.template("cost", String.format("%.2f", preset.getCost())))
                 )));
             }
-            lore.add(MINI_MESSAGE.serialize(MINI_MESSAGE.parse(
+            lore.add(MINI_MESSAGE.serialize(MINI_MESSAGE.deserialize(
                     TranslatableCaption.of("preset.preset_lore_component").getComponent(player),
-                    Template.template("component", preset.getComponent().name().toLowerCase()),
-                    Template.template("prefix", TranslatableCaption.of("core.prefix").getComponent(player))
+                    TemplateResolver.templates(Template.template("component", preset.getComponent().name().toLowerCase()),
+                            Template.template("prefix", TranslatableCaption.of("core.prefix").getComponent(player)))
             )));
             lore.removeIf(String::isEmpty);
             lore.addAll(preset.getDescription());

--- a/Core/src/main/java/com/plotsquared/core/configuration/ConfigurationSection.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/ConfigurationSection.java
@@ -74,7 +74,7 @@ public interface ConfigurationSection {
      *
      * @param path Path to check for existence.
      * @return True if this section contains the requested path, either via
-     *         default or being set.
+     * default or being set.
      * @throws IllegalArgumentException Thrown when path is {@code null}.
      */
     boolean contains(String path);
@@ -88,7 +88,7 @@ public interface ConfigurationSection {
      *
      * @param path Path to check for existence.
      * @return True if this section contains the requested path, regardless of
-     *         having a default.
+     * having a default.
      * @throws IllegalArgumentException Thrown when path is {@code null}.
      */
     boolean isSet(String path);

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/CaptionUtility.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/CaptionUtility.java
@@ -106,9 +106,9 @@ public class CaptionUtility {
      */
     public static String stripClickEvents(final @NonNull String miniMessageString) {
         // parse, transform and serialize again
-        Component component = MiniMessage.get().parse(miniMessageString);
+        Component component = MiniMessage.miniMessage().parse(miniMessageString);
         component = CLICK_STRIP_TRANSFORM.transform(component);
-        return MiniMessage.get().serialize(component);
+        return MiniMessage.miniMessage().serialize(component);
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/CaptionUtility.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/CaptionUtility.java
@@ -61,6 +61,7 @@ public class CaptionUtility {
             )
     );
 
+    private static final MiniMessage MINI_MESSAGE = MiniMessage.miniMessage();
 
     /**
      * Format a chat message but keep the formatting keys
@@ -106,9 +107,9 @@ public class CaptionUtility {
      */
     public static String stripClickEvents(final @NonNull String miniMessageString) {
         // parse, transform and serialize again
-        Component component = MiniMessage.miniMessage().parse(miniMessageString);
+        Component component = MINI_MESSAGE.parse(miniMessageString);
         component = CLICK_STRIP_TRANSFORM.transform(component);
-        return MiniMessage.miniMessage().serialize(component);
+        return MINI_MESSAGE.serialize(component);
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/Templates.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/Templates.java
@@ -59,7 +59,7 @@ public final class Templates {
             final @NonNull String key, final @NonNull Caption caption,
             final @NonNull Template... replacements
     ) {
-        return Template.of(key, MINI_MESSAGE.parse(caption.getComponent(localeHolder), replacements));
+        return Template.template(key, MINI_MESSAGE.parse(caption.getComponent(localeHolder), replacements));
     }
 
     /**
@@ -71,7 +71,7 @@ public final class Templates {
      */
     public static @NonNull Template of(final @NonNull String key, final @NonNull UUID uuid) {
         final String username = PlayerManager.getName(uuid);
-        return Template.of(key, username);
+        return Template.template(key, username);
     }
 
     /**
@@ -82,7 +82,7 @@ public final class Templates {
      * @return Generated template
      */
     public static @NonNull Template of(final @NonNull String key, final @NonNull String value) {
-        return Template.of(key, value);
+        return Template.template(key, value);
     }
 
     /**
@@ -93,7 +93,7 @@ public final class Templates {
      * @return Generated template
      */
     public static @NonNull Template of(final @NonNull String key, final @NonNull PlotArea area) {
-        return Template.of(key, area.toString());
+        return Template.template(key, area.toString());
     }
 
     /**
@@ -104,7 +104,7 @@ public final class Templates {
      * @return Generated template
      */
     public static @NonNull Template of(final @NonNull String key, final @NonNull Number number) {
-        return Template.of(key, number.toString());
+        return Template.template(key, number.toString());
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/Templates.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/Templates.java
@@ -29,6 +29,7 @@ import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.util.PlayerManager;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.UUID;
@@ -53,13 +54,38 @@ public final class Templates {
      * @param caption      Caption object
      * @param replacements Replacements
      * @return Generated template
+     *
+     * @deprecated Use {@link #template(LocaleHolder, String, Caption, Template...)} instead. This method is going to
+     * be removed once MiniMessage drops {@link MiniMessage#parse(String, Template...)}
      */
+    @Deprecated(forRemoval = true, since = "6.2.0")
+    @SuppressWarnings("all")
     public static @NonNull Template of(
             final @NonNull LocaleHolder localeHolder,
             final @NonNull String key, final @NonNull Caption caption,
             final @NonNull Template... replacements
     ) {
         return Template.template(key, MINI_MESSAGE.parse(caption.getComponent(localeHolder), replacements));
+    }
+
+    /**
+     * Create a {@link net.kyori.adventure.text.minimessage.Template} from a PlotSquared {@link Caption}
+     *
+     * @param localeHolder Locale holder
+     * @param key          Template key
+     * @param caption      Caption object
+     * @param replacements Replacements
+     * @return Generated template
+     *
+     * @since 6.2.0
+     */
+    public static @NonNull Template template(
+            final @NonNull LocaleHolder localeHolder,
+            final @NonNull String key, final @NonNull Caption caption,
+            final @NonNull Template... replacements
+    ) {
+        return Template.template(key, MINI_MESSAGE.deserialize(caption.getComponent(localeHolder),
+                TemplateResolver.templates(replacements)));
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/Templates.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/Templates.java
@@ -54,7 +54,6 @@ public final class Templates {
      * @param caption      Caption object
      * @param replacements Replacements
      * @return Generated template
-     *
      * @deprecated Use {@link #template(LocaleHolder, String, Caption, Template...)} instead. This method is going to
      * be removed once MiniMessage drops {@link MiniMessage#parse(String, Template...)}
      */
@@ -75,7 +74,6 @@ public final class Templates {
      * @param caption      Caption object
      * @param replacements Replacements
      * @return Generated template
-     *
      * @since 6.2.0
      */
     public static @NonNull Template template(

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/Templates.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/Templates.java
@@ -59,7 +59,6 @@ public final class Templates {
      * be removed once MiniMessage drops {@link MiniMessage#parse(String, Template...)}
      */
     @Deprecated(forRemoval = true, since = "6.2.0")
-    @SuppressWarnings("all")
     public static @NonNull Template of(
             final @NonNull LocaleHolder localeHolder,
             final @NonNull String key, final @NonNull Caption caption,

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/package-info.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/package-info.java
@@ -1,0 +1,62 @@
+/*
+ *       _____  _       _    _____                                _
+ *      |  __ \| |     | |  / ____|                              | |
+ *      | |__) | | ___ | |_| (___   __ _ _   _  __ _ _ __ ___  __| |
+ *      |  ___/| |/ _ \| __|\___ \ / _` | | | |/ _` | '__/ _ \/ _` |
+ *      | |    | | (_) | |_ ____) | (_| | |_| | (_| | | |  __/ (_| |
+ *      |_|    |_|\___/ \__|_____/ \__, |\__,_|\__,_|_|  \___|\__,_|
+ *                                    | |
+ *                                    |_|
+ *            PlotSquared plot management system for Minecraft
+ *                  Copyright (C) 2021 IntellectualSites
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+/**
+ * Future versions of MiniMessage, starting of 4.10.0, have a different naming convention. If PlotSquared updates
+ * MiniMessage, certain methods are going to be renamed to keep up consistency with the new naming convention.
+ * <br>
+ * The existing methods have not been deprecated yet, since we don't know when we will update MiniMessage, but we know
+ * it likely will be a major update, because MiniMessage 4.10.0 did not retain backwards compatibility.
+ * <br>
+ * <table border="1">
+ *     <caption>MiniMessage naming convention relevant for PlotSquared API</caption>
+ *   <tr>
+ *     <td>Current method</td>
+ *     <td>Future change</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link net.kyori.adventure.text.minimessage.Template}</td> <td>{@code Placeholder}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link net.kyori.adventure.text.minimessage.Template#template(java.lang.String, java.lang.String)}</td> <td>{@code Placeholder#component(String, ComponentLike)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link net.kyori.adventure.text.minimessage.template.TemplateResolver}</td> <td>{@code PlaceholderResolver}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link net.kyori.adventure.text.minimessage.template.TemplateResolver#templates(net.kyori.adventure.text.minimessage.Template...)}</td> <td>{@code PlaceholderResolver#placeholders}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link net.kyori.adventure.text.minimessage.MiniMessage#parse(java.lang.String)}</td> <td>{@code MiniMessage#deserialize()}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link net.kyori.adventure.text.minimessage.MiniMessage#get()}</td> <td>{@code MiniMessage#miniMessage()}</td>
+ *   </tr>
+ * </table>
+ * <br>
+ * This table has been added in 6.2.0
+ *
+ */
+package com.plotsquared.core.configuration.caption;

--- a/Core/src/main/java/com/plotsquared/core/generator/HybridPlotManager.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridPlotManager.java
@@ -46,7 +46,6 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BaseBlock;
-import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;

--- a/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
@@ -334,7 +334,7 @@ public class HybridPlotWorld extends ClassicPlotWorld {
                 LOGGER.info("- plot schematic: {}", schematic3File.getPath());
             }
         }
-        if ((schematic1 == null&& schematic2 == null) || this.ROAD_WIDTH == 0) {
+        if ((schematic1 == null && schematic2 == null) || this.ROAD_WIDTH == 0) {
             if (Settings.DEBUG) {
                 LOGGER.info("- schematic: false");
             }

--- a/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
+++ b/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
@@ -146,7 +146,7 @@ public class PlotListener {
                 .hasPermission(player, "plots.admin.entry.denied")) {
             player.sendMessage(
                     TranslatableCaption.of("deny.no_enter"),
-                    Template.of("plot", plot.toString())
+                    Template.template("plot", plot.toString())
             );
             return false;
         }
@@ -176,18 +176,18 @@ public class PlotListener {
                 if (!Settings.Chat.NOTIFICATION_AS_ACTIONBAR) {
                     player.sendMessage(
                             TranslatableCaption.of("flags.greeting_flag_format"),
-                            Template.of("world", plot.getWorldName()),
-                            Template.of("plot_id", plot.getId().toString()),
-                            Template.of("alias", plot.getAlias()),
-                            Template.of("greeting", greeting)
+                            Template.template("world", plot.getWorldName()),
+                            Template.template("plot_id", plot.getId().toString()),
+                            Template.template("alias", plot.getAlias()),
+                            Template.template("greeting", greeting)
                     );
                 } else {
                     player.sendActionBar(
                             TranslatableCaption.of("flags.greeting_flag_format"),
-                            Template.of("world", plot.getWorldName()),
-                            Template.of("plot_id", plot.getId().toString()),
-                            Template.of("alias", plot.getAlias()),
-                            Template.of("greeting", greeting)
+                            Template.template("world", plot.getWorldName()),
+                            Template.template("plot_id", plot.getId().toString()),
+                            Template.template("alias", plot.getAlias()),
+                            Template.template("greeting", greeting)
                     );
                 }
             }
@@ -198,8 +198,8 @@ public class PlotListener {
                         final PlotPlayer<?> owner = PlotSquared.platform().playerManager().getPlayerIfExists(uuid);
                         if (owner != null && !owner.getUUID().equals(player.getUUID()) && owner.canSee(player)) {
                             Caption caption = TranslatableCaption.of("notification.notify_enter");
-                            Template playerTemplate = Template.of("player", player.getName());
-                            Template plotTemplate = Template.of("plot", plot.getId().toString());
+                            Template playerTemplate = Template.template("player", player.getName());
+                            Template plotTemplate = Template.template("plot", plot.getId().toString());
                             if (!Settings.Chat.NOTIFICATION_AS_ACTIONBAR) {
                                 owner.sendMessage(caption, playerTemplate, plotTemplate);
                             } else {
@@ -232,8 +232,8 @@ public class PlotListener {
                     } else {
                         player.sendMessage(
                                 TranslatableCaption.of("gamemode.gamemode_was_bypassed"),
-                                Template.of("gamemode", String.valueOf(gameMode)),
-                                Template.of("plot", plot.getId().toString())
+                                Template.template("gamemode", String.valueOf(gameMode)),
+                                Template.template("plot", plot.getId().toString())
                         );
                     }
                 }
@@ -247,8 +247,8 @@ public class PlotListener {
                     } else {
                         player.sendMessage(
                                 TranslatableCaption.of("gamemode.gamemode_was_bypassed"),
-                                Template.of("gamemode", String.valueOf(guestGameMode)),
-                                Template.of("plot", plot.getId().toString())
+                                Template.template("gamemode", String.valueOf(guestGameMode)),
+                                Template.template("plot", plot.getId().toString())
                         );
                     }
                 }
@@ -332,10 +332,10 @@ public class PlotListener {
                                     ".title_entered_plot");
                             Caption subHeader = fromFlag ? StaticCaption.of(subtitle) : TranslatableCaption.of("titles" +
                                     ".title_entered_plot_sub");
-                            Template plotTemplate = Template.of("plot", lastPlot.getId().toString());
-                            Template worldTemplate = Template.of("world", player.getLocation().getWorldName());
-                            Template ownerTemplate = Template.of("owner", owner);
-                            Template aliasTemplate = Template.of("alias", plot.getAlias());
+                            Template plotTemplate = Template.template("plot", lastPlot.getId().toString());
+                            Template worldTemplate = Template.template("world", player.getLocation().getWorldName());
+                            Template ownerTemplate = Template.template("owner", owner);
+                            Template aliasTemplate = Template.template("alias", plot.getAlias());
 
                             final Consumer<String> userConsumer = user -> {
                                 if (Settings.Titles.TITLES_AS_ACTIONBAR) {
@@ -409,8 +409,8 @@ public class PlotListener {
                         } else {
                             player.sendMessage(
                                     TranslatableCaption.of("gamemode.gamemode_was_bypassed"),
-                                    Template.of("gamemode", pw.getGameMode().getName().toLowerCase()),
-                                    Template.of("plot", plot.toString())
+                                    Template.template("gamemode", pw.getGameMode().getName().toLowerCase()),
+                                    Template.template("plot", plot.toString())
                             );
                         }
                     }
@@ -421,18 +421,18 @@ public class PlotListener {
                     if (!Settings.Chat.NOTIFICATION_AS_ACTIONBAR) {
                         player.sendMessage(
                                 TranslatableCaption.of("flags.farewell_flag_format"),
-                                Template.of("world", plot.getWorldName()),
-                                Template.of("plot_id", plot.getId().toString()),
-                                Template.of("alias", plot.getAlias()),
-                                Template.of("farewell", farewell)
+                                Template.template("world", plot.getWorldName()),
+                                Template.template("plot_id", plot.getId().toString()),
+                                Template.template("alias", plot.getAlias()),
+                                Template.template("farewell", farewell)
                         );
                     } else {
                         player.sendActionBar(
                                 TranslatableCaption.of("flags.farewell_flag_format"),
-                                Template.of("world", plot.getWorldName()),
-                                Template.of("plot_id", plot.getId().toString()),
-                                Template.of("alias", plot.getAlias()),
-                                Template.of("farewell", farewell)
+                                Template.template("world", plot.getWorldName()),
+                                Template.template("plot_id", plot.getId().toString()),
+                                Template.template("alias", plot.getAlias()),
+                                Template.template("farewell", farewell)
                         );
                     }
                 }
@@ -443,8 +443,8 @@ public class PlotListener {
                             final PlotPlayer<?> owner = PlotSquared.platform().playerManager().getPlayerIfExists(uuid);
                             if ((owner != null) && !owner.getUUID().equals(player.getUUID()) && owner.canSee(player)) {
                                 Caption caption = TranslatableCaption.of("notification.notify_leave");
-                                Template playerTemplate = Template.of("player", player.getName());
-                                Template plotTemplate = Template.of("plot", plot.getId().toString());
+                                Template playerTemplate = Template.template("player", player.getName());
+                                Template plotTemplate = Template.template("plot", plot.getId().toString());
                                 if (!Settings.Chat.NOTIFICATION_AS_ACTIONBAR) {
                                     owner.sendMessage(caption, playerTemplate, plotTemplate);
                                 } else {

--- a/Core/src/main/java/com/plotsquared/core/listener/WESubscriber.java
+++ b/Core/src/main/java/com/plotsquared/core/listener/WESubscriber.java
@@ -98,7 +98,7 @@ public class WESubscriber {
                     if (Permissions.hasPermission(plotPlayer, "plots.worldedit.bypass")) {
                         plotPlayer.sendMessage(
                                 TranslatableCaption.of("worldedit.worldedit_bypass"),
-                                Template.of("command", "/plot toggle worldedit")
+                                Template.template("command", "/plot toggle worldedit")
                         );
                     }
                     if (this.plotAreaManager.hasPlotArea(world)) {

--- a/Core/src/main/java/com/plotsquared/core/player/ConsolePlayer.java
+++ b/Core/src/main/java/com/plotsquared/core/player/ConsolePlayer.java
@@ -50,6 +50,7 @@ import com.sk89q.worldedit.world.item.ItemType;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.UUID;
@@ -161,7 +162,8 @@ public class ConsolePlayer extends PlotPlayer<Actor> {
                 .replace('\u2010', '%').replace('\u2020', '&').replace('\u2030', '&')
                 .replace("<prefix>", TranslatableCaption.of("core.prefix").getComponent(this));
         // Parse the message
-        PlotSquared.platform().consoleAudience().sendMessage(MINI_MESSAGE.parse(message, replacements));
+        PlotSquared.platform().consoleAudience().sendMessage(MINI_MESSAGE.deserialize(message,
+                TemplateResolver.templates(replacements)));
     }
 
     @Override

--- a/Core/src/main/java/com/plotsquared/core/player/MetaDataAccess.java
+++ b/Core/src/main/java/com/plotsquared/core/player/MetaDataAccess.java
@@ -62,7 +62,7 @@ public abstract class MetaDataAccess<T> implements AutoCloseable {
      * Check if the player has meta data stored with the given key
      *
      * @return {@code true} if player has meta data with this key, or
-     *         {@code false}
+     * {@code false}
      */
     public abstract boolean isPresent();
 

--- a/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
+++ b/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
@@ -67,6 +67,7 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import net.kyori.adventure.title.Title;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -866,9 +867,9 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
             final int fadeIn, final int stay, final int fadeOut,
             final @NonNull Template... replacements
     ) {
-        final Component titleComponent = MiniMessage.get().parse(title.getComponent(this), replacements);
+        final Component titleComponent = MiniMessage.miniMessage().deserialize(title.getComponent(this), TemplateResolver.templates(replacements));
         final Component subtitleComponent =
-                MiniMessage.get().parse(subtitle.getComponent(this), replacements);
+                MiniMessage.miniMessage().deserialize(subtitle.getComponent(this), TemplateResolver.templates(replacements));
         final Title.Times times = Title.Times.of(
                 Duration.of(Settings.Titles.TITLES_FADE_IN * 50L, ChronoUnit.MILLIS),
                 Duration.of(Settings.Titles.TITLES_STAY * 50L, ChronoUnit.MILLIS),
@@ -906,7 +907,7 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
                 .replace("<prefix>", TranslatableCaption.of("core.prefix").getComponent(this));
 
 
-        final Component component = MiniMessage.get().parse(message, replacements);
+        final Component component = MiniMessage.miniMessage().deserialize(message, TemplateResolver.templates(replacements));
         getAudience().sendActionBar(component);
     }
 
@@ -932,7 +933,7 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
                 .replace('\u2010', '%').replace('\u2020', '&').replace('\u2030', '&')
                 .replace("<prefix>", TranslatableCaption.of("core.prefix").getComponent(this));
         // Parse the message
-        final Component component = MiniMessage.get().parse(message, replacements);
+        final Component component = MiniMessage.miniMessage().deserialize(message, TemplateResolver.templates(replacements));
         if (!Objects.equal(component, this.getMeta("lastMessage"))
                 || System.currentTimeMillis() - this.<Long>getMeta("lastMessageTime") > 5000) {
             setMeta("lastMessage", component);

--- a/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
+++ b/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
@@ -106,6 +106,7 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
             Collections.synchronizedSet(new HashSet<>());
 
     private static final Map<Class, PlotPlayerConverter> converters = new HashMap<>();
+    private static final MiniMessage MINI_MESSAGE = MiniMessage.miniMessage();
     private final LockRepository lockRepository = new LockRepository();
     private final PlotAreaManager plotAreaManager;
     private final EventDispatcher eventDispatcher;
@@ -119,7 +120,6 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
     private Locale locale;
     // Delayed initialisation
     private PermissionProfile permissionProfile;
-    private static final MiniMessage MINI_MESSAGE = MiniMessage.miniMessage();
 
     public PlotPlayer(
             final @NonNull PlotAreaManager plotAreaManager, final @NonNull EventDispatcher eventDispatcher,

--- a/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
+++ b/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
@@ -119,6 +119,7 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
     private Locale locale;
     // Delayed initialisation
     private PermissionProfile permissionProfile;
+    private static final MiniMessage MINI_MESSAGE = MiniMessage.miniMessage();
 
     public PlotPlayer(
             final @NonNull PlotAreaManager plotAreaManager, final @NonNull EventDispatcher eventDispatcher,
@@ -867,9 +868,9 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
             final int fadeIn, final int stay, final int fadeOut,
             final @NonNull Template... replacements
     ) {
-        final Component titleComponent = MiniMessage.miniMessage().deserialize(title.getComponent(this), TemplateResolver.templates(replacements));
+        final Component titleComponent = MINI_MESSAGE.deserialize(title.getComponent(this), TemplateResolver.templates(replacements));
         final Component subtitleComponent =
-                MiniMessage.miniMessage().deserialize(subtitle.getComponent(this), TemplateResolver.templates(replacements));
+                MINI_MESSAGE.deserialize(subtitle.getComponent(this), TemplateResolver.templates(replacements));
         final Title.Times times = Title.Times.of(
                 Duration.of(Settings.Titles.TITLES_FADE_IN * 50L, ChronoUnit.MILLIS),
                 Duration.of(Settings.Titles.TITLES_STAY * 50L, ChronoUnit.MILLIS),
@@ -907,7 +908,7 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
                 .replace("<prefix>", TranslatableCaption.of("core.prefix").getComponent(this));
 
 
-        final Component component = MiniMessage.miniMessage().deserialize(message, TemplateResolver.templates(replacements));
+        final Component component = MINI_MESSAGE.deserialize(message, TemplateResolver.templates(replacements));
         getAudience().sendActionBar(component);
     }
 
@@ -933,7 +934,7 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
                 .replace('\u2010', '%').replace('\u2020', '&').replace('\u2030', '&')
                 .replace("<prefix>", TranslatableCaption.of("core.prefix").getComponent(this));
         // Parse the message
-        final Component component = MiniMessage.miniMessage().deserialize(message, TemplateResolver.templates(replacements));
+        final Component component = MINI_MESSAGE.deserialize(message, TemplateResolver.templates(replacements));
         if (!Objects.equal(component, this.getMeta("lastMessage"))
                 || System.currentTimeMillis() - this.<Long>getMeta("lastMessageTime") > 5000) {
             setMeta("lastMessage", component);

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -40,7 +40,6 @@ import com.plotsquared.core.database.DBFunc;
 import com.plotsquared.core.events.Result;
 import com.plotsquared.core.events.TeleportCause;
 import com.plotsquared.core.generator.ClassicPlotWorld;
-import com.plotsquared.core.generator.HybridPlotWorld;
 import com.plotsquared.core.listener.PlotListener;
 import com.plotsquared.core.location.BlockLoc;
 import com.plotsquared.core.location.Direction;
@@ -80,6 +79,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -449,7 +449,7 @@ public class Plot {
      * that could alter the de facto owner of the plot.
      *
      * @return The plot owner of this particular (sub-)plot
-     *         as stored in the database, if one exists. Else, null.
+     * as stored in the database, if one exists. Else, null.
      */
     public @Nullable UUID getOwnerAbs() {
         return this.owner;
@@ -1201,12 +1201,12 @@ public class Plot {
      *
      * @return array of entity counts
      * @see RegionManager#countEntities(Plot)
-     *         0 = Entity
-     *         1 = Animal
-     *         2 = Monster
-     *         3 = Mob
-     *         4 = Boat
-     *         5 = Misc
+     * 0 = Entity
+     * 1 = Animal
+     * 2 = Monster
+     * 3 = Mob
+     * 4 = Boat
+     * 5 = Misc
      */
     public int[] countEntities() {
         int[] count = new int[6];
@@ -1564,7 +1564,7 @@ public class Plot {
                 x = bot.getX() + loc.getX();
                 z = bot.getZ() + loc.getZ();
             }
-            if (loc.getY()  == Integer.MIN_VALUE) {
+            if (loc.getY() == Integer.MIN_VALUE) {
                 if (isLoaded()) {
                     this.worldUtil.getHighestBlock(
                             plot.getWorldName(),
@@ -1707,7 +1707,7 @@ public class Plot {
             updateWorldBorder();
         }
         this.getPlotModificationManager().setSign(player.getName());
-        player.sendMessage(TranslatableCaption.of("working.claimed"), Template.of("plot", this.getId().toString()));
+        player.sendMessage(TranslatableCaption.of("working.claimed"), Template.template("plot", this.getId().toString()));
         if (teleport) {
             if (!auto && Settings.Teleport.ON_CLAIM) {
                 teleportPlayer(player, TeleportCause.COMMAND_CLAIM, result -> {
@@ -2575,8 +2575,8 @@ public class Plot {
                 return;
             }
             Caption caption = TranslatableCaption.of("debug.plot_debug");
-            Template plotTemplate = Template.of("plot", this.toString());
-            Template messageTemplate = Template.of("message", message);
+            Template plotTemplate = Template.template("plot", this.toString());
+            Template messageTemplate = Template.template("message", message);
             for (final PlotPlayer<?> player : players) {
                 if (isOwner(player.getUUID()) || Permissions.hasPermission(player, Permission.PERMISSION_ADMIN_DEBUG_OTHER)) {
                     player.sendMessage(caption, plotTemplate, messageTemplate);
@@ -2609,7 +2609,7 @@ public class Plot {
         if (result == Result.DENY) {
             player.sendMessage(
                     TranslatableCaption.of("events.event_denied"),
-                    Template.of("value", "Teleport")
+                    Template.template("value", "Teleport")
             );
             resultConsumer.accept(false);
             return;
@@ -2624,7 +2624,7 @@ public class Plot {
             }
             player.sendMessage(
                     TranslatableCaption.of("teleport.teleport_in_seconds"),
-                    Template.of("amount", String.valueOf(Settings.Teleport.DELAY))
+                    Template.template("amount", String.valueOf(Settings.Teleport.DELAY))
             );
             final String name = player.getName();
             TaskManager.addToTeleportQueue(name);
@@ -2845,13 +2845,12 @@ public class Plot {
                             } else {
                                 value = flag.toString();
                             }
-                            Component snip = MINI_MESSAGE.parse(
+                            Component snip = MINI_MESSAGE.deserialize(
                                     prefix + CaptionUtility.format(
                                             player,
-                                            TranslatableCaption.of("info.plot_flag_list").getComponent(player)
-                                    ),
-                                    Template.of("flag", flag.getName()),
-                                    Template.of("value", CaptionUtility.formatRaw(player, value.toString()))
+                                            TranslatableCaption.of("info.plot_flag_list").getComponent(player)),
+                                    TemplateResolver.templates(Template.template("flag", flag.getName()),
+                                            Template.template("value", CaptionUtility.formatRaw(player, value.toString())))
                             );
                             flagBuilder.append(snip);
                             prefix = ", ";
@@ -2869,51 +2868,51 @@ public class Plot {
                     } else {
                         owner = PlayerManager.getPlayerList(this.getOwners(), player);
                     }
-                    Template headerTemplate = Template.of(
+                    Template headerTemplate = Template.template(
                             "header",
                             TranslatableCaption.of("info.plot_info_header").getComponent(player)
                     );
-                    Template footerTemplate = Template.of(
+                    Template footerTemplate = Template.template(
                             "footer",
                             TranslatableCaption.of("info.plot_info_footer").getComponent(player)
                     );
                     Template areaTemplate;
                     if (this.getArea() != null) {
                         areaTemplate =
-                                Template.of(
+                                Template.template(
                                         "area",
                                         this.getArea().getWorldName() + (this.getArea().getId() == null
                                                 ? ""
                                                 : "(" + this.getArea().getId() + ")")
                                 );
                     } else {
-                        areaTemplate = Template.of("area", TranslatableCaption.of("info.none").getComponent(player));
+                        areaTemplate = Template.template("area", TranslatableCaption.of("info.none").getComponent(player));
                     }
                     long creationDate = Long.parseLong(String.valueOf(timestamp));
                     SimpleDateFormat sdf = new SimpleDateFormat(Settings.Timeformat.DATE_FORMAT);
                     sdf.setTimeZone(TimeZone.getTimeZone(Settings.Timeformat.TIME_ZONE));
                     String newDate = sdf.format(creationDate);
 
-                    Template idTemplate = Template.of("id", this.getId().toString());
-                    Template aliasTemplate = Template.of("alias", alias);
-                    Template numTemplate = Template.of("num", String.valueOf(num));
-                    Template descTemplate = Template.of("desc", description);
-                    Template biomeTemplate = Template.of("biome", biome.toString().toLowerCase());
-                    Template ownerTemplate = Template.of("owner", owner);
-                    Template membersTemplate = Template.of("members", members);
-                    Template playerTemplate = Template.of("player", player.getName());
-                    Template trustedTemplate = Template.of("trusted", trusted);
-                    Template helpersTemplate = Template.of("helpers", members);
-                    Template deniedTemplate = Template.of("denied", denied);
-                    Template seenTemplate = Template.of("seen", seen);
-                    Template flagsTemplate = Template.of("flags", flags);
-                    Template creationTemplate = Template.of("creationdate", newDate);
-                    Template buildTemplate = Template.of("build", String.valueOf(build));
+                    Template idTemplate = Template.template("id", this.getId().toString());
+                    Template aliasTemplate = Template.template("alias", alias);
+                    Template numTemplate = Template.template("num", String.valueOf(num));
+                    Template descTemplate = Template.template("desc", description);
+                    Template biomeTemplate = Template.template("biome", biome.toString().toLowerCase());
+                    Template ownerTemplate = Template.template("owner", owner);
+                    Template membersTemplate = Template.template("members", members);
+                    Template playerTemplate = Template.template("player", player.getName());
+                    Template trustedTemplate = Template.template("trusted", trusted);
+                    Template helpersTemplate = Template.template("helpers", members);
+                    Template deniedTemplate = Template.template("denied", denied);
+                    Template seenTemplate = Template.template("seen", seen);
+                    Template flagsTemplate = Template.template("flags", flags);
+                    Template creationTemplate = Template.template("creationdate", newDate);
+                    Template buildTemplate = Template.template("build", String.valueOf(build));
                     if (iInfo.getComponent(player).contains("<rating>")) {
                         TaskManager.runTaskAsync(() -> {
                             Template ratingTemplate;
                             if (Settings.Ratings.USE_LIKES) {
-                                ratingTemplate = Template.of(
+                                ratingTemplate = Template.template(
                                         "rating",
                                         String.format("%.0f%%", Like.getLikesPercentage(this) * 100D)
                                 );
@@ -2931,13 +2930,13 @@ public class Plot {
                                                 .append(String.format("%.1f", ratings[i]));
                                         prefix = ",";
                                     }
-                                    ratingTemplate = Template.of("rating", rating.toString());
+                                    ratingTemplate = Template.template("rating", rating.toString());
                                 } else {
                                     double rating = this.getAverageRating();
                                     if (Double.isFinite(rating)) {
-                                        ratingTemplate = Template.of("rating", String.format("%.1f", rating) + '/' + max);
+                                        ratingTemplate = Template.template("rating", String.format("%.1f", rating) + '/' + max);
                                     } else {
-                                        ratingTemplate = Template.of(
+                                        ratingTemplate = Template.template(
                                                 "rating",
                                                 TranslatableCaption.of("info.none").getComponent(player)
                                         );
@@ -2945,9 +2944,35 @@ public class Plot {
                                 }
                             }
                             future.complete(StaticCaption.of(MINI_MESSAGE.serialize(MINI_MESSAGE
-                                    .parse(
+                                    .deserialize(
                                             iInfo.getComponent(player),
-                                            headerTemplate,
+                                            TemplateResolver.templates(headerTemplate,
+                                                    areaTemplate,
+                                                    idTemplate,
+                                                    aliasTemplate,
+                                                    numTemplate,
+                                                    descTemplate,
+                                                    biomeTemplate,
+                                                    ownerTemplate,
+                                                    membersTemplate,
+                                                    playerTemplate,
+                                                    trustedTemplate,
+                                                    helpersTemplate,
+                                                    deniedTemplate,
+                                                    seenTemplate,
+                                                    flagsTemplate,
+                                                    buildTemplate,
+                                                    ratingTemplate,
+                                                    creationTemplate,
+                                                    footerTemplate)
+                                    ))));
+                        });
+                        return;
+                    }
+                    future.complete(StaticCaption.of(MINI_MESSAGE.serialize(MINI_MESSAGE
+                            .deserialize(
+                                    iInfo.getComponent(player),
+                                    TemplateResolver.templates(headerTemplate,
                                             areaTemplate,
                                             idTemplate,
                                             aliasTemplate,
@@ -2963,33 +2988,7 @@ public class Plot {
                                             seenTemplate,
                                             flagsTemplate,
                                             buildTemplate,
-                                            ratingTemplate,
-                                            creationTemplate,
-                                            footerTemplate
-                                    ))));
-                        });
-                        return;
-                    }
-                    future.complete(StaticCaption.of(MINI_MESSAGE.serialize(MINI_MESSAGE
-                            .parse(
-                                    iInfo.getComponent(player),
-                                    headerTemplate,
-                                    areaTemplate,
-                                    idTemplate,
-                                    aliasTemplate,
-                                    numTemplate,
-                                    descTemplate,
-                                    biomeTemplate,
-                                    ownerTemplate,
-                                    membersTemplate,
-                                    playerTemplate,
-                                    trustedTemplate,
-                                    helpersTemplate,
-                                    deniedTemplate,
-                                    seenTemplate,
-                                    flagsTemplate,
-                                    buildTemplate,
-                                    footerTemplate
+                                            footerTemplate)
                             ))));
                 }
         );

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
@@ -71,6 +71,7 @@ import com.sk89q.worldedit.world.gamemode.GameModes;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -411,7 +412,7 @@ public abstract class PlotArea {
         this.getFlagContainer().addAll(parseFlags(flags));
         ConsolePlayer.getConsole().sendMessage(
                 TranslatableCaption.of("flags.area_flags"),
-                Template.of("flags", flags.toString())
+                Template.template("flags", flags.toString())
         );
 
         this.spawnEggs = config.getBoolean("event.spawn.egg");
@@ -432,7 +433,7 @@ public abstract class PlotArea {
         this.getRoadFlagContainer().addAll(parseFlags(roadflags));
         ConsolePlayer.getConsole().sendMessage(
                 TranslatableCaption.of("flags.road_flags"),
-                Template.of("flags", roadflags.toString())
+                Template.template("flags", roadflags.toString())
         );
 
         loadConfiguration(config);
@@ -450,14 +451,14 @@ public abstract class PlotArea {
                 } else {
                     value = flag.toString();
                 }
-                Component snip = MINI_MESSAGE.parse(
+                Component snip = MINI_MESSAGE.deserialize(
                         prefix + CaptionUtility
                                 .format(
                                         ConsolePlayer.getConsole(),
                                         TranslatableCaption.of("info.plot_flag_list").getComponent(LocaleHolder.console())
                                 ),
-                        Template.of("flag", flag.getName()),
-                        Template.of("value", CaptionUtility.formatRaw(ConsolePlayer.getConsole(), value.toString()))
+                        TemplateResolver.templates( Template.template("flag", flag.getName()),
+                                Template.template("value", CaptionUtility.formatRaw(ConsolePlayer.getConsole(), value.toString())))
                 );
                 if (flagsComponent != null) {
                     flagsComponent.append(snip);

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
@@ -457,7 +457,7 @@ public abstract class PlotArea {
                                         ConsolePlayer.getConsole(),
                                         TranslatableCaption.of("info.plot_flag_list").getComponent(LocaleHolder.console())
                                 ),
-                        TemplateResolver.templates( Template.template("flag", flag.getName()),
+                        TemplateResolver.templates(Template.template("flag", flag.getName()),
                                 Template.template("value", CaptionUtility.formatRaw(ConsolePlayer.getConsole(), value.toString())))
                 );
                 if (flagsComponent != null) {
@@ -1306,8 +1306,8 @@ public abstract class PlotArea {
      *
      * @return the legacy sign material.
      * @deprecated Use {@link #signMaterial()}. This method is used for 1.13 only and
-     *         will be removed without replacement in favor of {@link #signMaterial()}
-     *         once we remove the support for 1.13.
+     * will be removed without replacement in favor of {@link #signMaterial()}
+     * once we remove the support for 1.13.
      */
     @Deprecated(forRemoval = true)
     public String getLegacySignMaterial() {

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
@@ -387,7 +387,7 @@ public final class PlotModificationManager {
             Caption[] lines = new Caption[]{TranslatableCaption.of("signs.owner_sign_line_1"), TranslatableCaption.of(
                     "signs.owner_sign_line_2"),
                     TranslatableCaption.of("signs.owner_sign_line_3"), TranslatableCaption.of("signs.owner_sign_line_4")};
-            PlotSquared.platform().worldUtil().setSign(location, lines, Template.of("id", id), Template.of("owner", name));
+            PlotSquared.platform().worldUtil().setSign(location, lines, Template.template("id", id), Template.template("owner", name));
         }
     }
 
@@ -497,7 +497,7 @@ public final class PlotModificationManager {
                         if (player != null) {
                             player.sendMessage(
                                     TranslatableCaption.of("events.event_denied"),
-                                    Template.of("value", "Auto merge on claim")
+                                    Template.template("value", "Auto merge on claim")
                             );
                         }
                         return;

--- a/Core/src/main/java/com/plotsquared/core/plot/comment/CommentManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/comment/CommentManager.java
@@ -77,8 +77,8 @@ public class CommentManager {
                             player.sendTitle(
                                     StaticCaption.of(""),
                                     TranslatableCaption.of("comment.inbox_notification"),
-                                    Template.of("amount", Integer.toString(total)),
-                                    Template.of("command", "/plot inbox")
+                                    Template.template("amount", Integer.toString(total)),
+                                    Template.template("command", "/plot inbox")
                             );
                         }
                     }

--- a/Core/src/main/java/com/plotsquared/core/plot/expiration/ExpireManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/expiration/ExpireManager.java
@@ -152,14 +152,14 @@ public class ExpireManager {
                             current.getCenter(pp::teleport);
                             metaDataAccess.remove();
                             Caption msg = TranslatableCaption.of("expiry.expired_options_clicky");
-                            Template numTemplate = Template.of("num", String.valueOf(num));
-                            Template areIsTemplate = Template.of("are_or_is", (num > 1 ? "plots are" : "plot is"));
-                            Template list_cmd = Template.of("list_cmd", "/plot list expired");
-                            Template plot = Template.of("plot", current.toString());
-                            Template cmd_del = Template.of("cmd_del", "/plot delete");
-                            Template cmd_keep_1d = Template.of("cmd_keep_1d", "/plot flag set keep 1d");
-                            Template cmd_keep = Template.of("cmd_keep", "/plot flag set keep true");
-                            Template cmd_no_show_expir = Template.of("cmd_no_show_expir", "/plot toggle clear-confirmation");
+                            Template numTemplate = Template.template("num", String.valueOf(num));
+                            Template areIsTemplate = Template.template("are_or_is", (num > 1 ? "plots are" : "plot is"));
+                            Template list_cmd = Template.template("list_cmd", "/plot list expired");
+                            Template plot = Template.template("plot", current.toString());
+                            Template cmd_del = Template.template("cmd_del", "/plot delete");
+                            Template cmd_keep_1d = Template.template("cmd_keep_1d", "/plot flag set keep 1d");
+                            Template cmd_keep = Template.template("cmd_keep", "/plot flag set keep true");
+                            Template cmd_no_show_expir = Template.template("cmd_no_show_expir", "/plot toggle clear-confirmation");
                             pp.sendMessage(
                                     msg,
                                     numTemplate,

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/DenyTeleportFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/DenyTeleportFlag.java
@@ -89,7 +89,7 @@ public class DenyTeleportFlag extends PlotFlag<DenyTeleportFlag.DeniedGroup, Den
         final DeniedGroup group = DeniedGroup.fromString(input);
         if (group == null) {
             throw new FlagParseException(this, input, TranslatableCaption.of("flags.flag_error_enum"),
-                    Template.of("list", "members, nonmembers, trusted, nontrusted, nonowners")
+                    Template.template("list", "members, nonmembers, trusted, nontrusted, nonowners")
             );
         }
         return flagOf(group);

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/FeedFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/FeedFlag.java
@@ -49,7 +49,7 @@ public class FeedFlag extends TimedFlag<Integer, FeedFlag> {
                     this,
                     input,
                     TranslatableCaption.of("invalid.not_a_number"),
-                    Template.of("value", input)
+                    Template.template("value", input)
             );
         }
         if (parsed < 1) {
@@ -57,7 +57,7 @@ public class FeedFlag extends TimedFlag<Integer, FeedFlag> {
                     this,
                     input,
                     TranslatableCaption.of("invalid.number_not_positive"),
-                    Template.of("value", String.valueOf(parsed))
+                    Template.template("value", String.valueOf(parsed))
             );
         }
         return parsed;

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/HealFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/HealFlag.java
@@ -49,7 +49,7 @@ public class HealFlag extends TimedFlag<Integer, HealFlag> {
                     this,
                     input,
                     TranslatableCaption.of("invalid.not_a_number"),
-                    Template.of("value", input)
+                    Template.template("value", input)
             );
         }
         if (parsed < 1) {
@@ -57,7 +57,7 @@ public class HealFlag extends TimedFlag<Integer, HealFlag> {
                     this,
                     input,
                     TranslatableCaption.of("invalid.number_not_positive"),
-                    Template.of("value", String.valueOf(parsed))
+                    Template.template("value", String.valueOf(parsed))
             );
         }
         return parsed;

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/TitlesFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/TitlesFlag.java
@@ -54,7 +54,7 @@ public class TitlesFlag extends PlotFlag<TitlesFlag.TitlesFlagValue, TitlesFlag>
                     this,
                     input,
                     TranslatableCaption.of("flags.flag_error_enum"),
-                    Template.of("list", "none, true, false")
+                    Template.template("list", "none, true, false")
             );
         }
         return flagOf(titlesFlagValue);

--- a/Core/src/main/java/com/plotsquared/core/queue/QueueCoordinator.java
+++ b/Core/src/main/java/com/plotsquared/core/queue/QueueCoordinator.java
@@ -39,23 +39,20 @@ import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
-
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 public abstract class QueueCoordinator {
 
+    private final AtomicBoolean enqueued = new AtomicBoolean();
     private boolean forceSync = false;
     @Nullable
     private Object chunkObject;
-    private final AtomicBoolean enqueued = new AtomicBoolean();
-
     @Inject
     private GlobalBlockQueue blockQueue;
 
@@ -205,8 +202,8 @@ public abstract class QueueCoordinator {
      * @param biome biome
      * @return success or not
      * @deprecated Biomes now take XYZ, see {@link #setBiome(int, int, int, BiomeType)}
-     *         <br>
-     *         Scheduled for removal once we drop the support for versions not supporting 3D biomes.
+     * <br>
+     * Scheduled for removal once we drop the support for versions not supporting 3D biomes.
      */
     @Deprecated(forRemoval = true)
     public abstract boolean setBiome(int x, int z, @NonNull BiomeType biome);

--- a/Core/src/main/java/com/plotsquared/core/queue/subscriber/DefaultProgressSubscriber.java
+++ b/Core/src/main/java/com/plotsquared/core/queue/subscriber/DefaultProgressSubscriber.java
@@ -120,7 +120,7 @@ public class DefaultProgressSubscriber implements ProgressSubscriber {
                         }
                         actor.sendMessage(
                                 caption,
-                                Template.of("progress", String.format("%.2f", this.progress.doubleValue() * 100))
+                                Template.template("progress", String.format("%.2f", this.progress.doubleValue() * 100))
                         );
                     }, interval), wait);
         }

--- a/Core/src/main/java/com/plotsquared/core/setup/CommonSetupSteps.java
+++ b/Core/src/main/java/com/plotsquared/core/setup/CommonSetupSteps.java
@@ -213,7 +213,7 @@ public enum CommonSetupSteps implements SetupStep {
             }
             if (PlotSquared.platform().worldUtil().isWorld(argument)) {
                 if (PlotSquared.get().getPlotAreaManager().hasPlotArea(argument)) {
-                    plotPlayer.sendMessage(TranslatableCaption.of("setup.setup_world_taken"), Template.of("value", argument));
+                    plotPlayer.sendMessage(TranslatableCaption.of("setup.setup_world_taken"), Template.template("value", argument));
                     return this;
                 }
                 plotPlayer.sendMessage(TranslatableCaption.of("setup.setup_world_apply_plotsquared"));

--- a/Core/src/main/java/com/plotsquared/core/setup/SettingsNodeStep.java
+++ b/Core/src/main/java/com/plotsquared/core/setup/SettingsNodeStep.java
@@ -84,10 +84,10 @@ public class SettingsNodeStep implements SetupStep {
     public void announce(PlotPlayer<?> plotPlayer) {
         plotPlayer.sendMessage(
                 TranslatableCaption.of("setup.setup_step"),
-                Template.of("step", String.valueOf(this.getId() + 1)),
-                Template.of("description", this.configurationNode.getDescription().getComponent(plotPlayer)),
-                Template.of("type", this.configurationNode.getType().getType()),
-                Template.of("value", String.valueOf(this.configurationNode.getDefaultValue()))
+                Template.template("step", String.valueOf(this.getId() + 1)),
+                Template.template("description", this.configurationNode.getDescription().getComponent(plotPlayer)),
+                Template.template("type", this.configurationNode.getType().getType()),
+                Template.template("value", String.valueOf(this.configurationNode.getDefaultValue()))
         );
     }
 

--- a/Core/src/main/java/com/plotsquared/core/synchronization/LockRepository.java
+++ b/Core/src/main/java/com/plotsquared/core/synchronization/LockRepository.java
@@ -71,9 +71,9 @@ public final class LockRepository {
      * @param runnable Action to run when the lock is available
      */
     public void useLock(final @NonNull LockKey key, final @NonNull Runnable runnable) {
-       try (LockAccess ignored = lock(key)) {
-           runnable.run();
-       }
+        try (LockAccess ignored = lock(key)) {
+            runnable.run();
+        }
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/util/BlockUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/BlockUtil.java
@@ -84,7 +84,7 @@ public final class BlockUtil {
      *
      * @param id String or integer ID
      * @return Parsed block state, or {@code null} if none
-     *         could be parsed
+     * could be parsed
      */
     public static @Nullable BlockState get(final @NonNull String id) {
         if (id.length() == 1 && id.charAt(0) == '*') {
@@ -136,7 +136,7 @@ public final class BlockUtil {
      *
      * @param map Serialized block state
      * @return Deserialized block state, or {@code null} if the map is
-     *         not a properly serialized block state
+     * not a properly serialized block state
      */
     public static @Nullable BlockState deserialize(final @NonNull Map<String, Object> map) {
         if (map.containsKey("material")) {

--- a/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
+++ b/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
@@ -345,7 +345,7 @@ public class EventDispatcher {
                 if (notifyPerms) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.flag_tutorial_usage"),
-                            Template.of("flag", PlaceFlag.getFlagName(UseFlag.class))
+                            Template.template("flag", PlaceFlag.getFlagName(UseFlag.class))
                     );
                 }
                 return false;
@@ -412,7 +412,7 @@ public class EventDispatcher {
                 if (notifyPerms) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.flag_tutorial_usage"),
-                            Template.of("flag", PlotFlag.getFlagName(MobPlaceFlag.class)
+                            Template.template("flag", PlotFlag.getFlagName(MobPlaceFlag.class)
                                     + '/' + PlotFlag.getFlagName(PlaceFlag.class))
                     );
                 }
@@ -448,7 +448,7 @@ public class EventDispatcher {
                 if (notifyPerms) {
                     player.sendMessage(
                             TranslatableCaption.of("commandconfig.flag_tutorial_usage"),
-                            Template.of("flag", PlotFlag.getFlagName(MiscPlaceFlag.class)
+                            Template.template("flag", PlotFlag.getFlagName(MiscPlaceFlag.class)
                                     + '/' + PlotFlag.getFlagName(PlaceFlag.class))
                     );
                 }

--- a/Core/src/main/java/com/plotsquared/core/util/LegacyConverter.java
+++ b/Core/src/main/java/com/plotsquared/core/util/LegacyConverter.java
@@ -119,8 +119,8 @@ public final class LegacyConverter {
         this.setString(section, key, bucket);
         ConsolePlayer.getConsole().sendMessage(
                 TranslatableCaption.of("legacyconfig.legacy_config_replaced"),
-                Template.of("value1", block),
-                Template.of("value2", bucket.toString())
+                Template.template("value1", block),
+                Template.template("value2", bucket.toString())
         );
     }
 
@@ -135,8 +135,8 @@ public final class LegacyConverter {
         ConsolePlayer.getConsole()
                 .sendMessage(
                         TranslatableCaption.of("legacyconfig.legacy_config_replaced"),
-                        Template.of("value1", plotBlockArrayString(blocks)),
-                        Template.of("value2", bucket.toString())
+                        Template.template("value1", plotBlockArrayString(blocks)),
+                        Template.template("value2", bucket.toString())
                 );
     }
 

--- a/Core/src/main/java/com/plotsquared/core/util/PatternUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/PatternUtil.java
@@ -91,7 +91,7 @@ public class PatternUtil {
         } catch (InputParseException e) {
             throw new Command.CommandException(
                     TranslatableCaption.of("invalid.not_valid_block"),
-                    Template.of("value", e.getMessage())
+                    Template.template("value", e.getMessage())
             );
         }
     }

--- a/Core/src/main/java/com/plotsquared/core/util/Permissions.java
+++ b/Core/src/main/java/com/plotsquared/core/util/Permissions.java
@@ -95,7 +95,7 @@ public class Permissions {
             if (notify) {
                 player.sendMessage(
                         TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", permission)
+                        Template.template("node", permission)
                 );
             }
             return false;

--- a/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
@@ -149,9 +149,9 @@ public abstract class PlayerManager<P extends PlotPlayer<? extends T>, T> {
         TextComponent.Builder list = Component.text();
         for (int x = 0; x < users.size(); x++) {
             if (x + 1 == uuids.size()) {
-                list.append(MINI_MESSAGE.parse(c, Template.of("user", users.get(x))));
+                list.append(MINI_MESSAGE.parse(c, Template.template("user", users.get(x))));
             } else {
-                list.append(MINI_MESSAGE.parse(c + ", ", Template.of("user", users.get(x))));
+                list.append(MINI_MESSAGE.parse(c + ", ", Template.template("user", users.get(x))));
             }
         }
         return list.asComponent();

--- a/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
@@ -38,6 +38,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -149,9 +150,11 @@ public abstract class PlayerManager<P extends PlotPlayer<? extends T>, T> {
         TextComponent.Builder list = Component.text();
         for (int x = 0; x < users.size(); x++) {
             if (x + 1 == uuids.size()) {
-                list.append(MINI_MESSAGE.parse(c, Template.template("user", users.get(x))));
+                list.append(MINI_MESSAGE.deserialize(c,
+                        TemplateResolver.templates(Template.template("user", users.get(x)))));
             } else {
-                list.append(MINI_MESSAGE.parse(c + ", ", Template.template("user", users.get(x))));
+                list.append(MINI_MESSAGE.deserialize(c + ", ",
+                        TemplateResolver.templates(Template.template("user", users.get(x)))));
             }
         }
         return list.asComponent();

--- a/Core/src/main/java/com/plotsquared/core/util/TabCompletions.java
+++ b/Core/src/main/java/com/plotsquared/core/util/TabCompletions.java
@@ -38,7 +38,6 @@ import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.uuid.UUIDMapping;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -116,7 +115,6 @@ public final class TabCompletions {
      * @param input    Command input
      * @param existing Players that should not be included in completions
      * @return List of completions
-     *
      * @deprecated In favor {@link #completeAddedPlayers(PlotPlayer, Plot, String, List)}
      */
     @Deprecated(forRemoval = true)

--- a/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
@@ -91,7 +91,7 @@ public abstract class WorldUtil {
      *
      * @param worldName World name
      * @return {@code true} if there exists a world with the given world name,
-     *         {@code false} if not
+     * {@code false} if not
      */
     public abstract boolean isWorld(@NonNull String worldName);
 

--- a/Core/src/main/java/com/plotsquared/core/util/helpmenu/HelpObject.java
+++ b/Core/src/main/java/com/plotsquared/core/util/helpmenu/HelpObject.java
@@ -43,11 +43,11 @@ public class HelpObject {
     public HelpObject(final Command command, final String label, final PlotPlayer<?> audience) {
         rendered = MINI_MESSAGE.serialize(MINI_MESSAGE.parse(
                 TranslatableCaption.of("help.help_item").getComponent(audience),
-                Template.of("usage", command.getUsage().replace("{label}", label)),
-                Template.of("alias", command.getAliases().isEmpty() ? "" : StringMan.join(command.getAliases(), " | ")),
+                Template.template("usage", command.getUsage().replace("{label}", label)),
+                Template.template("alias", command.getAliases().isEmpty() ? "" : StringMan.join(command.getAliases(), " | ")),
                 Templates.of(audience, "desc", command.getDescription()),
-                Template.of("arguments", buildArgumentList(command.getRequiredArguments())),
-                Template.of("label", label)
+                Template.template("arguments", buildArgumentList(command.getRequiredArguments())),
+                Template.template("label", label)
         ));
     }
 

--- a/Core/src/main/java/com/plotsquared/core/util/helpmenu/HelpObject.java
+++ b/Core/src/main/java/com/plotsquared/core/util/helpmenu/HelpObject.java
@@ -47,7 +47,7 @@ public class HelpObject {
                 TemplateResolver.templates(
                         Template.template("usage", command.getUsage().replace("{label}", label)),
                         Template.template("alias", command.getAliases().isEmpty() ? "" : StringMan.join(command.getAliases(), " | ")),
-                        Templates.of(audience, "desc", command.getDescription()),
+                        Templates.template(audience, "desc", command.getDescription()),
                         Template.template("arguments", buildArgumentList(command.getRequiredArguments())),
                         Template.template("label", label)
                 )

--- a/Core/src/main/java/com/plotsquared/core/util/helpmenu/HelpObject.java
+++ b/Core/src/main/java/com/plotsquared/core/util/helpmenu/HelpObject.java
@@ -33,6 +33,7 @@ import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.util.StringMan;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 
 public class HelpObject {
 
@@ -41,13 +42,15 @@ public class HelpObject {
     private final String rendered;
 
     public HelpObject(final Command command, final String label, final PlotPlayer<?> audience) {
-        rendered = MINI_MESSAGE.serialize(MINI_MESSAGE.parse(
+        rendered = MINI_MESSAGE.serialize(MINI_MESSAGE.deserialize(
                 TranslatableCaption.of("help.help_item").getComponent(audience),
-                Template.template("usage", command.getUsage().replace("{label}", label)),
-                Template.template("alias", command.getAliases().isEmpty() ? "" : StringMan.join(command.getAliases(), " | ")),
-                Templates.of(audience, "desc", command.getDescription()),
-                Template.template("arguments", buildArgumentList(command.getRequiredArguments())),
-                Template.template("label", label)
+                TemplateResolver.templates(
+                        Template.template("usage", command.getUsage().replace("{label}", label)),
+                        Template.template("alias", command.getAliases().isEmpty() ? "" : StringMan.join(command.getAliases(), " | ")),
+                        Templates.of(audience, "desc", command.getDescription()),
+                        Template.template("arguments", buildArgumentList(command.getRequiredArguments())),
+                        Template.template("label", label)
+                )
         ));
     }
 

--- a/Core/src/main/java/com/plotsquared/core/util/helpmenu/HelpPage.java
+++ b/Core/src/main/java/com/plotsquared/core/util/helpmenu/HelpPage.java
@@ -46,17 +46,17 @@ public class HelpPage {
 
     public HelpPage(CommandCategory category, int currentPage, int maxPages) {
         this.helpObjects = new ArrayList<>();
-        this.catTemplate = Template.of("category", category == null ? "ALL" : category.name());
-        this.curTemplate = Template.of("current", String.valueOf(currentPage + 1));
-        this.maxTemplate = Template.of("max", String.valueOf(maxPages + 1));
+        this.catTemplate = Template.template("category", category == null ? "ALL" : category.name());
+        this.curTemplate = Template.template("current", String.valueOf(currentPage + 1));
+        this.maxTemplate = Template.template("max", String.valueOf(maxPages + 1));
     }
 
     public void render(PlotPlayer<?> player) {
         if (this.helpObjects.size() < 1) {
             player.sendMessage(TranslatableCaption.of("help.no_permission"));
         } else {
-            Template header = Template.of("header", TranslatableCaption.of("help.help_header").getComponent(player));
-            Template page_header = Template.of(
+            Template header = Template.template("header", TranslatableCaption.of("help.help_header").getComponent(player));
+            Template page_header = Template.template(
                     "page_header",
                     MINI_MESSAGE.parse(
                             TranslatableCaption.of("help.help_page_header").getComponent(player),
@@ -65,8 +65,8 @@ public class HelpPage {
                             maxTemplate
                     )
             );
-            Template help_objects = Template.of("help_objects", StringMan.join(this.helpObjects, "\n"));
-            Template footer = Template.of("footer", TranslatableCaption.of("help.help_footer").getComponent(player));
+            Template help_objects = Template.template("help_objects", StringMan.join(this.helpObjects, "\n"));
+            Template footer = Template.template("footer", TranslatableCaption.of("help.help_footer").getComponent(player));
             player.sendMessage(
                     StaticCaption.of("<header>\n<page_header>\n<help_objects>\n<footer>"),
                     header,

--- a/Core/src/main/java/com/plotsquared/core/util/helpmenu/HelpPage.java
+++ b/Core/src/main/java/com/plotsquared/core/util/helpmenu/HelpPage.java
@@ -32,6 +32,7 @@ import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.util.StringMan;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,11 +59,12 @@ public class HelpPage {
             Template header = Template.template("header", TranslatableCaption.of("help.help_header").getComponent(player));
             Template page_header = Template.template(
                     "page_header",
-                    MINI_MESSAGE.parse(
+                    MINI_MESSAGE.deserialize(
                             TranslatableCaption.of("help.help_page_header").getComponent(player),
-                            catTemplate,
-                            curTemplate,
-                            maxTemplate
+                            TemplateResolver.templates(
+                                    catTemplate,
+                                    curTemplate,
+                                    maxTemplate)
                     )
             );
             Template help_objects = Template.template("help_objects", StringMan.join(this.helpObjects, "\n"));

--- a/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
+++ b/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
@@ -64,6 +64,7 @@ public final class PlaceholderRegistry {
 
     private final Map<String, Placeholder> placeholders;
     private final EventDispatcher eventDispatcher;
+    private static final MiniMessage MINI_MESSAGE = MiniMessage.miniMessage();
 
     @Inject
     public PlaceholderRegistry(final @NonNull EventDispatcher eventDispatcher) {
@@ -80,7 +81,7 @@ public final class PlaceholderRegistry {
      * @return a legacy-formatted string.
      */
     private static String legacyComponent(TranslatableCaption caption, LocaleHolder localeHolder) {
-        Component component = MiniMessage.miniMessage().parse(caption.getComponent(localeHolder));
+        Component component = MINI_MESSAGE.parse(caption.getComponent(localeHolder));
         return PlotSquared.platform().toLegacyPlatformString(component);
     }
 

--- a/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
+++ b/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
@@ -62,9 +62,9 @@ import java.util.function.BiFunction;
 @Singleton
 public final class PlaceholderRegistry {
 
+    private static final MiniMessage MINI_MESSAGE = MiniMessage.miniMessage();
     private final Map<String, Placeholder> placeholders;
     private final EventDispatcher eventDispatcher;
-    private static final MiniMessage MINI_MESSAGE = MiniMessage.miniMessage();
 
     @Inject
     public PlaceholderRegistry(final @NonNull EventDispatcher eventDispatcher) {

--- a/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
+++ b/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
@@ -80,7 +80,7 @@ public final class PlaceholderRegistry {
      * @return a legacy-formatted string.
      */
     private static String legacyComponent(TranslatableCaption caption, LocaleHolder localeHolder) {
-        Component component = MiniMessage.get().parse(caption.getComponent(localeHolder));
+        Component component = MiniMessage.miniMessage().parse(caption.getComponent(localeHolder));
         return PlotSquared.platform().toLegacyPlatformString(component);
     }
 

--- a/Core/src/main/java/com/plotsquared/core/util/query/OwnersIncludeFilter.java
+++ b/Core/src/main/java/com/plotsquared/core/util/query/OwnersIncludeFilter.java
@@ -28,7 +28,6 @@ package com.plotsquared.core.util.query;
 import com.plotsquared.core.plot.Plot;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-import java.util.Objects;
 import java.util.UUID;
 
 class OwnersIncludeFilter implements PlotFilter {

--- a/Core/src/main/java/com/plotsquared/core/util/task/PlotSquaredTask.java
+++ b/Core/src/main/java/com/plotsquared/core/util/task/PlotSquaredTask.java
@@ -60,7 +60,7 @@ public interface PlotSquaredTask extends Runnable {
      * Check if the task has been cancelled
      *
      * @return {@code true} if the tasks is cancelled,
-     *         {@code false} if not
+     * {@code false} if not
      */
     boolean isCancelled();
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ snakeyaml = "1.28" # Version set by Bukkit
 
 # Adventure & MiniMessage
 adventure-api = "4.9.3"
-adventure-text-minimessage = "4.1.0-SNAPSHOT"
+adventure-text-minimessage = "4.2.0-SNAPSHOT"
 adventure-platform-bukkit = "4.0.0"
 
 # Plugins


### PR DESCRIPTION
## Description
According to OSS Sonatype, 4.1.0-SNAPSHOT was last updated back in July 2021, either renovate missed it or there was no release of 4.2.0. However, there are over 600 deprecation & "scheduled for removal" warnings we should address in a timely manner.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)