### PR TITLE
Kick players on merged plots appropriately

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Deny.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Deny.java
@@ -161,6 +161,7 @@ public class Deny extends SubCommand {
     }
 
     private void handleKick(PlotPlayer<?> player, Plot plot) {
+        plot = plot.getBasePlot(false);
         if (player == null) {
             return;
         }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #3638

## Description
Fixes denied players not getting kicked when the command isn't executed on the base plot.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
