### PR TITLE
Make y location of homes always absolute

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/SetHome.java
+++ b/Core/src/main/java/com/plotsquared/core/command/SetHome.java
@@ -57,8 +57,12 @@ public class SetHome extends SetCommand {
                 Plot base = plot.getBasePlot(false);
                 Location bottom = base.getBottomAbs();
                 Location location = player.getLocationFull();
-                BlockLoc rel = new BlockLoc(location.getX() - bottom.getX(), location.getY(),
-                        location.getZ() - bottom.getZ(), location.getYaw(), location.getPitch()
+                BlockLoc rel = new BlockLoc(
+                        location.getX() - bottom.getX(),
+                        location.getY(), // y is absolute
+                        location.getZ() - bottom.getZ(),
+                        location.getYaw(),
+                        location.getPitch()
                 );
                 base.setHome(rel);
                 player.sendMessage(TranslatableCaption.of("position.position_set"));

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -1465,7 +1465,7 @@ public class Plot {
                     .at(
                             bottom.getWorldName(),
                             bottom.getX() + home.getX(),
-                            bottom.getY() + home.getY(),
+                            home.getY(), // y is absolute
                             bottom.getZ() + home.getZ(),
                             home.getYaw(),
                             home.getPitch()


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, please create one so we can look into it before approving your PR.
-->

Fixes #3536
Fixes #3565

## Description
<!-- Please describe what this pull request does. -->

This is my approach to fix current issues with `/plot home`. With this solution, the y coordinate is always absolute. While this isn't consistent with the y and z coordinates, it allows to change the minimum world height without having to update *all* home locations manually (there is no way for us to know that the world height was modified and apply such changes automatically).

Users who already updated existing home locations manually need to undo those changes.

I considered the alternative way, making y properly relative everywhere, but this means existing homes are unusable as soon as the world min is modified.

We might reconsider that behavior once we have a way to migrate sql data more easily.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)
