### PR TITLE
Make /plot setowner available for users as well

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Owner.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Owner.java
@@ -29,7 +29,6 @@ import com.google.inject.Inject;
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.configuration.caption.TranslatableCaption;
-import com.plotsquared.core.database.SQLManager;
 import com.plotsquared.core.events.PlotChangeOwnerEvent;
 import com.plotsquared.core.events.PlotUnlinkEvent;
 import com.plotsquared.core.events.Result;
@@ -44,7 +43,6 @@ import com.plotsquared.core.util.PlayerManager;
 import com.plotsquared.core.util.TabCompletions;
 import com.plotsquared.core.util.task.TaskManager;
 import net.kyori.adventure.text.minimessage.Template;
-import org.apache.logging.log4j.LogManager;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 

--- a/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
+++ b/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
@@ -327,7 +327,7 @@ public class PlotListener {
                         }
                         if ((lastPlot != null) && plot.getId().equals(lastPlot.getId()) && plot.hasOwner()) {
                             final UUID plotOwner = plot.getOwnerAbs();
-                            String owner = PlayerManager.getName(plotOwner, false);
+                            String owner = PlayerManager.getName(plotOwner, player, false);
                             Caption header = fromFlag ? StaticCaption.of(title) : TranslatableCaption.of("titles" +
                                     ".title_entered_plot");
                             Caption subHeader = fromFlag ? StaticCaption.of(subtitle) : TranslatableCaption.of("titles" +

--- a/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
@@ -164,25 +164,51 @@ public abstract class PlayerManager<P extends PlotPlayer<? extends T>, T> {
      * @return The player's name, None, Everyone or Unknown
      */
     public static @NonNull String getName(final @Nullable UUID owner) {
-        return getName(owner, true);
+        return getName(owner, LocaleHolder.console());
+    }
+
+    /**
+     * Get the name from a UUID.
+     *
+     * @param owner        Owner UUID
+     * @param localeHolder The locale holder to use as the translation provider
+     * @return The player's name, None, Everyone or Unknown
+     */
+    public static @NonNull String getName(final @Nullable UUID owner, final @NonNull LocaleHolder localeHolder) {
+        return getName(owner, localeHolder, true);
     }
 
     /**
      * Get the name from a UUID.
      *
      * @param owner    Owner UUID
-     * @param blocking Whether or not the operation can be blocking
+     * @param blocking Whether the operation can be blocking
      * @return The player's name, None, Everyone or Unknown
      */
     public static @NonNull String getName(final @Nullable UUID owner, final boolean blocking) {
+        return getName(owner, LocaleHolder.console(), blocking);
+    }
+
+    /**
+     * Get the name from a UUID.
+     *
+     * @param owner        Owner UUID
+     * @param localeHolder The locale holder to use as the translation provider
+     * @param blocking     Whether the operation can be blocking
+     * @return The player's name, None, Everyone or Unknown
+     */
+    public static @NonNull String getName(
+            final @Nullable UUID owner, final @NonNull LocaleHolder localeHolder,
+            final boolean blocking
+    ) {
         if (owner == null) {
-            TranslatableCaption.of("info.none");
+            return TranslatableCaption.of("info.none").getComponent(localeHolder);
         }
         if (owner.equals(DBFunc.EVERYONE)) {
-            TranslatableCaption.of("info.everyone");
+            return TranslatableCaption.of("info.everyone").getComponent(localeHolder);
         }
         if (owner.equals(DBFunc.SERVER)) {
-            TranslatableCaption.of("info.server");
+            return TranslatableCaption.of("info.server").getComponent(localeHolder);
         }
         final String name;
         if (blocking) {
@@ -198,7 +224,7 @@ public abstract class PlayerManager<P extends PlotPlayer<? extends T>, T> {
             }
         }
         if (name == null) {
-            TranslatableCaption.of("info.unknown");
+            return TranslatableCaption.of("info.unknown").getComponent(localeHolder);
         }
         return name;
     }

--- a/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
+++ b/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
@@ -116,7 +116,7 @@ public final class PlaceholderRegistry {
             }
 
             try {
-                return PlayerManager.getName(plotOwner, false);
+                return PlayerManager.getName(plotOwner, player, false);
             } catch (final Exception ignored) {
             }
             return legacyComponent(TranslatableCaption.of("info.unknown"), player);


### PR DESCRIPTION
## Overview

Closes #3347 

## Description
Allows players to use setowner as well. The Set-Command implementation already supports this kind of functionality. 
Also fixed the getName-method, which hasn't returned anything yet.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
