### PR TITLE
chore: Address Paper javadoc warnings

### DIFF
--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -97,7 +97,7 @@ tasks.named<ShadowJar>("shadowJar") {
 tasks {
     withType<Javadoc> {
         val opt = options as StandardJavadocDocletOptions
-        opt.links("https://papermc.io/javadocs/paper/1.18/")
+        opt.links("https://jd.papermc.io/paper/1.18/")
         opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-bukkit/" + libs.worldeditBukkit.get().versionConstraint.toString())
         opt.links("https://javadoc.io/doc/com.plotsquared/PlotSquared-Core/latest/")
         opt.links("https://jd.adventure.kyori.net/api/" + libs.adventure.get().versionConstraint.toString())


### PR DESCRIPTION
## Overview

## Description
Paper changed their location of their javadocs, which now causes a bunch of warnings due the redirect.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [ ] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
