### PR TITLE
Fix: use ownersInclude instead of ownedBy where required

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Cluster.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Cluster.java
@@ -559,13 +559,7 @@ public class Cluster extends SubCommand {
                                                 Template.of("cluster", cluster.getName())
                                         );
                                     }
-                                    for (final Plot plot : PlotQuery.newQuery().inWorld(player2.getLocation()
-                                            .getWorldName()).ownedBy(uuid)) {
-                                        PlotCluster current = plot.getCluster();
-                                        if (current != null && current.equals(cluster)) {
-                                            plot.unclaim();
-                                        }
-                                    }
+                                    removePlayerPlots(cluster, uuid, player2.getLocation().getWorldName());
                                     player.sendMessage(TranslatableCaption.of("cluster.cluster_kicked_user"));
                                 }
                             }
@@ -628,13 +622,7 @@ public class Cluster extends SubCommand {
                         TranslatableCaption.of("cluster.cluster_removed"),
                         Template.of("cluster", cluster.getName())
                 );
-                for (final Plot plot : PlotQuery.newQuery().inWorld(player.getLocation().getWorldName())
-                        .ownedBy(uuid)) {
-                    PlotCluster current = plot.getCluster();
-                    if (current != null && current.equals(cluster)) {
-                        plot.unclaim();
-                    }
-                }
+                removePlayerPlots(cluster, uuid, player.getLocation().getWorldName());
                 return true;
             }
             case "members": {
@@ -864,6 +852,24 @@ public class Cluster extends SubCommand {
                 )
         );
         return false;
