### PR TITLE
fix: npe thrown in entity spawn listener

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
@@ -75,8 +75,7 @@ public class EntitySpawnListener implements Listener {
 
     public static void testCreate(final Entity entity) {
         @NonNull World world = entity.getWorld();
-        if (areaName.equals(world.getName())) {
-        } else {
+        if (!world.getName().equals(areaName)) {
             areaName = world.getName();
             hasPlotArea = PlotSquared.get().getPlotAreaManager().hasPlotArea(areaName);
         }


### PR DESCRIPTION
## Overview
A NPE is thrown when spawning entities.

Error: https://gist.github.com/yannicklamprecht/062d467138b52ea8c8a4a3ab2401f63f

1. Build a PlotSquared version with this commit or later https://github.com/IntellectualSites/PlotSquared/commit/af2613202d05d1069d4416b53c50018dce2a6752
2. Start up a Paper server and spawn an entity
3. It will throw a NPE on line https://github.com/IntellectualSites/PlotSquared/commit/af2613202d05d1069d4416b53c50018dce2a6752#diff-88a5d02f8bdf730223f88142fcc0147612cf7b80f597d3e15e600c9862cd90bcR78

Background info: areaName is not set at that point in time, it will be set after that condition.


PS: Yeah I'm a little to lazy to create an issue. <3

## Description

It will fix a NPE introduced some commit before.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
