### PR TITLE
Deprecate `Load#secToTime()` in favor of `TimeUtil#secToTime()`

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Load.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Load.java
@@ -40,6 +40,7 @@ import com.plotsquared.core.plot.schematic.Schematic;
 import com.plotsquared.core.plot.world.PlotAreaManager;
 import com.plotsquared.core.util.Permissions;
 import com.plotsquared.core.util.SchematicHandler;
+import com.plotsquared.core.util.TimeUtil;
 import com.plotsquared.core.util.task.RunnableVal;
 import com.plotsquared.core.util.task.TaskManager;
 import net.kyori.adventure.text.minimessage.Template;
@@ -205,7 +206,7 @@ public class Load extends SubCommand {
                     if (split.length < 5) {
                         continue;
                     }
-                    String time = secToTime((System.currentTimeMillis() / 1000) - Long.parseLong(split[0]));
+                    String time = TimeUtil.secToTime((System.currentTimeMillis() / 1000) - Long.parseLong(split[0]));
                     String world = split[1];
                     PlotId id = PlotId.fromString(split[2] + ';' + split[3]);
                     String size = split[4];
@@ -223,6 +224,10 @@ public class Load extends SubCommand {
         }
     }
 
+    /**
+     * @deprecated Use {@link TimeUtil#secToTime(long)}
+     */
+    @Deprecated(forRemoval = true, since = "TODO")
     public String secToTime(long time) {
         StringBuilder toreturn = new StringBuilder();
         if (time >= 33868800) {

--- a/Core/src/main/java/com/plotsquared/core/util/TimeUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/TimeUtil.java
@@ -44,27 +44,27 @@ public final class TimeUtil {
         StringBuilder toReturn = new StringBuilder();
         if (time >= 33868800) {
             int years = (int) (time / 33868800);
-            time -= years * 33868800;
+            time -= years * 33868800L;
             toReturn.append(years).append("y ");
         }
         if (time >= 604800) {
             int weeks = (int) (time / 604800);
-            time -= weeks * 604800;
+            time -= weeks * 604800L;
             toReturn.append(weeks).append("w ");
         }
         if (time >= 86400) {
             int days = (int) (time / 86400);
-            time -= days * 86400;
+            time -= days * 86400L;
             toReturn.append(days).append("d ");
         }
         if (time >= 3600) {
             int hours = (int) (time / 3600);
-            time -= hours * 3600;
+            time -= hours * 3600L;
             toReturn.append(hours).append("h ");
         }
         if (time >= 60) {
             int minutes = (int) (time / 60);
-            time -= minutes * 60;
+            time -= minutes * 60L;
             toReturn.append(minutes).append("m ");
         }
         if (toReturn.length() == 0 || time > 0) {


### PR DESCRIPTION
We should utilize the method from TimeUtil, because it does much better fit here than in Load and is basically duplicated in the Load class.