+    }
+
+    private void removePlayerPlots(final PlotCluster cluster, final UUID uuid, final String world) {
+        for (final Plot plot : PlotQuery.newQuery().inWorld(world).ownedBy(uuid)) {
+            PlotCluster current = plot.getCluster();
+            if (current != null && current.equals(cluster)) {
+                if (plot.getOwners().size() == 1) {
+                    plot.unclaim();
+                } else {
+                    for (UUID newOwner : plot.getOwners()) {
+                        if (!newOwner.equals(uuid)) {
+                            plot.setOwner(newOwner);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
     }
 
     @Override

--- a/Core/src/main/java/com/plotsquared/core/command/ListCmd.java
+++ b/Core/src/main/java/com/plotsquared/core/command/ListCmd.java
@@ -203,7 +203,7 @@ public class ListCmd extends SubCommand {
                 sort[0] = false;
                 plotConsumer.accept(PlotQuery
                         .newQuery()
-                        .ownedBy(player)
+                        .ownersInclude(player)
                         .whereBasePlot()
                         .withSortingStrategy(SortingStrategy.SORT_BY_TEMP));
             }
@@ -397,7 +397,8 @@ public class ListCmd extends SubCommand {
                             sort[0] = false;
                             plotConsumer.accept(PlotQuery
                                     .newQuery()
-                                    .ownedBy(uuid)
+                                    .ownersInclude(uuid)
+                                    .whereBasePlot()
                                     .withSortingStrategy(SortingStrategy.SORT_BY_TEMP));
                         }
                     }

--- a/Core/src/main/java/com/plotsquared/core/command/Visit.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Visit.java
@@ -56,6 +56,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
+import static com.plotsquared.core.configuration.Settings.Teleport.VISIT_MERGED_OWNERS;
+
 @CommandDeclaration(command = "visit",
         permission = "plots.visit",
         usage = "/plot visit <player> | <alias> | <plot> [area]|[#] [#]",
@@ -235,8 +237,8 @@ public class Visit extends Command {
                         } else {
                             final UUID uuid = uuids.toArray(new UUID[0])[0];
                             PlotQuery query = PlotQuery.newQuery();
-                            if (Settings.Teleport.VISIT_MERGED_OWNERS) {
-                                query.ownersInclude(uuid);
+                            if (VISIT_MERGED_OWNERS) {
+                                query.whereBasePlot().ownersInclude(uuid);
                             } else {
                                 query.whereBasePlot().ownedBy(uuid);
                             }
@@ -273,7 +275,8 @@ public class Visit extends Command {
                         if (throwable instanceof TimeoutException) {
                             // The request timed out
                             player.sendMessage(TranslatableCaption.of("players.fetching_players_timeout"));
-                        } else if (uuid != null && !PlotQuery.newQuery().ownedBy(uuid).anyMatch()) {
+                        } else if (uuid != null && (VISIT_MERGED_OWNERS ? !PlotQuery.newQuery().ownersInclude(uuid).anyMatch() :
+                                !PlotQuery.newQuery().ownedBy(uuid).anyMatch())) {
                             // It was a valid UUID but the player has no plots
                             player.sendMessage(TranslatableCaption.of("errors.player_no_plots"));
                         } else if (uuid == null) {
@@ -296,7 +299,8 @@ public class Visit extends Command {
                         } else {
                             this.visit(
                                     player,
-                                    PlotQuery.newQuery().ownedBy(uuid).whereBasePlot(),
+                                    VISIT_MERGED_OWNERS ? PlotQuery.newQuery().ownersInclude(uuid).whereBasePlot() :
+                                            PlotQuery.newQuery().ownedBy(uuid).whereBasePlot(),
                                     null,
                                     confirm,
                                     whenDone,

--- a/Core/src/main/java/com/plotsquared/core/command/Visit.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Visit.java
@@ -56,8 +56,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
-import static com.plotsquared.core.configuration.Settings.Teleport.VISIT_MERGED_OWNERS;
-
 @CommandDeclaration(command = "visit",
         permission = "plots.visit",
         usage = "/plot visit <player> | <alias> | <plot> [area]|[#] [#]",
@@ -237,7 +235,7 @@ public class Visit extends Command {
                         } else {
                             final UUID uuid = uuids.toArray(new UUID[0])[0];
                             PlotQuery query = PlotQuery.newQuery();
-                            if (VISIT_MERGED_OWNERS) {
+                            if (Settings.Teleport.VISIT_MERGED_OWNERS) {
                                 query.whereBasePlot().ownersInclude(uuid);
                             } else {
                                 query.whereBasePlot().ownedBy(uuid);
@@ -275,8 +273,9 @@ public class Visit extends Command {
                         if (throwable instanceof TimeoutException) {
                             // The request timed out
                             player.sendMessage(TranslatableCaption.of("players.fetching_players_timeout"));
-                        } else if (uuid != null && (VISIT_MERGED_OWNERS ? !PlotQuery.newQuery().ownersInclude(uuid).anyMatch() :
-                                !PlotQuery.newQuery().ownedBy(uuid).anyMatch())) {
+                        } else if (uuid != null && (Settings.Teleport.VISIT_MERGED_OWNERS
+                                ? !PlotQuery.newQuery().ownersInclude(uuid).anyMatch()
+                                : !PlotQuery.newQuery().ownedBy(uuid).anyMatch())) {
                             // It was a valid UUID but the player has no plots
                             player.sendMessage(TranslatableCaption.of("errors.player_no_plots"));
                         } else if (uuid == null) {
@@ -299,8 +298,9 @@ public class Visit extends Command {
                         } else {
                             this.visit(
                                     player,
-                                    VISIT_MERGED_OWNERS ? PlotQuery.newQuery().ownersInclude(uuid).whereBasePlot() :
-                                            PlotQuery.newQuery().ownedBy(uuid).whereBasePlot(),
+                                    Settings.Teleport.VISIT_MERGED_OWNERS
+                                            ? PlotQuery.newQuery().ownersInclude(uuid).whereBasePlot()
+                                            : PlotQuery.newQuery().ownedBy(uuid).whereBasePlot(),
                                     null,
                                     confirm,
                                     whenDone,


### PR DESCRIPTION
- Also account for multiple plot owners in Cluster player removal
- Add whereBasePlot to avoid merged plots listing multiple times if required
- Only use ownersInclude in visit if enabled in config
- Fixes #3143

- [x] I tested my changes and approved their functionality.

