### PR TITLE
Display "/plot help" categories only, if the player has permission to access these commands

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/CommandCategory.java
+++ b/Core/src/main/java/com/plotsquared/core/command/CommandCategory.java
@@ -28,6 +28,8 @@ package com.plotsquared.core.command;
 import com.plotsquared.core.configuration.caption.Caption;
 import com.plotsquared.core.configuration.caption.LocaleHolder;
 import com.plotsquared.core.configuration.caption.TranslatableCaption;
+import com.plotsquared.core.permissions.PermissionHolder;
+import com.plotsquared.core.player.PlotPlayer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -95,4 +97,16 @@ public enum CommandCategory implements Caption {
     public String getComponent(@NonNull LocaleHolder localeHolder) {
         return this.caption.getComponent(localeHolder);
     }
+
+    /**
+     * Checks if a player has access to this command category
+     *
+     * @param player The player to check against
+     * @return {@code true} if at least one command of this category can be executed by the player, {@code false} otherwise
+     * @since TODO
+     */
+    public boolean hasPermission(PlotPlayer<?> player) {
+        return !MainCommand.getInstance().getCommands(this, player).isEmpty();
+    }
+
 }

--- a/Core/src/main/java/com/plotsquared/core/command/CommandCategory.java
+++ b/Core/src/main/java/com/plotsquared/core/command/CommandCategory.java
@@ -104,7 +104,7 @@ public enum CommandCategory implements Caption {
      * @return {@code true} if at least one command of this category can be executed by the player, {@code false} otherwise
      * @since TODO
      */
-    public boolean hasPermission(PlotPlayer<?> player) {
+    boolean canAccess(PlotPlayer<?> player) {
         return !MainCommand.getInstance().getCommands(this, player).isEmpty();
     }
 

--- a/Core/src/main/java/com/plotsquared/core/command/CommandCategory.java
+++ b/Core/src/main/java/com/plotsquared/core/command/CommandCategory.java
@@ -28,7 +28,6 @@ package com.plotsquared.core.command;
 import com.plotsquared.core.configuration.caption.Caption;
 import com.plotsquared.core.configuration.caption.LocaleHolder;
 import com.plotsquared.core.configuration.caption.TranslatableCaption;
-import com.plotsquared.core.permissions.PermissionHolder;
 import com.plotsquared.core.player.PlotPlayer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 

--- a/Core/src/main/java/com/plotsquared/core/command/Help.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Help.java
@@ -41,10 +41,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @CommandDeclaration(command = "help",
         aliases = "?",

--- a/Core/src/main/java/com/plotsquared/core/command/Help.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Help.java
@@ -37,8 +37,11 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.minimessage.Template;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -155,12 +158,26 @@ public class Help extends Command {
 
     @Override
     public Collection<Command> tab(PlotPlayer<?> player, String[] args, boolean space) {
-        return Stream.of("claiming", "teleport", "settings", "chat", "schematic", "appearance", "info", "debug",
-                        "administration", "all"
-                )
-                .filter(value -> value.startsWith(args[0].toLowerCase(Locale.ENGLISH)))
-                .map(value -> new Command(null, false, value, "", RequiredType.NONE, null) {
-                }).collect(Collectors.toList());
+        final String argument = args[0].toLowerCase(Locale.ENGLISH);
+        List<Command> result = new ArrayList<>();
+
+        for (final CommandCategory category : CommandCategory.values()) {
+            if (!category.hasPermission(player)) {
+                continue;
+            }
+            String name = category.name().toLowerCase();
+            if (!name.startsWith(argument)) {
+                continue;
+            }
+            result.add(new Command(null, false, name, "", RequiredType.NONE, null) {
+            });
+        }
+        // add the category "all"
+        if ("all".startsWith(argument)) {
+            result.add(new Command(null, false, "all", "", RequiredType.NONE, null) {
+            });
+        }
+        return result;
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/command/Help.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Help.java
@@ -119,7 +119,7 @@ public class Help extends Command {
                 TextComponent.Builder builder = Component.text();
                 builder.append(MINI_MESSAGE.parse(TranslatableCaption.of("help.help_header").getComponent(player)));
                 for (CommandCategory c : CommandCategory.values()) {
-                    if (!c.hasPermission(player)) {
+                    if (!c.canAccess(player)) {
                         continue;
                     }
                     builder.append(Component.newline()).append(MINI_MESSAGE
@@ -159,7 +159,7 @@ public class Help extends Command {
         List<Command> result = new ArrayList<>();
 
         for (final CommandCategory category : CommandCategory.values()) {
-            if (!category.hasPermission(player)) {
+            if (!category.canAccess(player)) {
                 continue;
             }
             String name = category.name().toLowerCase();

--- a/Core/src/main/java/com/plotsquared/core/command/Help.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Help.java
@@ -119,6 +119,9 @@ public class Help extends Command {
                 TextComponent.Builder builder = Component.text();
                 builder.append(MINI_MESSAGE.parse(TranslatableCaption.of("help.help_header").getComponent(player)));
                 for (CommandCategory c : CommandCategory.values()) {
+                    if (!c.hasPermission(player)) {
+                        continue;
+                    }
                     builder.append(Component.newline()).append(MINI_MESSAGE
                             .parse(
                                     TranslatableCaption.of("help.help_info_item").getComponent(player),

--- a/Core/src/main/java/com/plotsquared/core/util/helpmenu/HelpMenu.java
+++ b/Core/src/main/java/com/plotsquared/core/util/helpmenu/HelpMenu.java
@@ -52,8 +52,7 @@ public class HelpMenu {
     }
 
     public HelpMenu getCommands() {
-        this.commands =
-                MainCommand.getInstance().getCommands(this.commandCategory, this.commandCaller);
+        this.commands = MainCommand.getInstance().getCommands(this.commandCategory, this.commandCaller);
         return this;
     }
 


### PR DESCRIPTION
## Overview
Fixes #3140

## Description
The listed categories in `/plot help` are only visible if the player has access to at least one command of that category.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
