### PR TITLE
Implement chunkObject into queueing

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/queue/BukkitQueueCoordinator.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/queue/BukkitQueueCoordinator.java
@@ -51,6 +51,7 @@ import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
 import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
 import org.bukkit.block.Block;
 import org.bukkit.block.Container;
 import org.bukkit.block.data.BlockData;
@@ -266,7 +267,13 @@ public class BukkitQueueCoordinator extends BasicQueueCoordinator {
         } catch (WorldEditException ignored) {
             // Fallback to not so nice method
             BlockData blockData = BukkitAdapter.adapt(block);
-            Block existing = getBukkitWorld().getBlockAt(x, y, z);
+            Block existing;
+            // Assume a chunk object has been given only when it should have been.
+            if (getChunkObject() instanceof Chunk) {
+                existing = ((Chunk) getChunkObject()).getBlock(x & 15, y, z & 15);
+            } else {
+                 existing = getBukkitWorld().getBlockAt(x, y, z);
+            }
             final BlockState existingBaseBlock = BukkitAdapter.adapt(existing.getBlockData());
             if (BukkitBlockUtil.get(existing).equals(existingBaseBlock) && existing.getBlockData().matches(blockData)) {
                 return;

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/queue/BukkitQueueCoordinator.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/queue/BukkitQueueCoordinator.java
@@ -269,8 +269,8 @@ public class BukkitQueueCoordinator extends BasicQueueCoordinator {
             BlockData blockData = BukkitAdapter.adapt(block);
             Block existing;
             // Assume a chunk object has been given only when it should have been.
-            if (getChunkObject() instanceof Chunk) {
-                existing = ((Chunk) getChunkObject()).getBlock(x & 15, y, z & 15);
+            if (getChunkObject() instanceof Chunk chunkObject) {
+                existing = chunkObject.getBlock(x & 15, y, z & 15);
             } else {
                  existing = getBukkitWorld().getBlockAt(x, y, z);
             }

--- a/Core/src/main/java/com/plotsquared/core/queue/QueueCoordinator.java
+++ b/Core/src/main/java/com/plotsquared/core/queue/QueueCoordinator.java
@@ -143,7 +143,8 @@ public abstract class QueueCoordinator {
     }
 
     /**
-     * Set a chunk object (e.g. the Bukkit Chunk object) to the queue
+     * Set a chunk object (e.g. the Bukkit Chunk object) to the queue. This will be used as fallback in case of WNA failure.
+     * Should ONLY be used in specific cases (i.e. generation, where a chunk is being populated)
      *
      * @param chunkObject chunk object. Usually the implementation-specific chunk (e.g. bukkit Chunk)
      */


### PR DESCRIPTION
 - This should only be used in generation
 - The chunk will be used as fallback to set to using bukkit API if WNA fails
