### PR TITLE
Clean up PlayerCommandPreprocess listener

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/util/RegExUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/RegExUtil.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+@Deprecated(since = "TODO", forRemoval = true)
 public class RegExUtil {
 
     public static Map<String, Pattern> compiledPatterns;


### PR DESCRIPTION
## Description
I cleaned up the code in the listener for the PlayerCommandPreprocessEvent. There were a lot of unnecessary operations like multiple `toLowerCase` calls.

Previously, the flag also allowed arbitrary regular expressions. As this isn't documented behavior, I removed it.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)
