### PR TITLE
Replace legacy color codes in flag examples

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/DescriptionFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/DescriptionFlag.java
@@ -58,7 +58,7 @@ public class DescriptionFlag extends StringFlag<DescriptionFlag> {
 
     @Override
     public String getExample() {
-        return "&6This is my plot!";
+        return "<gold>This is my plot!";
     }
 
     @Override

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/GreetingFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/GreetingFlag.java
@@ -58,7 +58,7 @@ public class GreetingFlag extends StringFlag<GreetingFlag> {
 
     @Override
     public String getExample() {
-        return "&6Welcome to my plot!";
+        return "<gold>Welcome to my plot!";
     }
 
     @Override


### PR DESCRIPTION
## Description
<!-- Please describe what this pull request does. -->

Replaces two usages of legacy color codes in flag value examples.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)
