### PR TITLE
Unify true/false style in `@return` javadoc

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/PlotSquared.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotSquared.java
@@ -306,7 +306,7 @@ public class PlotSquared {
      *
      * @param version  First version
      * @param version2 Second version
-     * @return true if `version` is &gt;= `version2`
+     * @return {@code true} if `version` is &gt;= `version2`
      */
     public boolean checkVersion(
             final int[] version,
@@ -733,7 +733,7 @@ public class PlotSquared {
      *
      * @param plot      the plot to remove
      * @param callEvent If to call an event about the plot being removed
-     * @return true if plot existed | false if it didn't
+     * @return {@code true} if plot existed | {@code false} if it didn't
      */
     public boolean removePlot(
             final @NonNull Plot plot,
@@ -1476,7 +1476,7 @@ public class PlotSquared {
      *
      * @param world            World name
      * @param chunkCoordinates Chunk coordinates
-     * @return True if the chunk uses non-standard generation, false if not
+     * @return {@code true} if the chunk uses non-standard generation, {@code false} if not
      */
     public boolean isNonStandardGeneration(
             final @NonNull String world,

--- a/Core/src/main/java/com/plotsquared/core/PlotVersion.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotVersion.java
@@ -122,7 +122,7 @@ public final class PlotVersion {
      * Compare a given version string with the one cached here.
      *
      * @param versionString the version to compare
-     * @return true if the given version is a "later" version
+     * @return {@code true} if the given version is a "later" version
      */
     public boolean isLaterVersion(final @NonNull String versionString) {
         int dash = versionString.indexOf('-');
@@ -144,7 +144,7 @@ public final class PlotVersion {
      * Compare a given version with the one cached here.
      *
      * @param verArray the version to compare
-     * @return true if the given version is a "later" version
+     * @return {@code true} if the given version is a "later" version
      */
     public boolean isLaterVersion(int[] verArray) {
         if (verArray[0] > version[0]) {

--- a/Core/src/main/java/com/plotsquared/core/backup/BackupManager.java
+++ b/Core/src/main/java/com/plotsquared/core/backup/BackupManager.java
@@ -88,7 +88,7 @@ public interface BackupManager {
      * Returns true if (potentially) destructive actions should cause
      * PlotSquared to create automatic plot backups
      *
-     * @return True if automatic backups are enabled
+     * @return {@code true} if automatic backups are enabled
      */
     boolean shouldAutomaticallyBackup();
 

--- a/Core/src/main/java/com/plotsquared/core/command/Command.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Command.java
@@ -288,7 +288,7 @@ public abstract class Command {
      * @param args     Arguments
      * @param confirm  Instance, Success, Failure
      * @param whenDone task to run when done
-     * @return CompletableFuture true if the command executed fully, false in
+     * @return CompletableFuture {@code true} if the command executed fully, {@code false} in
      *         any other case
      */
     public CompletableFuture<Boolean> execute(

--- a/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
@@ -165,7 +165,7 @@ public final class FlagCommand extends Command {
     /**
      * Checks if the player is allowed to modify the flags at their current location
      *
-     * @return true if the player is allowed to modify the flags at their current location
+     * @return {@code true} if the player is allowed to modify the flags at their current location
      */
     private static boolean checkRequirements(final @NonNull PlotPlayer<?> player) {
         final Location location = player.getLocation();

--- a/Core/src/main/java/com/plotsquared/core/configuration/ConfigurationSection.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/ConfigurationSection.java
@@ -73,7 +73,7 @@ public interface ConfigurationSection {
      * has been specified, this will return true.
      *
      * @param path Path to check for existence.
-     * @return True if this section contains the requested path, either via
+     * @return {@code true} if this section contains the requested path, either via
      *         default or being set.
      * @throws IllegalArgumentException Thrown when path is {@code null}.
      */
@@ -87,7 +87,7 @@ public interface ConfigurationSection {
      * has been specified, this will still return false.
      *
      * @param path Path to check for existence.
-     * @return True if this section contains the requested path, regardless of
+     * @return {@code true} if this section contains the requested path, regardless of
      *         having a default.
      * @throws IllegalArgumentException Thrown when path is {@code null}.
      */

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/CaptionMap.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/CaptionMap.java
@@ -60,7 +60,7 @@ public interface CaptionMap {
      * Check if the map supports a given locale
      *
      * @param locale Locale
-     * @return True if the map supports the locale
+     * @return {@code true} if the map supports the locale
      */
     boolean supportsLocale(final @NonNull Locale locale);
 

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/ChatFormatter.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/ChatFormatter.java
@@ -99,7 +99,7 @@ public interface ChatFormatter {
          * Whether or not the output should escape
          * any formatting keys
          *
-         * @return True if raw output is to be used
+         * @return {@code true} if raw output is to be used
          */
         public boolean isRawOutput() {
             return this.rawOutput;

--- a/Core/src/main/java/com/plotsquared/core/database/AbstractDB.java
+++ b/Core/src/main/java/com/plotsquared/core/database/AbstractDB.java
@@ -371,7 +371,7 @@ public interface AbstractDB {
     /**
      * Don't use this method unless you want to ruin someone's server.
      *
-     * @return true if the tables were deleted, false when an error is encountered
+     * @return {@code true} if the tables were deleted, {@code false} when an error is encountered
      */
     boolean deleteTables();
 

--- a/Core/src/main/java/com/plotsquared/core/database/Database.java
+++ b/Core/src/main/java/com/plotsquared/core/database/Database.java
@@ -52,7 +52,7 @@ public abstract class Database {
     /**
      * Checks if a connection is open with the database.
      *
-     * @return true if the connection is open
+     * @return {@code true} if the connection is open
      * @throws SQLException if the connection cannot be checked
      */
     public abstract boolean checkConnection() throws SQLException;
@@ -67,7 +67,7 @@ public abstract class Database {
     /**
      * Closes the connection with the database.
      *
-     * @return true if successful
+     * @return {@code true} if successful
      * @throws SQLException if the connection cannot be closed
      */
     public abstract boolean closeConnection() throws SQLException;

--- a/Core/src/main/java/com/plotsquared/core/events/PlayerPlotDeniedEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlayerPlotDeniedEvent.java
@@ -42,7 +42,7 @@ public class PlayerPlotDeniedEvent extends PlotEvent {
      * @param initiator Player that initiated the event
      * @param plot      Plot in which the event occurred
      * @param player    Player that was denied/un-denied
-     * @param added     true of add to deny list, false if removed
+     * @param added     {@code true} of add to deny list, {@code false} if removed
      */
     public PlayerPlotDeniedEvent(PlotPlayer<?> initiator, Plot plot, UUID player, boolean added) {
         super(plot);

--- a/Core/src/main/java/com/plotsquared/core/events/PlayerPlotHelperEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlayerPlotHelperEvent.java
@@ -45,7 +45,7 @@ public class PlayerPlotHelperEvent extends PlotEvent {
      * @param initiator Player that initiated the event
      * @param plot      Plot in which the event occurred
      * @param player    Player that was added/removed from the helper list
-     * @param added     true of the player was added, false if the player was removed
+     * @param added     {@code true} if the player was added, {@code false} if the player was removed
      */
     public PlayerPlotHelperEvent(PlotPlayer<?> initiator, Plot plot, UUID player, boolean added) {
         super(plot);

--- a/Core/src/main/java/com/plotsquared/core/events/PlayerPlotTrustedEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlayerPlotTrustedEvent.java
@@ -42,7 +42,7 @@ public class PlayerPlotTrustedEvent extends PlotEvent {
      * @param initiator Player that initiated the event
      * @param plot      Plot in which the event occurred
      * @param player    Player that was added/removed from the trusted list
-     * @param added     true of the player was added, false if the player was removed
+     * @param added     {@code true} if the player was added, {@code false} if the player was removed
      */
     public PlayerPlotTrustedEvent(PlotPlayer<?> initiator, Plot plot, UUID player, boolean added) {
         super(plot);

--- a/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
+++ b/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
@@ -501,7 +501,7 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
      * Retrieves the attribute of this player.
      *
      * @param key metadata key
-     * @return the attribute will be either true or false
+     * @return the attribute will be either {@code true} or {@code false}
      */
     public boolean getAttribute(String key) {
         if (!hasPersistentMeta("attrib_" + key)) {
@@ -572,7 +572,7 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
     /**
      * Check if this player is banned.
      *
-     * @return true if the player is banned, false otherwise.
+     * @return {@code true} if the player is banned, {@code false} otherwise.
      */
     public abstract boolean isBanned();
 

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -1225,7 +1225,7 @@ public class Plot {
     /**
      * Returns true if a previous task was running
      *
-     * @return true if a previous task is running
+     * @return {@code true} if a previous task is running
      */
     public int addRunning() {
         int value = this.getRunning();
@@ -1269,7 +1269,7 @@ public class Plot {
     /**
      * Unclaim the plot (does not modify terrain). Changes made to this plot will not be reflected in unclaimed plot objects.
      *
-     * @return false if the Plot has no owner, otherwise true.
+     * @return {@code false} if the Plot has no owner, otherwise {@code true}.
      */
     public boolean unclaim() {
         if (!this.hasOwner()) {
@@ -2669,7 +2669,7 @@ public class Plot {
     /**
      * Checks if the owner of this Plot is online.
      *
-     * @return true if the owner of the Plot is online
+     * @return {@code true} if the owner of the Plot is online
      */
     public boolean isOnline() {
         if (!this.hasOwner()) {

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
@@ -295,7 +295,7 @@ public abstract class PlotArea {
      * Check if a PlotArea is compatible (move/copy etc.).
      *
      * @param plotArea the {@link PlotArea} to compare
-     * @return true if both areas are compatible
+     * @return {@code true} if both areas are compatible
      */
     public boolean isCompatible(final @NonNull PlotArea plotArea) {
         final ConfigurationSection section = this.worldConfiguration.getConfigurationSection("worlds");
@@ -1101,7 +1101,7 @@ public abstract class PlotArea {
      * If a schematic is available, it can be used for plot claiming.
      *
      * @param schematic the schematic to look for.
-     * @return true if the schematic exists, false otherwise.
+     * @return {@code true} if the schematic exists, {@code false} otherwise.
      */
     public boolean hasSchematic(@NonNull String schematic) {
         return getSchematics().contains(schematic.toLowerCase());
@@ -1110,7 +1110,7 @@ public abstract class PlotArea {
     /**
      * Get whether economy is enabled and used on this plot area or not.
      *
-     * @return true if this plot area uses economy, false otherwise.
+     * @return {@code true} if this plot area uses economy, {@code false} otherwise.
      */
     public boolean useEconomy() {
         return useEconomy;
@@ -1119,7 +1119,7 @@ public abstract class PlotArea {
     /**
      * Get whether the plot area is limited by a world border or not.
      *
-     * @return true if the plot area has a world border, false otherwise.
+     * @return {@code true} if the plot area has a world border, {@code false} otherwise.
      */
     public boolean hasWorldBorder() {
         return worldBorder;
@@ -1128,7 +1128,7 @@ public abstract class PlotArea {
     /**
      * Get whether plot signs are allowed or not.
      *
-     * @return true if plot signs are allow, false otherwise.
+     * @return {@code true} if plot signs are allowed, {@code false} otherwise.
      */
     public boolean allowSigns() {
         return allowSigns;

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotManager.java
@@ -187,7 +187,7 @@ public abstract class PlotManager {
      * @param plotIds list of PlotIds to finish the merge for
      * @param queue   Nullable {@link QueueCoordinator}. If null, creates own queue and enqueues,
      *                otherwise writes to the queue but does not enqueue.
-     * @return false if part if the merge failed, otherwise true if successful.
+     * @return {@code false} if part if the merge failed, otherwise {@code true} if successful.
      */
     public abstract boolean finishPlotMerge(@NonNull List<PlotId> plotIds, @Nullable QueueCoordinator queue);
 
@@ -224,7 +224,7 @@ public abstract class PlotManager {
      *
      * @param queue Nullable {@link QueueCoordinator}. If null, creates own queue and enqueues,
      *              otherwise writes to the queue but does not enqueue.
-     * @return true if the wall blocks were successfully set
+     * @return {@code true} if the wall blocks were successfully set
      */
     public boolean regenerateAllPlotWalls(@Nullable QueueCoordinator queue) {
         boolean success = true;

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
@@ -448,7 +448,7 @@ public final class PlotModificationManager {
      * - Any setting from before plot creation will not be saved until the server is stopped properly. i.e. Set any values/options after plot
      * creation.
      *
-     * @return true if plot was created successfully
+     * @return {@code true} if plot was created successfully
      */
     public boolean create() {
         return this.create(this.plot.getOwnerAbs(), true);
@@ -792,7 +792,7 @@ public final class PlotModificationManager {
     /**
      * Unlink a plot and remove the roads
      *
-     * @return true if plot was linked
+     * @return {@code true} if plot was linked
      * @see #unlinkPlot(boolean, boolean)
      */
     public boolean unlink() {

--- a/Core/src/main/java/com/plotsquared/core/plot/comment/CommentInbox.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/comment/CommentInbox.java
@@ -54,7 +54,7 @@ public abstract class CommentInbox {
     /**
      * @param plot   the plot's inbox to write to
      * @param player the player trying to write the comment
-     * @return true if the player can write a comment on the plot
+     * @return {@code true} if the player can write a comment on the plot
      */
     public boolean canWrite(Plot plot, PlotPlayer<?> player) {
         if (plot == null) {
@@ -68,7 +68,7 @@ public abstract class CommentInbox {
     /**
      * @param plot   the plot's inbox to write to
      * @param player the player trying to modify the inbox
-     * @return true if the player can write a comment on the plot
+     * @return {@code true} if the player can write a comment on the plot
      */
     @SuppressWarnings({"BooleanMethodIsAlwaysInverted"})
     public boolean canModify(Plot plot, PlotPlayer<?> player) {

--- a/Core/src/main/java/com/plotsquared/core/util/ChunkUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/ChunkUtil.java
@@ -123,7 +123,7 @@ public class ChunkUtil {
      * @param pos1  Region minimum point
      * @param pos2  Region maximum point
      * @param chunk BlockVector2 of chunk coordinates
-     * @return true if the region pos1-pos2 contains the chunk
+     * @return {@code true} if the region pos1-pos2 contains the chunk
      */
     public static boolean isWholeChunk(@NonNull Location pos1, @NonNull Location pos2, @NonNull BlockVector2 chunk) {
         int x1 = pos1.getX();

--- a/Core/src/main/java/com/plotsquared/core/util/PremiumVerification.java
+++ b/Core/src/main/java/com/plotsquared/core/util/PremiumVerification.java
@@ -52,7 +52,7 @@ public class PremiumVerification {
 
     /**
      * @param userID Spigot user ID
-     * @return true if userID does not contain __USER__
+     * @return {@code true} if userID does not contain __USER__
      */
     private static Boolean isPremium(String userID) {
         return !userID.contains("__USER__");
@@ -61,7 +61,7 @@ public class PremiumVerification {
     /**
      * Returns true if this plugin is premium
      *
-     * @return if is premium
+     * @return {@code true} if is premium
      */
     public static Boolean isPremium() {
         return usingPremium == null ? (usingPremium = isPremium(getUserID())) : usingPremium;

--- a/Core/src/main/java/com/plotsquared/core/util/RegionManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/RegionManager.java
@@ -120,7 +120,7 @@ public abstract class RegionManager {
      * @param actor   the actor associated with the cuboid set
      * @param queue   Nullable {@link QueueCoordinator}. If null, creates own queue and enqueues,
      *                otherwise writes to the queue but does not enqueue.
-     * @return true if not enqueued, otherwise whether the created queue enqueued.
+     * @return {@code true} if not enqueued, otherwise whether the created queue enqueued.
      */
     public boolean setCuboids(
             final @NonNull PlotArea area,
@@ -161,7 +161,7 @@ public abstract class RegionManager {
      * Notify any plugins that may want to modify clear behaviour that a clear is occuring
      *
      * @param manager plot manager
-     * @return true if the notified will accept the clear task
+     * @return {@code true} if the notified will accept the clear task
      */
     public boolean notifyClear(PlotManager manager) {
         return false;
@@ -174,7 +174,7 @@ public abstract class RegionManager {
      * @param whenDone task to run when complete
      * @param manager  plot manager
      * @param actor    the player running the clear
-     * @return true if the clear worked. False if someone went wrong so P2 can then handle the clear
+     * @return {@code true} if the clear worked. {@code false} if someone went wrong so P2 can then handle the clear
      */
     public abstract boolean handleClear(
             @NonNull Plot plot,

--- a/Core/src/main/java/com/plotsquared/core/util/SchematicHandler.java
+++ b/Core/src/main/java/com/plotsquared/core/util/SchematicHandler.java
@@ -543,7 +543,7 @@ public abstract class SchematicHandler {
      *
      * @param tag  to save
      * @param path to save in
-     * @return true if succeeded
+     * @return {@code true} if succeeded
      */
     public boolean save(CompoundTag tag, String path) {
         if (tag == null) {

--- a/Core/src/main/java/com/plotsquared/core/util/query/PlotQuery.java
+++ b/Core/src/main/java/com/plotsquared/core/util/query/PlotQuery.java
@@ -419,7 +419,7 @@ public final class PlotQuery implements Iterable<Plot> {
      * Get whether any provided plot matches the given filters.
      * If no plot was provided, false will be returned.
      *
-     * @return true if any provided plot matches the filters.
+     * @return {@code true} if any provided plot matches the filters.
      */
     public boolean anyMatch() {
         if (this.filters.isEmpty()) {

--- a/Core/src/main/java/com/plotsquared/core/uuid/UUIDService.java
+++ b/Core/src/main/java/com/plotsquared/core/uuid/UUIDService.java
@@ -70,7 +70,7 @@ public interface UUIDService {
      * Check whether or not this service can be safely used synchronously
      * without blocking the server for an extended amount of time.
      *
-     * @return True if the service can be used synchronously
+     * @return {@code true} if the service can be used synchronously
      */
     default boolean canBeSynchronous() {
         return false;


### PR DESCRIPTION
## Overview

## Description
The change proposed shifts the left over true/false in `@return` javadocs to the typical escaped style, we use everywhere else.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [X] Changelog entries in the PR title are correct
- [X] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.