### PR TITLE
Restore ability to use PlaceholderAPI in greeting and farewell flag

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
+++ b/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
@@ -174,21 +174,9 @@ public class PlotListener {
             String greeting = plot.getFlag(GreetingFlag.class);
             if (!greeting.isEmpty()) {
                 if (!Settings.Chat.NOTIFICATION_AS_ACTIONBAR) {
-                    player.sendMessage(
-                            TranslatableCaption.of("flags.greeting_flag_format"),
-                            Template.of("world", plot.getWorldName()),
-                            Template.of("plot_id", plot.getId().toString()),
-                            Template.of("alias", plot.getAlias()),
-                            Template.of("greeting", greeting)
-                    );
+                    plot.format(StaticCaption.of(greeting), player, false).thenAcceptAsync(player::sendMessage);
                 } else {
-                    player.sendActionBar(
-                            TranslatableCaption.of("flags.greeting_flag_format"),
-                            Template.of("world", plot.getWorldName()),
-                            Template.of("plot_id", plot.getId().toString()),
-                            Template.of("alias", plot.getAlias()),
-                            Template.of("greeting", greeting)
-                    );
+                    plot.format(StaticCaption.of(greeting), player, false).thenAcceptAsync(player::sendActionBar);
                 }
             }
 
@@ -413,21 +401,9 @@ public class PlotListener {
                 String farewell = plot.getFlag(FarewellFlag.class);
                 if (!farewell.isEmpty()) {
                     if (!Settings.Chat.NOTIFICATION_AS_ACTIONBAR) {
-                        player.sendMessage(
-                                TranslatableCaption.of("flags.farewell_flag_format"),
-                                Template.of("world", plot.getWorldName()),
-                                Template.of("plot_id", plot.getId().toString()),
-                                Template.of("alias", plot.getAlias()),
-                                Template.of("farewell", farewell)
-                        );
+                        plot.format(StaticCaption.of(farewell), player, false).thenAcceptAsync(player::sendMessage);
                     } else {
-                        player.sendActionBar(
-                                TranslatableCaption.of("flags.farewell_flag_format"),
-                                Template.of("world", plot.getWorldName()),
-                                Template.of("plot_id", plot.getId().toString()),
-                                Template.of("alias", plot.getAlias()),
-                                Template.of("farewell", farewell)
-                        );
+                        plot.format(StaticCaption.of(farewell), player, false).thenAcceptAsync(player::sendActionBar);
                     }
                 }
 

--- a/Core/src/main/resources/lang/messages_en.json
+++ b/Core/src/main/resources/lang/messages_en.json
@@ -620,8 +620,6 @@
   "flags.flag_error_title": "Flag value must be in the format </red><grey>\"A title\" \"The subtitle\"</grey><red>.",
   "flags.area_flags": "<prefix><gray>Area flags: </gray><dark_aqua><flags></dark_aqua>",
   "flags.road_flags": "<prefix><gray>Road flags: </gray><dark_aqua><flags></dark_aqua>",
-  "flags.greeting_flag_format": "<prefix><gold>[<world>;<plot_id>]:</gold> <greeting>",
-  "flags.farewell_flag_format": "<prefix><gold>[<world>;<plot_id>]:</gold> <farewell>",
   "commands.description.add": "<gray>Allow a user to build in a plot while the plot owner is online.</gray>",
   "commands.description.alias": "<gray>Set the plot alias.</gray>",
   "commands.description.area": "<gray>Create a new plot area.</gray>",


### PR DESCRIPTION
## Overview

Fixes #3465

## Description
My change proposed address the regression I introduced here https://github.com/IntellectualSites/PlotSquared/commit/6528c60f4d8a8c31f850d71170b0667748a650c7
PlaceholderAPI (PAPI), and all its thousands of placeholders, work out of the box in the greeting and farewell flag, as intended, and I think it's more future proof to rely on PAPI placeholders here, instead of working with our internal captions and templates, because they rely on hardcoded templates.
Worth to note, the 4 internal placeholders are all covered by our internal PlaceholderRegistry, alongside many other placeholders.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [X] Changelog entries in the PR title are correct
- [X] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
