### PR TITLE
build: Switch PRTree GAV to our deployment

### DIFF
--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -94,7 +94,7 @@ tasks.named<ShadowJar>("shadowJar") {
 tasks {
     withType<Javadoc> {
         val opt = options as StandardJavadocDocletOptions
-        opt.links("https://papermc.io/javadocs/paper/1.18/")
+        opt.links("https://papermc.io/javadocs/paper/1.17/")
         opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-core/7.2.7/")
         opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-bukkit/7.2.7/")
         opt.links("https://jd.adventure.kyori.net/api/4.9.3/")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,7 +73,7 @@ allprojects {
 
     plugins.withId("java") {
         the<JavaPluginExtension>().toolchain {
-            languageVersion.set(JavaLanguageVersion.of(17))
+            languageVersion.set(JavaLanguageVersion.of(16))
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ hyperverse = "0.6.0-SNAPSHOT"
 mvdwapi = "3.1.1"
 
 # Third party
-prtree = "1.5.0"
+prtree = "2.0.0"
 aopalliance = "1.0"
 pipeline = "1.4.0-SNAPSHOT"
 arkitektonika = "2.1.0"
@@ -75,7 +75,7 @@ essentialsx = { group = "net.essentialsx", name = "EssentialsX", version.ref = "
 hyperverse = { group = "se.hyperver.hyperverse", name = "Core", version.ref = "hyperverse" }
 
 # Third party
-prtree = { group = "org.khelekore", name = "prtree", version.ref = "prtree" }
+prtree = { group = "com.intellectualsites.prtree", name = "PRTree", version.ref = "prtree" }
 aopalliance = { group = "aopalliance", name = "aopalliance", version.ref = "aopalliance" }
 pipeline = { group = "com.intellectualsites", name = "Pipeline", version.ref = "pipeline" }
 mvdwapi = { group = "be.maximvdw", name = "MVdWPlaceholderAPI", version.ref = "mvdwapi" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
 # Minecraft expectations
-gson = "2.8.8" # Version set by Minecraft
+gson = "2.8.0" # Version set by Minecraft
 log4j-api = "2.14.1" # Version set by Minecraft
 
 # Platform expectations
-paper = "1.18-R0.1-SNAPSHOT"
+paper = "1.17.1-R0.1-SNAPSHOT"
 checker-qual = "3.19.0"
 guice = "5.0.1"
 findbugs = "3.0.1"


### PR DESCRIPTION
## Overview

Fixes #3359

## Description
PRTree is now available under the proposed GAV on the central repository. I would like to pull this PR into 6.2.0 once PRTree has been synced with OSSRH.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)