### PR TITLE
Set plot biome chunk by chunk

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/util/RegionManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/RegionManager.java
@@ -411,16 +411,16 @@ public abstract class RegionManager {
         queue.addReadChunks(region.getChunks());
         final BlockVector3 regionMin = region.getMinimumPoint();
         final BlockVector3 regionMax = region.getMaximumPoint();
-        queue.setChunkConsumer(blockVector2 -> {
+        queue.setChunkConsumer(chunkPos -> {
             BlockVector3 chunkMin = BlockVector3.at(
-                    Math.max(blockVector2.getX() << 4, regionMin.getBlockX()),
+                    Math.max(chunkPos.getX() << 4, regionMin.getBlockX()),
                     regionMin.getBlockY(),
-                    Math.max(blockVector2.getZ() << 4, regionMin.getBlockZ())
+                    Math.max(chunkPos.getZ() << 4, regionMin.getBlockZ())
             );
             BlockVector3 chunkMax = BlockVector3.at(
-                    Math.min((blockVector2.getX() << 4) + 15, regionMax.getBlockX()),
+                    Math.min((chunkPos.getX() << 4) + 15, regionMax.getBlockX()),
                     regionMax.getBlockY(),
-                    Math.min((blockVector2.getZ() << 4) + 15, regionMax.getBlockZ())
+                    Math.min((chunkPos.getZ() << 4) + 15, regionMax.getBlockZ())
             );
             CuboidRegion chunkRegion = new CuboidRegion(region.getWorld(), chunkMin, chunkMax);
             WorldUtil.setBiome(
@@ -428,7 +428,7 @@ public abstract class RegionManager {
                     chunkRegion,
                     biome
             );
-            worldUtil.refreshChunk(blockVector2.getBlockX(), blockVector2.getBlockZ(), area.getWorldName());
+            worldUtil.refreshChunk(chunkPos.getBlockX(), chunkPos.getBlockZ(), area.getWorldName());
         });
         queue.setCompleteTask(whenDone);
         queue.enqueue();

--- a/Core/src/main/java/com/plotsquared/core/util/RegionManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/RegionManager.java
@@ -409,10 +409,23 @@ public abstract class RegionManager {
     ) {
         final QueueCoordinator queue = blockQueue.getNewQueue(worldUtil.getWeWorld(area.getWorldName()));
         queue.addReadChunks(region.getChunks());
+        final BlockVector3 regionMin = region.getMinimumPoint();
+        final BlockVector3 regionMax = region.getMaximumPoint();
         queue.setChunkConsumer(blockVector2 -> {
+            BlockVector3 chunkMin = BlockVector3.at(
+                    Math.max(blockVector2.getX() << 4, regionMin.getBlockX()),
+                    regionMin.getBlockY(),
+                    Math.max(blockVector2.getZ() << 4, regionMin.getBlockZ())
+            );
+            BlockVector3 chunkMax = BlockVector3.at(
+                    Math.min((blockVector2.getX() << 4) + 15, regionMax.getBlockX()),
+                    regionMax.getBlockY(),
+                    Math.min((blockVector2.getZ() << 4) + 15, regionMax.getBlockZ())
+            );
+            CuboidRegion chunkRegion = new CuboidRegion(region.getWorld(), chunkMin, chunkMax);
             WorldUtil.setBiome(
                     area.getWorldName(),
-                    region,
+                    chunkRegion,
                     biome
             );
             worldUtil.refreshChunk(blockVector2.getBlockX(), blockVector2.getBlockZ(), area.getWorldName());


### PR DESCRIPTION
## Overview

Fixes #3549 (see my comment at the end)

## Description

Currently PlotSquared iterates through all chunks in a plot in an attempt to set the biome chunk by chunk. However, for each iteration it doesn't set the biome of the current chunk, but of the entire plot! I changed it so it only sets the biome of the current chunk of the iteration.

We could optimise biome modifications more by only setting the biome once per 4x4x4 cube. But that seems annoying to implement and I don't have time for that right now.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)
