### PR TITLE
Separate linked javadocs per module

### DIFF
--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -95,9 +95,9 @@ tasks.named<ShadowJar>("shadowJar") {
 tasks {
     withType<Javadoc> {
         val opt = options as StandardJavadocDocletOptions
-        opt.links("https://papermc.io/javadocs/paper/1.17/")
-        opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-core/7.2.7/")
-        opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-bukkit/7.2.7/")
+        opt.links("https://papermc.io/javadocs/paper/1.18/")
+        opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-bukkit/7.2.8/")
+        opt.links("https://javadoc.io/doc/com.plotsquared/PlotSquared-Core/latest/")
         opt.links("https://jd.adventure.kyori.net/api/4.9.3/")
         opt.links("https://google.github.io/guice/api-docs/5.0.1/javadoc/")
         opt.links("https://checkerframework.org/api/")

--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -96,10 +96,10 @@ tasks {
     withType<Javadoc> {
         val opt = options as StandardJavadocDocletOptions
         opt.links("https://papermc.io/javadocs/paper/1.18/")
-        opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-bukkit/7.2.8/")
+        opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-bukkit/" + libs.worldeditBukkit.get().versionConstraint.toString())
         opt.links("https://javadoc.io/doc/com.plotsquared/PlotSquared-Core/latest/")
-        opt.links("https://jd.adventure.kyori.net/api/4.9.3/")
-        opt.links("https://google.github.io/guice/api-docs/5.0.1/javadoc/")
+        opt.links("https://jd.adventure.kyori.net/api/" + libs.adventure.get().versionConstraint.toString())
+        opt.links("https://google.github.io/guice/api-docs/" + libs.guice.get().versionConstraint.toString() + "/javadoc/")
         opt.links("https://checkerframework.org/api/")
     }
 }

--- a/Core/build.gradle.kts
+++ b/Core/build.gradle.kts
@@ -58,9 +58,9 @@ tasks.processResources {
 tasks {
     withType<Javadoc> {
         val opt = options as StandardJavadocDocletOptions
-        opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-core/7.2.8/")
-        opt.links("https://jd.adventure.kyori.net/api/4.9.3/")
-        opt.links("https://google.github.io/guice/api-docs/5.0.1/javadoc/")
+        opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-core/" + libs.worldeditCore.get().versionConstraint.toString())
+        opt.links("https://jd.adventure.kyori.net/api/" + libs.adventure.get().versionConstraint.toString())
+        opt.links("https://google.github.io/guice/api-docs/" + libs.guice.get().versionConstraint.toString() + "/javadoc/")
         opt.links("https://checkerframework.org/api/")
     }
 }

--- a/Core/build.gradle.kts
+++ b/Core/build.gradle.kts
@@ -54,3 +54,13 @@ tasks.processResources {
         )
     }
 }
+
+tasks {
+    withType<Javadoc> {
+        val opt = options as StandardJavadocDocletOptions
+        opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-core/7.2.8/")
+        opt.links("https://jd.adventure.kyori.net/api/4.9.3/")
+        opt.links("https://google.github.io/guice/api-docs/5.0.1/javadoc/")
+        opt.links("https://checkerframework.org/api/")
+    }
+}


### PR DESCRIPTION
## Overview

## Description
Javadocs are written and published per module. Modules do now deliver javadoc linking properly, where the Bukkit module contains links for Bukkit-like stuff and the Core module for core components. See the WorldEdit doc separation for example, Bukkit can only utilize the bukkit module, therefore the core javadocs have been moved to the core module, to ensure, when you are working with any module, the proper javadocs are linked and no FQNs are served for important parts of our code base.

Are there any other kinds of interesting javadoc links we could add that may be handy for API consumers?

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [X] Changelog entries in the PR title are correct
- [X] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
