### PR TITLE
Fix: Resolve username in plot entry title when disabling UUID cache

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
+++ b/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
@@ -309,7 +309,7 @@ public class PlotListener {
                         }
                         if ((lastPlot != null) && plot.getId().equals(lastPlot.getId()) && plot.hasOwner()) {
                             final UUID plotOwner = plot.getOwnerAbs();
-                            String owner = PlayerManager.resolveName(plotOwner, false).getComponent(player);
+                            String owner = PlayerManager.resolveName(plotOwner, true).getComponent(player);
                             Caption header = fromFlag ? StaticCaption.of(title) : TranslatableCaption.of("titles" +
                                     ".title_entered_plot");
                             Caption subHeader = fromFlag ? StaticCaption.of(subtitle) : TranslatableCaption.of("titles" +


### PR DESCRIPTION
## Overview
Fixes an issue mentioned by a user, when disabling the UUID cache (or limit the uuid cache) the player name in the title is `unknown`.

## Description
As the title task is asynchronous the resolveName task can be blocking.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)
