### PR TITLE
Fix generation of augmented/partial worlds when single worlds are enabled

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitSetupUtils.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitSetupUtils.java
@@ -76,7 +76,7 @@ public class BukkitSetupUtils extends SetupUtils {
 
     @Override
     public void updateGenerators(final boolean force) {
-        if (!SetupUtils.generators.isEmpty() && !force) {
+        if (loaded && !SetupUtils.generators.isEmpty() && !force) {
             return;
         }
         String testWorld = "CheckingPlotSquaredGenerator";
@@ -100,6 +100,7 @@ public class BukkitSetupUtils extends SetupUtils {
                 e.printStackTrace();
             }
         }
+        loaded = true;
     }
 
     @Override

--- a/Core/src/main/java/com/plotsquared/core/util/SetupUtils.java
+++ b/Core/src/main/java/com/plotsquared/core/util/SetupUtils.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 public abstract class SetupUtils {
 
     public static HashMap<String, GeneratorWrapper<?>> generators = new HashMap<>();
+    protected boolean loaded = false;
 
     /**
      * @since 6.1.0


### PR DESCRIPTION
 - Enabling single worlds adds "PlotSquared:single" to the generators map in SetupUtils
 - Adding a switch for if the map has ever been loaded into means that the first time updateGenerators is called, they will always be updated
 - This means that ultimately PlotSquared is not added as a generator for augmented/partial worlds in bukkit/yml (as it is not, it is a populator)
