### PR TITLE
Replace delombok-ed equals and hashCode methods

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitWorld.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitWorld.java
@@ -83,32 +83,29 @@ public class BukkitWorld implements World<org.bukkit.World> {
         return this.world.getName();
     }
 
+    @Override
     public boolean equals(final Object o) {
-        if (o == this) {
+        if (this == o) {
             return true;
         }
-        if (!(o instanceof final BukkitWorld other)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!other.canEqual(this)) {
-            return false;
-        }
-        if (!Objects.equals(this.world, other.world)) {
-            return false;
-        }
-        return true;
+        final BukkitWorld that = (BukkitWorld) o;
+        return world.equals(that.world);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(world);
+    }
+
+    /**
+     * @deprecated This method is not meant to be invoked or overridden, with no replacement.
+     */
+    @Deprecated(forRemoval = true, since = "TODO")
     protected boolean canEqual(final Object other) {
         return other instanceof BukkitWorld;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $world = this.world;
-        result = result * PRIME + ($world == null ? 43 : $world.hashCode());
-        return result;
     }
 
     public String toString() {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitWorld.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitWorld.java
@@ -97,7 +97,7 @@ public class BukkitWorld implements World<org.bukkit.World> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(world);
+        return world.hashCode();
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotWorld.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotWorld.java
@@ -119,7 +119,7 @@ public abstract class PlotWorld {
 
     @Override
     public int hashCode() {
-        return Objects.hash(world);
+        return world.hashCode();
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotWorld.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotWorld.java
@@ -105,31 +105,29 @@ public abstract class PlotWorld {
         return this.world;
     }
 
+    @Override
     public boolean equals(final Object o) {
-        if (o == this) {
+        if (this == o) {
             return true;
         }
-        if (!(o instanceof final PlotWorld other)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!other.canEqual(this)) {
-            return false;
-        }
-        final Object this$world = this.getWorld();
-        final Object other$world = other.getWorld();
-        return Objects.equals(this$world, other$world);
+        final PlotWorld plotWorld = (PlotWorld) o;
+        return world.equals(plotWorld.world);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(world);
+    }
+
+    /**
+     * @deprecated This method is not meant to be invoked or overridden, with no replacement.
+     */
+    @Deprecated(forRemoval = true, since = "TODO")
     protected boolean canEqual(final Object other) {
         return other instanceof PlotWorld;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $world = this.getWorld();
-        result = result * PRIME + ($world == null ? 43 : $world.hashCode());
-        return result;
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/FlagContainer.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/FlagContainer.java
@@ -371,31 +371,29 @@ public class FlagContainer {
         }
     }
 
+    @Override
     public boolean equals(final Object o) {
-        if (o == this) {
+        if (this == o) {
             return true;
         }
-        if (!(o instanceof final FlagContainer other)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!other.canEqual(this)) {
-            return false;
-        }
-        final Object this$flagMap = this.getFlagMap();
-        final Object other$flagMap = other.getFlagMap();
-        return Objects.equals(this$flagMap, other$flagMap);
+        final FlagContainer that = (FlagContainer) o;
+        return flagMap.equals(that.flagMap);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(flagMap);
+    }
+
+    /**
+     * @deprecated This method is not meant to be invoked or overridden, with no replacement.
+     */
+    @Deprecated(forRemoval = true, since = "TODO")
     protected boolean canEqual(final Object other) {
         return other instanceof FlagContainer;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $flagMap = this.getFlagMap();
-        result = result * PRIME + ($flagMap == null ? 43 : $flagMap.hashCode());
-        return result;
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/FlagContainer.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/FlagContainer.java
@@ -385,7 +385,7 @@ public class FlagContainer {
 
     @Override
     public int hashCode() {
-        return Objects.hash(flagMap);
+        return flagMap.hashCode();
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/PlotFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/PlotFlag.java
@@ -31,6 +31,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 
 /**
  * A plot flag is any property that can be assigned
@@ -200,34 +201,30 @@ public abstract class PlotFlag<T, F extends PlotFlag<T, F>> {
         return Collections.emptyList();
     }
 
+    @Override
     public boolean equals(final Object o) {
-        if (o == this) {
+        if (this == o) {
             return true;
         }
-        if (!(o instanceof final PlotFlag<?, ?> other)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!other.canEqual(this)) {
-            return false;
-        }
-        final Object this$value = this.getValue();
-        final Object other$value = other.getValue();
-        if (this$value == null ? other$value != null : !this$value.equals(other$value)) {
-            return false;
-        }
-        return true;
+        final PlotFlag<?, ?> plotFlag = (PlotFlag<?, ?>) o;
+        return value.equals(plotFlag.value);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    /**
+     * @deprecated This method is not meant to be invoked or overridden, with no replacement.
+     */
+    @Deprecated(forRemoval = true, since = "TODO")
     protected boolean canEqual(final Object other) {
         return other instanceof PlotFlag;
     }
 
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $value = this.getValue();
-        result = result * PRIME + ($value == null ? 43 : $value.hashCode());
-        return result;
-    }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/PlotFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/PlotFlag.java
@@ -215,7 +215,7 @@ public abstract class PlotFlag<T, F extends PlotFlag<T, F>> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(value);
+        return value.hashCode();
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/uuid/UUIDMapping.java
+++ b/Core/src/main/java/com/plotsquared/core/uuid/UUIDMapping.java
@@ -51,38 +51,29 @@ public class UUIDMapping {
         return this.uuid;
     }
 
+    @Override
     public boolean equals(final Object o) {
-        if (o == this) {
+        if (this == o) {
             return true;
         }
-        if (!(o instanceof final UUIDMapping other)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!other.canEqual(this)) {
-            return false;
-        }
-        final Object this$uuid = this.getUuid();
-        final Object other$uuid = other.getUuid();
-        if (!Objects.equals(this$uuid, other$uuid)) {
-            return false;
-        }
-        final Object this$username = this.getUsername();
-        final Object other$username = other.getUsername();
-        return Objects.equals(this$username, other$username);
+        final UUIDMapping that = (UUIDMapping) o;
+        return uuid.equals(that.uuid) && username.equals(that.username);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(uuid, username);
+    }
+
+    /**
+     * @deprecated This method is not meant to be invoked or overridden, with no replacement.
+     */
+    @Deprecated(forRemoval = true, since = "TODO")
     protected boolean canEqual(final Object other) {
         return other instanceof UUIDMapping;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $uuid = this.getUuid();
-        result = result * PRIME + $uuid.hashCode();
-        final Object $username = this.getUsername();
-        result = result * PRIME + $username.hashCode();
-        return result;
     }
 
 }


### PR DESCRIPTION
## Description
<!-- Please describe what this pull request does. -->

I refactored old code that was generated whilst delomboking. The equals and hashCode methods were newly generated with IntelliJ. The `canEqual` methods generated by lombok are deprecated for removal now.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)
