### PR TITLE
feat: Display explosion particles even after the event got canceled (with setting to control behavior)

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
@@ -325,7 +325,7 @@ public class EntityEventListener implements Listener {
         }
         event.setCancelled(true);
         //Spawn Explosion Particles when enabled in settings
-        if (Settings.General.ALWAYS_SHOW_EXPLOSIONS){
+        if (Settings.General.ALWAYS_SHOW_EXPLOSIONS) {
             event.getLocation().getWorld().spawnParticle(Particle.EXPLOSION_HUGE, event.getLocation(), 0);
         }
     }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
@@ -48,6 +48,7 @@ import com.plotsquared.core.util.Permissions;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.world.block.BlockType;
 import org.bukkit.Material;
+import org.bukkit.Particle;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Ageable;
@@ -323,6 +324,10 @@ public class EntityEventListener implements Listener {
             }
         }
         event.setCancelled(true);
+        //Spawn Explosion Particles when enabled in settings
+        if (Settings.General.ALWAYS_SHOW_EXPLOSIONS){
+            event.getLocation().getWorld().spawnParticle(Particle.EXPLOSION_HUGE, event.getLocation(), 0);
+        }
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)

--- a/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
@@ -279,6 +279,8 @@ public class Settings extends Config {
         public static boolean SCIENTIFIC = false;
         @Comment("Replace wall when merging")
         public static boolean MERGE_REPLACE_WALL = true;
+        @Comment("Always show explosion Particles")
+        public static boolean ALWAYS_SHOW_EXPLOSIONS = false;
         @Comment({"Blocks that may not be used in plot components",
                 "Checkout the wiki article regarding plot components before modifying: https://github.com/IntellectualSites/PlotSquared-Documentation/wiki/Plot-Components"})
         public static List<String>

--- a/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
@@ -279,7 +279,7 @@ public class Settings extends Config {
         public static boolean SCIENTIFIC = false;
         @Comment("Replace wall when merging")
         public static boolean MERGE_REPLACE_WALL = true;
-        @Comment("Always show explosion Particles")
+        @Comment("Always show explosion Particles, even if explosion flag is set to false")
         public static boolean ALWAYS_SHOW_EXPLOSIONS = false;
         @Comment({"Blocks that may not be used in plot components",
                 "Checkout the wiki article regarding plot components before modifying: https://github.com/IntellectualSites/PlotSquared-Documentation/wiki/Plot-Components"})


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, please create one so we can look into it before approving your PR.
-->

Fixes #3435 

## Description
<!-- Please describe what this pull request does. -->

It simply adds the config option to always display explosion particles, even if the event got canceled.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
