### PR TITLE
Fix `/plot music` being able to be used on unclaimed plots

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Music.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Music.java
@@ -76,6 +76,10 @@ public class Music extends SubCommand {
             player.sendMessage(TranslatableCaption.of("errors.not_in_plot"));
             return false;
         }
+        if (!plot.hasOwner()) {
+            player.sendMessage(TranslatableCaption.of("info.plot_unowned"));
+            return false;
+        }
         if (!plot.isAdded(player.getUUID()) && !Permissions
                 .hasPermission(player, Permission.PERMISSION_ADMIN_MUSIC_OTHER)) {
             player.sendMessage(


### PR DESCRIPTION
## Overview

## Description
While playing around with https://github.com/IntellectualSites/PlotSquared/pull/3430 I noticed, that you can use `/plot music` on unclaimed plots and can set music disks, yet that will fail, because the plot doesn't actually exist yet. 

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [x] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
