### PR TITLE
fix: mob cap counting for each connected plot individually

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
@@ -208,7 +208,7 @@ public class EntityEventListener implements Listener {
             }
             return;
         }
-        if (BukkitEntityUtil.checkEntity(entity, plot)) {
+        if (BukkitEntityUtil.checkEntity(entity, plot.getBasePlot(false))) {
             event.setCancelled(true);
         }
     }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #3050

## Description
<!-- Please describe what this pull request does. -->
handles entity counting with the base plot, eliminating inaccurate mob caps on merged plots and resulting in more entities on a plot than allowed by the mob cap.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
