### PR TITLE
Return `info.server` for `%plotsquared_currentplot_owner%` if plot is a server plot

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
+++ b/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
@@ -38,6 +38,7 @@ import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.flag.GlobalFlagContainer;
 import com.plotsquared.core.plot.flag.PlotFlag;
+import com.plotsquared.core.plot.flag.implementations.ServerPlotFlag;
 import com.plotsquared.core.util.EventDispatcher;
 import com.plotsquared.core.util.PlayerManager;
 import net.kyori.adventure.text.Component;
@@ -110,6 +111,9 @@ public final class PlaceholderRegistry {
             return plot.getAlias();
         });
         this.createPlaceholder("currentplot_owner", (player, plot) -> {
+            if (plot.getFlag(ServerPlotFlag.class)){
+                return legacyComponent(TranslatableCaption.of("info.server"), player);
+            }
             final UUID plotOwner = plot.getOwnerAbs();
             if (plotOwner == null) {
                 return legacyComponent(TranslatableCaption.of("generic.generic_unowned"), player);


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Does not have an issue connected, but a comment on an issue: https://github.com/IntellectualSites/PlotSquared/issues/2983#issuecomment-748925887

## Description
returns `info.server` for the `%plotsquared_currentplot_owner%` if the Serverplot flag is set to true.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
