### PR TITLE
Cancel block placement if the block consists of two block states

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -279,7 +279,7 @@ public class BlockEventListener implements Listener {
         BukkitPlayer pp = BukkitUtil.adapt(player);
         Plot plot = area.getPlot(location);
         if (plot != null) {
-            if ((location.getY() > area.getMaxBuildHeight() || location.getY() < area
+            if ((location.getY() >= area.getMaxBuildHeight() || location.getY() < area
                     .getMinBuildHeight()) && !Permissions
                     .hasPermission(pp, Permission.PERMISSION_ADMIN_BUILD_HEIGHT_LIMIT)) {
                 event.setCancelled(true);
@@ -364,7 +364,7 @@ public class BlockEventListener implements Listener {
                     event.setCancelled(true);
                     return;
                 }
-            } else if ((location.getY() > area.getMaxBuildHeight() || location.getY() < area
+            } else if ((location.getY() >= area.getMaxBuildHeight() || location.getY() < area
                     .getMinBuildHeight()) && !Permissions
                     .hasPermission(plotPlayer, Permission.PERMISSION_ADMIN_BUILD_HEIGHT_LIMIT)) {
                 event.setCancelled(true);
@@ -1245,7 +1245,7 @@ public class BlockEventListener implements Listener {
             if (Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_BUILD_HEIGHT_LIMIT)) {
                 continue;
             }
-            if (currentLocation.getY() > area.getMaxBuildHeight() || currentLocation.getY() < area.getMinBuildHeight()) {
+            if (currentLocation.getY() >= area.getMaxBuildHeight() || currentLocation.getY() < area.getMinBuildHeight()) {
                 pp.sendMessage(
                         TranslatableCaption.of("height.height_limit"),
                         Template.of("minHeight", String.valueOf(area.getMinBuildHeight())),

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -74,9 +74,8 @@ import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.block.data.type.Bed;
-import org.bukkit.block.data.type.Door;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Fireball;
 import org.bukkit.entity.Player;
@@ -94,6 +93,7 @@ import org.bukkit.event.block.BlockFormEvent;
 import org.bukkit.event.block.BlockFromToEvent;
 import org.bukkit.event.block.BlockGrowEvent;
 import org.bukkit.event.block.BlockIgniteEvent;
+import org.bukkit.event.block.BlockMultiPlaceEvent;
 import org.bukkit.event.block.BlockPhysicsEvent;
 import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
@@ -324,30 +324,6 @@ public class BlockEventListener implements Listener {
                     );
                     event.setCancelled(true);
                     return;
-                }
-            }
-            // The other block part can be placed outside the plot (#3483)
-            if (event.getBlock().getBlockData() instanceof Bed bed) {
-                org.bukkit.Location other = event.getBlock().getLocation().add(bed.getFacing().getDirection());
-                if (!(Objects.equals(BukkitUtil.adapt(other).getPlot(), plot))) {
-                    pp.sendMessage(
-                            TranslatableCaption.of("permission.no_permission_event"),
-                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_ROAD))
-                    );
-                    event.setCancelled(true);
-                    return;
-                }
-            }
-            // Same goes for doors, which may exceed the area height limit
-            if (event.getBlock().getBlockData() instanceof Door door) {
-                if (location.getY() + 1 > area.getMaxBuildHeight() &&
-                        !Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_BUILD_HEIGHT_LIMIT)) {
-                    pp.sendMessage(
-                            TranslatableCaption.of("height.height_limit"),
-                            Template.of("minHeight", String.valueOf(area.getMinBuildHeight())),
-                            Template.of("maxHeight", String.valueOf(area.getMaxBuildHeight()))
-                    );
-                    event.setCancelled(true);
                 }
             }
             if (plot.getFlag(DisablePhysicsFlag.class)) {
@@ -1231,6 +1207,53 @@ public class BlockEventListener implements Listener {
             // Cancel event so the sponge block doesn't turn into a wet sponge
             // if no water is being absorbed
             event.setCancelled(true);
+        }
+    }
+
+    /*
+     * BlockMultiPlaceEvent is called unrelated to the BlockPlaceEvent itself and therefor doesn't respect the cancellation.
+     */
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
+    public void onBlockMultiPlace(BlockMultiPlaceEvent event) {
+        // Check if the generic block place event would be cancelled
+        blockCreate(event);
+        if (event.isCancelled()) {
+            return;
+        }
+
+        BukkitPlayer pp = BukkitUtil.adapt(event.getPlayer());
+        Location placedLocation = BukkitUtil.adapt(event.getBlockReplacedState().getLocation());
+        PlotArea area = placedLocation.getPlotArea();
+        if (area == null) {
+            return;
+        }
+        Plot plot = placedLocation.getPlot();
+
+        for (final BlockState state : event.getReplacedBlockStates()) {
+            Location currentLocation = BukkitUtil.adapt(state.getLocation());
+            if (!Permissions.hasPermission(
+                    pp,
+                    Permission.PERMISSION_ADMIN_BUILD_ROAD
+            ) && !(Objects.equals(currentLocation.getPlot(), plot))) {
+                pp.sendMessage(
+                        TranslatableCaption.of("permission.no_permission_event"),
+                        Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_ROAD))
+                );
+                event.setCancelled(true);
+                break;
+            }
+            if (Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_BUILD_HEIGHT_LIMIT)) {
+                continue;
+            }
+            if (currentLocation.getY() > area.getMaxBuildHeight() || currentLocation.getY() < area.getMinBuildHeight()) {
+                pp.sendMessage(
+                        TranslatableCaption.of("height.height_limit"),
+                        Template.of("minHeight", String.valueOf(area.getMinBuildHeight())),
+                        Template.of("maxHeight", String.valueOf(area.getMaxBuildHeight()))
+                );
+                event.setCancelled(true);
+                break;
+            }
         }
     }
 

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -1211,7 +1211,7 @@ public class BlockEventListener implements Listener {
     }
 
     /*
-     * BlockMultiPlaceEvent is called unrelated to the BlockPlaceEvent itself and therefor doesn't respect the cancellation.
+     * BlockMultiPlaceEvent is called unrelated to the BlockPlaceEvent itself and therefore doesn't respect the cancellation.
      */
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     public void onBlockMultiPlace(BlockMultiPlaceEvent event) {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -75,6 +75,8 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.type.Bed;
+import org.bukkit.block.data.type.Door;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Fireball;
 import org.bukkit.entity.Player;
@@ -322,6 +324,30 @@ public class BlockEventListener implements Listener {
                     );
                     event.setCancelled(true);
                     return;
+                }
+            }
+            // The other block part can be placed outside the plot (#3483)
+            if (event.getBlock().getBlockData() instanceof Bed bed) {
+                org.bukkit.Location other = event.getBlock().getLocation().add(bed.getFacing().getDirection());
+                if (!(Objects.equals(BukkitUtil.adapt(other).getPlot(), plot))) {
+                    pp.sendMessage(
+                            TranslatableCaption.of("permission.no_permission_event"),
+                            Template.of("node", String.valueOf(Permission.PERMISSION_ADMIN_BUILD_ROAD))
+                    );
+                    event.setCancelled(true);
+                    return;
+                }
+            }
+            // Same goes for doors, which may exceed the area height limit
+            if (event.getBlock().getBlockData() instanceof Door door) {
+                if (location.getY() + 1 > area.getMaxBuildHeight() &&
+                        !Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_BUILD_HEIGHT_LIMIT)) {
+                    pp.sendMessage(
+                            TranslatableCaption.of("height.height_limit"),
+                            Template.of("minHeight", String.valueOf(area.getMinBuildHeight())),
+                            Template.of("maxHeight", String.valueOf(area.getMaxBuildHeight()))
+                    );
+                    event.setCancelled(true);
                 }
             }
             if (plot.getFlag(DisablePhysicsFlag.class)) {


### PR DESCRIPTION
## Overview

Fixes #3483

## Description
Cancels block placement if the block consists of two block states, and the second block state is outside of the plot (area).
Additionally cancelled the placement of doors, when the upper part exceeds the height limit of the current plot area.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
