### PR TITLE
Add ability to disable random Mojang uuid API calls

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -513,8 +513,10 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
                 this.backgroundPipeline.registerService(essentialsUUIDService);
             }
 
-            final SquirrelIdUUIDService impromptuMojangService = new SquirrelIdUUIDService(Settings.UUID.IMPROMPTU_LIMIT);
-            this.impromptuPipeline.registerService(impromptuMojangService);
+            if (Settings.UUID.IMPROMPTU_SERVICE_MOJANG_API) {
+                final SquirrelIdUUIDService impromptuMojangService = new SquirrelIdUUIDService(Settings.UUID.IMPROMPTU_LIMIT);
+                this.impromptuPipeline.registerService(impromptuMojangService);
+            }
             final SquirrelIdUUIDService backgroundMojangService = new SquirrelIdUUIDService(Settings.UUID.BACKGROUND_LIMIT);
             this.backgroundPipeline.registerService(backgroundMojangService);
         } else {

--- a/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
@@ -249,6 +249,8 @@ public class Settings extends Config {
         public static int UUID_CACHE_SIZE = 100000;
         @Comment("Rate limit (per 10 minutes) for background UUID fetching from the Mojang API")
         public static int BACKGROUND_LIMIT = 200;
+        @Comment("Whether the Mojang API service is enabled for inpromto (requires restart)")
+        public static boolean IMPROMPTU_SERVICE_MOJANG_API = true;
         @Comment("Rate limit (per 10 minutes) for random UUID fetching from the Mojang API")
         public static int IMPROMPTU_LIMIT = 300;
         @Comment("Timeout (in milliseconds) for non-blocking UUID requests (mostly commands)")

--- a/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
@@ -249,7 +249,8 @@ public class Settings extends Config {
         public static int UUID_CACHE_SIZE = 100000;
         @Comment("Rate limit (per 10 minutes) for background UUID fetching from the Mojang API")
         public static int BACKGROUND_LIMIT = 200;
-        @Comment("Whether the Mojang API service is enabled for inpromto (requires restart)")
+        @Comment("Whether the Mojang API service is enabled for impromptu api calls. If false only the Background task will use" +
+                " http requests to fill the UUID cache (requires restart)")
         public static boolean IMPROMPTU_SERVICE_MOJANG_API = true;
         @Comment("Rate limit (per 10 minutes) for random UUID fetching from the Mojang API")
         public static int IMPROMPTU_LIMIT = 300;
@@ -693,6 +694,7 @@ public class Settings extends Config {
         @Comment({"If blocks at the edges of queued operations should be set causing updates",
                 " - Slightly slower, but prevents issues such as fences left connected to nothing"})
         public static boolean UPDATE_EDGES = true;
+
     }
 
     @Comment("Settings related to tab completion")


### PR DESCRIPTION
# Seperated from #3584

## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, please create one so we can look into it before approving your PR.
-->

## Fixes #2959

With random Mojang API calls disabled the plugin should be less likely to throw a timeout error. The lookup should have enough time to check all other providers before timing out. This might still be a problem if too many invalid lookups happen at once. Replacing invalid UUIDs should not be necessary, but will still improve efficiency a bit.

## Description
<!-- Please describe what this pull request does. -->
Adding option to disable random Mojang API calls and only use the cache. Unknown UUIDs will already be returned as unknown (info.unknown from messages_en.json)

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)
