### PR TITLE
Fix: Missing Component returns + plot info on unknown plot owner

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Add.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Add.java
@@ -106,7 +106,7 @@ public class Add extends Command {
                                         .hasPermission(player, Permission.PERMISSION_ADMIN_COMMAND_TRUST))) {
                             player.sendMessage(
                                     TranslatableCaption.of("errors.invalid_player"),
-                                    Template.of("value", PlayerManager.getName(uuid))
+                                    Template.of("value", PlayerManager.resolveName(uuid).getComponent(player))
                             );
                             iterator.remove();
                             continue;
@@ -114,7 +114,7 @@ public class Add extends Command {
                         if (plot.isOwner(uuid)) {
                             player.sendMessage(
                                     TranslatableCaption.of("member.already_added"),
-                                    Template.of("player", PlayerManager.getName(uuid))
+                                    Template.of("player", PlayerManager.resolveName(uuid).getComponent(player))
                             );
                             iterator.remove();
                             continue;
@@ -122,7 +122,7 @@ public class Add extends Command {
                         if (plot.getMembers().contains(uuid)) {
                             player.sendMessage(
                                     TranslatableCaption.of("member.already_added"),
-                                    Template.of("player", PlayerManager.getName(uuid))
+                                    Template.of("player", PlayerManager.resolveName(uuid).getComponent(player))
                             );
                             iterator.remove();
                             continue;

--- a/Core/src/main/java/com/plotsquared/core/command/Deny.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Deny.java
@@ -125,7 +125,7 @@ public class Deny extends SubCommand {
                     } else if (plot.getDenied().contains(uuid)) {
                         player.sendMessage(
                                 TranslatableCaption.of("member.already_added"),
-                                Template.of("player", PlayerManager.getName(uuid))
+                                Template.of("player", PlayerManager.resolveName(uuid).getComponent(player))
                         );
                         return;
                     } else {

--- a/Core/src/main/java/com/plotsquared/core/command/Owner.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Owner.java
@@ -142,7 +142,7 @@ public class Owner extends SetCommand {
             if (plot.isOwner(uuid)) {
                 player.sendMessage(
                         TranslatableCaption.of("member.already_owner"),
-                        Template.of("player", PlayerManager.getName(uuid, false))
+                        Template.of("player", PlayerManager.resolveName(uuid, false).getComponent(player))
                 );
                 return;
             }
@@ -151,7 +151,7 @@ public class Owner extends SetCommand {
                 if (other == null) {
                     player.sendMessage(
                             TranslatableCaption.of("errors.invalid_player_offline"),
-                            Template.of("player", PlayerManager.getName(uuid))
+                            Template.of("player", PlayerManager.resolveName(uuid).getComponent(player))
                     );
                     return;
                 }

--- a/Core/src/main/java/com/plotsquared/core/command/Trust.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Trust.java
@@ -112,7 +112,7 @@ public class Trust extends Command {
                                     .hasPermission(player, Permission.PERMISSION_ADMIN_COMMAND_TRUST))) {
                         player.sendMessage(
                                 TranslatableCaption.of("errors.invalid_player"),
-                                Template.of("value", PlayerManager.getName(uuid))
+                                Template.of("value", PlayerManager.resolveName(uuid).getComponent(player))
                         );
                         iterator.remove();
                         continue;
@@ -120,7 +120,7 @@ public class Trust extends Command {
                     if (currentPlot.isOwner(uuid)) {
                         player.sendMessage(
                                 TranslatableCaption.of("member.already_added"),
-                                Template.of("value", PlayerManager.getName(uuid))
+                                Template.of("value", PlayerManager.resolveName(uuid).getComponent(player))
                         );
                         iterator.remove();
                         continue;
@@ -128,7 +128,7 @@ public class Trust extends Command {
                     if (currentPlot.getTrusted().contains(uuid)) {
                         player.sendMessage(
                                 TranslatableCaption.of("member.already_added"),
-                                Template.of("value", PlayerManager.getName(uuid))
+                                Template.of("value", PlayerManager.resolveName(uuid).getComponent(player))
                         );
                         iterator.remove();
                         continue;

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/Templates.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/Templates.java
@@ -70,7 +70,7 @@ public final class Templates {
      * @return Generated template
      */
     public static @NonNull Template of(final @NonNull String key, final @NonNull UUID uuid) {
-        final String username = PlayerManager.getName(uuid);
+        final String username = PlayerManager.resolveName(uuid).getComponent(LocaleHolder.console());
         return Template.of(key, username);
     }
 

--- a/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
+++ b/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
@@ -327,7 +327,7 @@ public class PlotListener {
                         }
                         if ((lastPlot != null) && plot.getId().equals(lastPlot.getId()) && plot.hasOwner()) {
                             final UUID plotOwner = plot.getOwnerAbs();
-                            String owner = PlayerManager.getName(plotOwner, false);
+                            String owner = PlayerManager.getName(plotOwner, player, false);
                             Caption header = fromFlag ? StaticCaption.of(title) : TranslatableCaption.of("titles" +
                                     ".title_entered_plot");
                             Caption subHeader = fromFlag ? StaticCaption.of(subtitle) : TranslatableCaption.of("titles" +

--- a/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
+++ b/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
@@ -327,7 +327,7 @@ public class PlotListener {
                         }
                         if ((lastPlot != null) && plot.getId().equals(lastPlot.getId()) && plot.hasOwner()) {
                             final UUID plotOwner = plot.getOwnerAbs();
-                            String owner = PlayerManager.getName(plotOwner, player, false);
+                            String owner = PlayerManager.resolveName(plotOwner, false).getComponent(player);
                             Caption header = fromFlag ? StaticCaption.of(title) : TranslatableCaption.of("titles" +
                                     ".title_entered_plot");
                             Caption subHeader = fromFlag ? StaticCaption.of(subtitle) : TranslatableCaption.of("titles" +

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -2838,7 +2838,7 @@ public class Plot {
                             if (time != 0) {
                                 seen = TimeUtil.secToTime(time);
                             } else {
-                                seen = TranslatableCaption.of("info.known").getComponent(player);
+                                seen = TranslatableCaption.of("info.unknown").getComponent(player);
                             }
                         }
                     } else {

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
@@ -30,6 +30,7 @@ import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.ConfigurationUtil;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.configuration.caption.Caption;
+import com.plotsquared.core.configuration.caption.LocaleHolder;
 import com.plotsquared.core.configuration.caption.TranslatableCaption;
 import com.plotsquared.core.database.DBFunc;
 import com.plotsquared.core.events.PlotComponentSetEvent;
@@ -358,7 +359,8 @@ public final class PlotModificationManager {
         if (createSign) {
             queue.setCompleteTask(() -> TaskManager.runTaskAsync(() -> {
                 for (Plot current : plots) {
-                    current.getPlotModificationManager().setSign(PlayerManager.getName(current.getOwnerAbs()));
+                    current.getPlotModificationManager().setSign(PlayerManager.resolveName(current.getOwnerAbs()).getComponent(
+                            LocaleHolder.console()));
                 }
             }));
         }

--- a/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
@@ -164,25 +164,51 @@ public abstract class PlayerManager<P extends PlotPlayer<? extends T>, T> {
      * @return The player's name, None, Everyone or Unknown
      */
     public static @NonNull String getName(final @Nullable UUID owner) {
-        return getName(owner, true);
+        return getName(owner, LocaleHolder.console());
+    }
+
+    /**
+     * Get the name from a UUID.
+     *
+     * @param owner        Owner UUID
+     * @param localeHolder The locale holder to use as the translation provider
+     * @return The player's name, None, Everyone or Unknown
+     */
+    public static @NonNull String getName(final @Nullable UUID owner, final @NonNull LocaleHolder localeHolder) {
+        return getName(owner, localeHolder, true);
     }
 
     /**
      * Get the name from a UUID.
      *
      * @param owner    Owner UUID
-     * @param blocking Whether or not the operation can be blocking
+     * @param blocking Whether the operation can be blocking
      * @return The player's name, None, Everyone or Unknown
      */
     public static @NonNull String getName(final @Nullable UUID owner, final boolean blocking) {
+        return getName(owner, LocaleHolder.console(), blocking);
+    }
+
+    /**
+     * Get the name from a UUID.
+     *
+     * @param owner        Owner UUID
+     * @param localeHolder The locale holder to use as the translation provider
+     * @param blocking     Whether the operation can be blocking
+     * @return The player's name, None, Everyone or Unknown
+     */
+    public static @NonNull String getName(
+            final @Nullable UUID owner, final @NonNull LocaleHolder localeHolder,
+            final boolean blocking
+    ) {
         if (owner == null) {
-            TranslatableCaption.of("info.none");
+            return TranslatableCaption.of("info.none").getComponent(localeHolder);
         }
         if (owner.equals(DBFunc.EVERYONE)) {
-            TranslatableCaption.of("info.everyone");
+            return TranslatableCaption.of("info.everyone").getComponent(localeHolder);
         }
         if (owner.equals(DBFunc.SERVER)) {
-            TranslatableCaption.of("info.server");
+            return TranslatableCaption.of("info.server").getComponent(localeHolder);
         }
         final String name;
         if (blocking) {
@@ -198,7 +224,7 @@ public abstract class PlayerManager<P extends PlotPlayer<? extends T>, T> {
             }
         }
         if (name == null) {
-            TranslatableCaption.of("info.unknown");
+            return TranslatableCaption.of("info.unknown").getComponent(localeHolder);
         }
         return name;
     }

--- a/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
@@ -166,7 +166,7 @@ public abstract class PlayerManager<P extends PlotPlayer<? extends T>, T> {
      * @return The player's name, None, Everyone or Unknown
      * @deprecated Use {@link #resolveName(UUID)}
      */
-    @Deprecated(forRemoval = true, since = "6.2.3")
+    @Deprecated(forRemoval = true, since = "TODO")
     public static @NonNull String getName(final @Nullable UUID owner) {
         return getName(owner, true);
     }
@@ -179,7 +179,7 @@ public abstract class PlayerManager<P extends PlotPlayer<? extends T>, T> {
      * @return The player's name, None, Everyone or Unknown
      * @deprecated Use {@link #resolveName(UUID, boolean)}
      */
-    @Deprecated(forRemoval = true, since = "6.2.3")
+    @Deprecated(forRemoval = true, since = "TODO")
     public static @NonNull String getName(final @Nullable UUID owner, final boolean blocking) {
         if (owner == null) {
             TranslatableCaption.of("info.none");

--- a/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
@@ -43,7 +43,16 @@ import net.kyori.adventure.text.minimessage.Template;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 

--- a/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
@@ -217,7 +217,7 @@ public abstract class PlayerManager<P extends PlotPlayer<? extends T>, T> {
      * @param owner The UUID of the owner
      * @return A caption containing either the name, {@code None}, {@code Everyone} or {@code Unknown}
      * @see #resolveName(UUID, boolean)
-     * @since 6.2.3
+     * @since TODO
      */
     public static @NonNull Caption resolveName(final @Nullable UUID owner) {
         return resolveName(owner, true);
@@ -229,7 +229,7 @@ public abstract class PlayerManager<P extends PlotPlayer<? extends T>, T> {
      * @param owner    The UUID of the owner
      * @param blocking If the operation should block the current thread for {@link Settings.UUID#BLOCKING_TIMEOUT} milliseconds
      * @return A caption containing either the name, {@code None}, {@code Everyone} or {@code Unknown}
-     * @since 6.2.3
+     * @since TODO
      */
     public static @NonNull Caption resolveName(final @Nullable UUID owner, final boolean blocking) {
         if (owner == null) {

--- a/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
+++ b/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
@@ -116,7 +116,7 @@ public final class PlaceholderRegistry {
             }
 
             try {
-                return PlayerManager.getName(plotOwner, player, false);
+                return PlayerManager.resolveName(plotOwner, false).getComponent(player);
             } catch (final Exception ignored) {
             }
             return legacyComponent(TranslatableCaption.of("info.unknown"), player);

--- a/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
+++ b/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
@@ -116,7 +116,7 @@ public final class PlaceholderRegistry {
             }
 
             try {
-                return PlayerManager.getName(plotOwner, false);
+                return PlayerManager.getName(plotOwner, player, false);
             } catch (final Exception ignored) {
             }
             return legacyComponent(TranslatableCaption.of("info.unknown"), player);


### PR DESCRIPTION
## Overview

Fixes #3443 

## Description
d3fe1d3b2bab02a7e1ef66d3c69d0cfa49d65f26 introduced an issue now known as https://github.com/IntellectualSites/PlotSquared/issues/3443
That was due to a incorrect locale, which should've thrown an exception, but that happened in another thread and just halted the whole thread.
That happened because of missing player data in bukkits storage, documentation from OfflinePlayer#getLastSeen:
> Gets the last date and time that this player was seen on the server.
> If the player has never played before, this will return 0.

That would also explain https://github.com/IntellectualSites/PlotSquared/issues/3006, as the mentioned method is used to determine the last online time of all plot owners. if that is equal to 0, nothing will be deleted: https://github.com/IntellectualSites/PlotSquared/blob/v6/Core/src/main/java/com/plotsquared/core/plot/expiration/ExpireManager.java#L229. That should be changed.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
