### PR TITLE
Make `/plot confirm` tasks run synchronous

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Confirm.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Confirm.java
@@ -48,7 +48,7 @@ public class Confirm extends SubCommand {
             player.sendMessage(TranslatableCaption.of("confirm.expired_confirm"));
             return false;
         }
-        TaskManager.runTaskAsync(command.command);
+        TaskManager.runTask(command.command);
         return true;
     }
 


### PR DESCRIPTION
Fixes #3517
