### PR TITLE
Update PaperMC repository endpoint

### DIFF
--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 
     maven {
         name = "PaperMC"
-        url = uri("https://papermc.io/repo/repository/maven-public/")
+        url = uri("https://repo.papermc.io/repository/maven-public/")
     }
 
     maven {


### PR DESCRIPTION
## Overview
Migrates to the new PaperMC endpoints anncounced yesterday.

## Description
Migrates to the new PaperMC endpoints anncounced yesterday.
`https://papermc.io/repo/repository/maven-public/` --> `https://repo.papermc.io/repository/maven-public/`

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
