### PR TITLE
fix: Reimplement the "unknown owner" option to plot purge

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Purge.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Purge.java
@@ -27,6 +27,7 @@ package com.plotsquared.core.command;
 
 import com.google.inject.Inject;
 import com.plotsquared.core.PlotSquared;
+import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.configuration.caption.TranslatableCaption;
 import com.plotsquared.core.database.DBFunc;
 import com.plotsquared.core.listener.PlotListener;
@@ -86,6 +87,7 @@ public class Purge extends SubCommand {
         UUID owner = null;
         UUID added = null;
         boolean clear = false;
+        boolean unknown = false;
         for (String arg : args) {
             String[] split = arg.split(":");
             if (split.length != 2) {
@@ -142,7 +144,7 @@ public class Purge extends SubCommand {
                         );
                         return false;
                     }
-                    owner = addedMapping.getUuid();
+                    added = addedMapping.getUuid();
                     break;
                 case "clear":
                 case "c":
@@ -150,6 +152,11 @@ public class Purge extends SubCommand {
                 case "d":
                 case "del":
                     clear = Boolean.parseBoolean(split[1]);
+                    break;
+                case "unknown":
+                case "?":
+                case "u":
+                    unknown = Boolean.parseBoolean(split[1]);
                     break;
                 default:
                     sendUsage(player);
@@ -173,6 +180,12 @@ public class Purge extends SubCommand {
             if (added != null && !plot.isAdded(added)) {
                 continue;
             }
+            if (unknown) {
+                UUIDMapping uuidMapping = PlotSquared.get().getImpromptuUUIDPipeline().getImmediately(plot.getOwner());
+                if (uuidMapping != null) {
+                    continue;
+                }
+            }
             toDelete.addAll(plot.getConnectedPlots());
         }
         if (PlotSquared.get().plots_tmp != null) {
@@ -184,6 +197,9 @@ public class Purge extends SubCommand {
                 }
                 for (Entry<PlotId, Plot> entry2 : entry.getValue().entrySet()) {
                     Plot plot = entry2.getValue();
+                    if (area != null && !plot.getArea().equals(area)) {
+                        continue;
+                    }
                     if (id != null && !plot.getId().equals(id)) {
                         continue;
                     }
@@ -192,6 +208,12 @@ public class Purge extends SubCommand {
                     }
                     if (added != null && !plot.isAdded(added)) {
                         continue;
+                    }
+                    if (unknown) {
+                        UUIDMapping addedMapping = PlotSquared.get().getImpromptuUUIDPipeline().getImmediately(plot.getOwner());
+                        if (addedMapping != null) {
+                            continue;
+                        }
                     }
                     toDelete.add(plot);
                 }
@@ -252,6 +274,13 @@ public class Purge extends SubCommand {
             TaskManager.runTaskAsync(runasync);
         };
         if (hasConfirmation(player)) {
+            if (unknown) {
+                if (Settings.UUID.BACKGROUND_CACHING_ENABLED) {
+                    player.sendMessage(TranslatableCaption.of("purge.confirm_purge_unknown_bg_enabled"));
+                } else {
+                    player.sendMessage(TranslatableCaption.of("purge.confirm_purge_unknown_bg_disabled"));
+                }
+            }
             CmdConfirm.addPending(player, cmd, run);
         } else {
             run.run();

--- a/Core/src/main/resources/lang/messages_en.json
+++ b/Core/src/main/resources/lang/messages_en.json
@@ -322,6 +322,8 @@
   "debugsavetest.starting": "<prefix><gold>Starting debugsavetest.</gold>",
   "debugsavetest.done": "<prefix><gold>Database sync finished.</gold>",
   "purge.purge_success": "<prefix><dark_aqua>Successfully purged <amount> plots.</dark_aqua>",
+  "purge.confirm_purge_unknown_bg_enabled": "<prefix><gray>Background UUID caching is enabled. Unknown plot owners may be found using this!</gray>",
+  "purge.confirm_purge_unknown_bg_disabled": "<prefix><gray>Background UUID caching is disabled. Unknown plot owners may be found using this! Enable it in settings.yml.</gray>",
   "players.fetching_player": "<prefix><gold>PlotSquared is attempting to find the specified player from your argument(s). This may take a while.</gold>",
   "players.fetching_players_timeout": "<prefix><red>The specified users did not exist in the cache and will be fetched in the background. Please wait a couple of minutes.</red>",
   "trim.trim_in_progress": "<prefix><red>A world trim task is already in progress!</red>",


### PR DESCRIPTION
- Warn user that backgorund UUID caching may fix the issue
- Also correct the UUID set when purging based on "shared" (added) player
- Fixes #3353