### PR TITLE
Fix the set block timer if the queue is not empty

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
@@ -262,7 +262,9 @@ public final class PlotModificationManager {
                     if (queue.size() > 0) {
                         queue.setCompleteTask(run);
                         queue.enqueue();
+                        return;
                     }
+                    run.run();
                     return;
                 }
                 Plot current = queue.poll();


### PR DESCRIPTION
## Overview

Fixes #3343

## Description
Fixes the issue, that plot delete doesnt work on partial plot worlds, as no changes will be put into the queue and `whenDone` isn't called.
Now, `whenDone` is called immediately if the queue is empty.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [x] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
