### PR TITLE
Update SquirrelID to 0.3.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,9 @@ allprojects {
         maven {
             name = "Jitpack"
             url = uri("https://jitpack.io")
+            content {
+                includeModule("com.github.MilkBowl", "VaultAPI")
+            }
         }
 
         maven {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ arkitektonika = "2.1.1"
 paster = "1.1.4"
 bstats = "3.0.0"
 paperlib = "1.0.7"
-squirrelid = "0.3.0"
+squirrelid = "0.3.1"
 serverlib = "2.3.1"
 http4j = "1.3"
 
@@ -78,7 +78,7 @@ prtree = { group = "com.intellectualsites.prtree", name = "PRTree", version.ref 
 aopalliance = { group = "aopalliance", name = "aopalliance", version.ref = "aopalliance" }
 cloudServices = { group = "cloud.commandframework", name = "cloud-services", version.ref = "cloud-services" }
 mvdwapi = { group = "com.intellectualsites.mvdwplaceholderapi", name = "MVdWPlaceholderAPI", version.ref = "mvdwapi" }
-squirrelid = { group = "com.github.EngineHub", name = "SquirrelID", version.ref = "squirrelid" }
+squirrelid = { group = "org.enginehub", name = "squirrelid", version.ref = "squirrelid" }
 serverlib = { group = "dev.notmyfault.serverlib", name = "ServerLib", version.ref = "serverlib" }
 bstats = { group = "org.bstats", name = "bstats-bukkit", version.ref = "bstats" }
 paperlib = { group = "io.papermc", name = "paperlib", version.ref = "paperlib" }


### PR DESCRIPTION
## Overview

EngineHub released 0.3.1 of squirrelid including sources and javadocs jars, therefore we no longer need to rely on the Jitpack artifact.

## Description
<!-- Please describe what this pull request does. -->

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)
