### PR TITLE
fix: Block Endermites from spawning if mob spawning is disabled

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
@@ -168,6 +168,7 @@ public class EntityEventListener implements Listener {
             case "RAID":
             case "SHEARED":
             case "SILVERFISH_BLOCK":
+            case "ENDER_PEARL":
             case "TRAP":
             case "VILLAGE_DEFENSE":
             case "VILLAGE_INVASION":

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
@@ -196,6 +196,7 @@ public class PaperListener implements Listener {
             case "RAID":
             case "SHEARED":
             case "SILVERFISH_BLOCK":
+            case "ENDER_PEARL":
             case "TRAP":
             case "VILLAGE_DEFENSE":
             case "VILLAGE_INVASION":


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #3147

## Description
<!-- Please describe what this pull request does. -->
Endermites will no longer spawn if `natural_mob_spawning` is set to `false`.


## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
