### PR TITLE
Make y location of homes absolute for `Plot#getHomeSynchronous`  too

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -1420,15 +1420,7 @@ public class Plot {
                         0
                 );
             }
-            Location location = Location
-                    .at(
-                            bottom.getWorldName(),
-                            bottom.getX() + home.getX(),
-                            bottom.getY() + home.getY(),
-                            bottom.getZ() + home.getZ(),
-                            home.getYaw(),
-                            home.getPitch()
-                    );
+            Location location = toHomeLocation(bottom, home);
             if (!this.worldUtil.getBlockSynchronous(location).getBlockType().getMaterial().isAir()) {
                 location = location.withY(
                         Math.max(1 + this.worldUtil.getHighestBlockSynchronous(
@@ -1461,15 +1453,7 @@ public class Plot {
                 return;
             }
             Location bottom = this.getBottomAbs();
-            Location location = Location
-                    .at(
-                            bottom.getWorldName(),
-                            bottom.getX() + home.getX(),
-                            home.getY(), // y is absolute
-                            bottom.getZ() + home.getZ(),
-                            home.getYaw(),
-                            home.getPitch()
-                    );
+            Location location = toHomeLocation(bottom, home);
             this.worldUtil.getBlock(location, block -> {
                 if (!block.getBlockType().getMaterial().isAir()) {
                     this.worldUtil.getHighestBlock(this.getWorldName(), location.getX(), location.getZ(),
@@ -1480,6 +1464,17 @@ public class Plot {
                 }
             });
         }
+    }
+
+    private Location toHomeLocation(Location bottom, BlockLoc relativeHome) {
+        return Location.at(
+                bottom.getWorldName(),
+                bottom.getX() + relativeHome.getX(),
+                relativeHome.getY(), // y is absolute
+                bottom.getZ() + relativeHome.getZ(),
+                relativeHome.getYaw(),
+                relativeHome.getPitch()
+        );
     }
 
     /**


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #3619 

## Description
<!-- Please describe what this pull request does. -->

I missed the `getHomeSynchronous` method when fixing the previous issues with home teleportation. I refactored the common logic into a new method.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
