### PR TITLE
Fixed plot top loc calculation based on max build height (like bottom…

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/generator/SquarePlotManager.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/SquarePlotManager.java
@@ -96,7 +96,7 @@ public abstract class SquarePlotManager extends GridPlotManager {
                 .floor(squarePlotWorld.ROAD_WIDTH / 2) - 1;
         int z = (squarePlotWorld.ROAD_OFFSET_Z + (pz * (squarePlotWorld.ROAD_WIDTH + squarePlotWorld.PLOT_WIDTH))) - (int) Math
                 .floor(squarePlotWorld.ROAD_WIDTH / 2) - 1;
-        return Location.at(squarePlotWorld.getWorldName(), x, Math.min(getWorldHeight(), 255), z);
+        return Location.at(squarePlotWorld.getWorldName(), x, Math.min(squarePlotWorld.getMaxBuildHeight(), 255), z);
     }
 
     @Override


### PR DESCRIPTION

## Overview
This PR tagets issue #3510 of invalid plot schematic exported area height.

Fixes #3510

## Description
This PR fixes calculation of plot top location depending on plot world max build height setting.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
