### PR TITLE
Deprecations to Queues

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/queue/ChunkQueueCoordinator.java
+++ b/Core/src/main/java/com/plotsquared/core/queue/ChunkQueueCoordinator.java
@@ -36,8 +36,12 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Queue that is limited to a single chunk
+ * Queue that is limited to a single chunk. It does not allow a delegate queue and should be treated as a cache for changes to
+ * be set to. Does not support tile entities or entities.
+ *
+ * @deprecated This class is poorly designed and will no longer be used in P2
  */
+@Deprecated(forRemoval = true)
 public class ChunkQueueCoordinator extends ScopedQueueCoordinator {
 
     public final BiomeType[][][] biomeResult;

--- a/Core/src/main/java/com/plotsquared/core/queue/ChunkQueueCoordinator.java
+++ b/Core/src/main/java/com/plotsquared/core/queue/ChunkQueueCoordinator.java
@@ -41,7 +41,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * @deprecated This class is poorly designed and will no longer be used in P2
  */
-@Deprecated(forRemoval = true)
+@Deprecated(forRemoval = true, since = "TODO")
 public class ChunkQueueCoordinator extends ScopedQueueCoordinator {
 
     public final BiomeType[][][] biomeResult;

--- a/Core/src/main/java/com/plotsquared/core/queue/ScopedQueueCoordinator.java
+++ b/Core/src/main/java/com/plotsquared/core/queue/ScopedQueueCoordinator.java
@@ -40,7 +40,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * @deprecated This should be renamed to NormalizedScopedQueueCoordinator or something.
  */
-@Deprecated(forRemoval = true)
+@Deprecated(forRemoval = true, since = "TODO")
 public class ScopedQueueCoordinator extends DelegateQueueCoordinator {
 
     private final Location min;

--- a/Core/src/main/java/com/plotsquared/core/queue/ScopedQueueCoordinator.java
+++ b/Core/src/main/java/com/plotsquared/core/queue/ScopedQueueCoordinator.java
@@ -35,8 +35,12 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Queue that only sets blocks with a designated area
+ * Queue that only sets blocks with a designated X-Z area, will accept any Y values. Requires all blocks be set normalized in
+ * the x and z directions, i.e. starting from 0,0. An offset of the minimum point of the region will then be applied to x and z.
+ *
+ * @deprecated This should be renamed to NormalizedScopedQueueCoordinator or something.
  */
+@Deprecated(forRemoval = true)
 public class ScopedQueueCoordinator extends DelegateQueueCoordinator {
 
     private final Location min;


### PR DESCRIPTION
 - Deprecate ScopedQueueCoordinator as it is poorly named
 - Deprecate ChunkQueueCoordinator for complete removal as it is poorly designed (though still used)