### PR TITLE
fix: Standardize projectile permissions

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
@@ -371,14 +371,14 @@ public class EntityEventListener implements Listener {
             if (shooter instanceof Player) {
                 PlotPlayer<?> pp = BukkitUtil.adapt((Player) shooter);
                 if (plot == null) {
-                    if (!Permissions.hasPermission(pp, Permission.PERMISSION_PROJECTILE_UNOWNED)) {
+                    if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_PROJECTILE_UNOWNED)) {
                         entity.remove();
                         event.setCancelled(true);
                     }
                     return;
                 }
                 if (plot.isAdded(pp.getUUID()) || Permissions
-                        .hasPermission(pp, Permission.PERMISSION_PROJECTILE_OTHER)) {
+                        .hasPermission(pp, Permission.PERMISSION_ADMIN_PROJECTILE_OTHER)) {
                     return;
                 }
                 entity.remove();

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -127,7 +127,6 @@ import org.bukkit.event.player.PlayerBucketFillEvent;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
-import org.bukkit.event.player.PlayerEggThrowEvent;
 import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.event.player.PlayerInteractAtEntityEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
@@ -1606,43 +1605,6 @@ public class PlayerEventListener extends PlotListener implements Listener {
                                 + " could not break vehicle because vehicle-break = false");
                     }
                 }
-            }
-        }
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onPlayerEggThrow(PlayerEggThrowEvent event) {
-        Location location = BukkitUtil.adapt(event.getEgg().getLocation());
-        PlotArea area = location.getPlotArea();
-        if (area == null) {
-            return;
-        }
-        Player player = event.getPlayer();
-        BukkitPlayer plotPlayer = BukkitUtil.adapt(player);
-        Plot plot = area.getPlot(location);
-        if (plot == null) {
-            if (!Permissions.hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_PROJECTILE_ROAD)) {
-                plotPlayer.sendMessage(
-                        TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_PROJECTILE_ROAD))
-                );
-                event.setHatching(false);
-            }
-        } else if (!plot.hasOwner()) {
-            if (!Permissions.hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_PROJECTILE_UNOWNED)) {
-                plotPlayer.sendMessage(
-                        TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_PROJECTILE_UNOWNED))
-                );
-                event.setHatching(false);
-            }
-        } else if (!plot.isAdded(plotPlayer.getUUID())) {
-            if (!Permissions.hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_PROJECTILE_OTHER)) {
-                plotPlayer.sendMessage(
-                        TranslatableCaption.of("permission.no_permission_event"),
-                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_PROJECTILE_OTHER))
-                );
-                event.setHatching(false);
             }
         }
     }

--- a/Core/src/main/java/com/plotsquared/core/permissions/Permission.java
+++ b/Core/src/main/java/com/plotsquared/core/permissions/Permission.java
@@ -37,8 +37,6 @@ public enum Permission {
     PERMISSION_STAR("*"),
     PERMISSION_ADMIN("plots.admin"),
     PERMISSION_ADMIN_AREA_SUDO("plots.admin.area.sudo"),
-    PERMISSION_PROJECTILE_UNOWNED("plots.projectile.unowned"),
-    PERMISSION_PROJECTILE_OTHER("plots.projectile.other"),
     PERMISSION_ADMIN_INTERACT_BLOCKED_CMDS("plots.admin.interact.blockedcommands"),
     PERMISSION_WORLDEDIT_BYPASS("plots.worldedit.bypass"),
     PERMISSION_PLOT_TOGGLE_TITLES("plots.toggle.titles"),

--- a/Core/src/main/java/com/plotsquared/core/permissions/Permission.java
+++ b/Core/src/main/java/com/plotsquared/core/permissions/Permission.java
@@ -37,6 +37,10 @@ public enum Permission {
     PERMISSION_STAR("*"),
     PERMISSION_ADMIN("plots.admin"),
     PERMISSION_ADMIN_AREA_SUDO("plots.admin.area.sudo"),
+    @Deprecated(forRemoval = true)
+    PERMISSION_PROJECTILE_UNOWNED("plots.projectile.unowned"),
+    @Deprecated(forRemoval = true)
+    PERMISSION_PROJECTILE_OTHER("plots.projectile.other"),
     PERMISSION_ADMIN_INTERACT_BLOCKED_CMDS("plots.admin.interact.blockedcommands"),
     PERMISSION_WORLDEDIT_BYPASS("plots.worldedit.bypass"),
     PERMISSION_PLOT_TOGGLE_TITLES("plots.toggle.titles"),

--- a/Core/src/main/java/com/plotsquared/core/permissions/Permission.java
+++ b/Core/src/main/java/com/plotsquared/core/permissions/Permission.java
@@ -37,9 +37,9 @@ public enum Permission {
     PERMISSION_STAR("*"),
     PERMISSION_ADMIN("plots.admin"),
     PERMISSION_ADMIN_AREA_SUDO("plots.admin.area.sudo"),
-    @Deprecated(forRemoval = true)
+    @Deprecated(forRemoval = true, since = "6.3.0")
     PERMISSION_PROJECTILE_UNOWNED("plots.projectile.unowned"),
-    @Deprecated(forRemoval = true)
+    @Deprecated(forRemoval = true, since = "6.3.0")
     PERMISSION_PROJECTILE_OTHER("plots.projectile.other"),
     PERMISSION_ADMIN_INTERACT_BLOCKED_CMDS("plots.admin.interact.blockedcommands"),
     PERMISSION_WORLDEDIT_BYPASS("plots.worldedit.bypass"),


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, please create one so we can look into it before approving your PR.
-->

Fixes #2986

## Description
<!-- Please describe what this pull request does. -->
- Let all projectiles (not just splash potions) have a permissions check on throwing
- Fixes snowballs, eggs, etc. being able to be thrown when not added to the plot, etc.
- Fixes #2986 (splash potions only able being to be thrown when also added to the plot)
- Remove the specialized code for egg hatching as now eggs are cancelled entirely
- Remove the non-standard plots.projectile.unowned and plots.projectile.other permissions in favor of the standard admin ones

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)