### PR TITLE
Ensure forceSync is provided when constructing chunk coordinators

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/queue/BukkitChunkCoordinator.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/queue/BukkitChunkCoordinator.java
@@ -92,9 +92,9 @@ public final class BukkitChunkCoordinator extends ChunkCoordinator {
             @Assisted final @NonNull Collection<BlockVector2> requestedChunks,
             @Assisted final @NonNull Runnable whenDone,
             @Assisted final @NonNull Consumer<Throwable> throwableConsumer,
-            @Assisted final boolean unloadAfter,
+            @Assisted("unloadAfter") final boolean unloadAfter,
             @Assisted final @NonNull Collection<ProgressSubscriber> progressSubscribers,
-            @Assisted final boolean forceSync
+            @Assisted("forceSync") final boolean forceSync
     ) {
         this.requestedChunks = new LinkedBlockingQueue<>(requestedChunks);
         this.availableChunks = new LinkedBlockingQueue<>();

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/queue/BukkitQueueCoordinator.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/queue/BukkitQueueCoordinator.java
@@ -235,6 +235,7 @@ public class BukkitQueueCoordinator extends BasicQueueCoordinator {
                         .withConsumer(consumer)
                         .unloadAfter(isUnloadAfter())
                         .withProgressSubscribers(getProgressSubscribers())
+                        .forceSync(isForceSync())
                         .build();
         return super.enqueue();
     }

--- a/Core/src/main/java/com/plotsquared/core/inject/factory/ChunkCoordinatorFactory.java
+++ b/Core/src/main/java/com/plotsquared/core/inject/factory/ChunkCoordinatorFactory.java
@@ -37,36 +37,6 @@ import java.util.function.Consumer;
 
 public interface ChunkCoordinatorFactory {
 
-    /**
-     * @deprecated Use {@link ChunkCoordinatorFactory#create(long, int, Consumer, World, Collection, Runnable, Consumer, boolean, Collection, boolean)}
-     */
-    @Deprecated(forRemoval = true, since = "TODO")
-    @NonNull
-    default ChunkCoordinator create(
-            final long maxIterationTime,
-            final int initialBatchSize,
-            final @NonNull Consumer<BlockVector2> chunkConsumer,
-            final @NonNull World world,
-            final @NonNull Collection<BlockVector2> requestedChunks,
-            final @NonNull Runnable whenDone,
-            final @NonNull Consumer<Throwable> throwableConsumer,
-            final boolean unloadAfter,
-            final @NonNull Collection<ProgressSubscriber> progressSubscribers
-    ) {
-        return create(
-                maxIterationTime,
-                initialBatchSize,
-                chunkConsumer,
-                world,
-                requestedChunks,
-                whenDone,
-                throwableConsumer,
-                unloadAfter,
-                progressSubscribers,
-                false
-        );
-    }
-
     @NonNull ChunkCoordinator create(
             final long maxIterationTime,
             final int initialBatchSize,

--- a/Core/src/main/java/com/plotsquared/core/inject/factory/ChunkCoordinatorFactory.java
+++ b/Core/src/main/java/com/plotsquared/core/inject/factory/ChunkCoordinatorFactory.java
@@ -25,6 +25,7 @@
  */
 package com.plotsquared.core.inject.factory;
 
+import com.google.inject.assistedinject.Assisted;
 import com.plotsquared.core.queue.ChunkCoordinator;
 import com.plotsquared.core.queue.subscriber.ProgressSubscriber;
 import com.sk89q.worldedit.math.BlockVector2;
@@ -44,8 +45,9 @@ public interface ChunkCoordinatorFactory {
             final @NonNull Collection<BlockVector2> requestedChunks,
             final @NonNull Runnable whenDone,
             final @NonNull Consumer<Throwable> throwableConsumer,
-            final boolean unloadAfter,
-            final @NonNull Collection<ProgressSubscriber> progressSubscribers
+            @Assisted("unloadAfter") final boolean unloadAfter,
+            final @NonNull Collection<ProgressSubscriber> progressSubscribers,
+            @Assisted("forceSync") final boolean forceSync
     );
 
 }

--- a/Core/src/main/java/com/plotsquared/core/inject/factory/ChunkCoordinatorFactory.java
+++ b/Core/src/main/java/com/plotsquared/core/inject/factory/ChunkCoordinatorFactory.java
@@ -37,6 +37,36 @@ import java.util.function.Consumer;
 
 public interface ChunkCoordinatorFactory {
 
+    /**
+     * @deprecated Use {@link ChunkCoordinatorFactory#create(long, int, Consumer, World, Collection, Runnable, Consumer, boolean, Collection, boolean)}
+     */
+    @Deprecated(forRemoval = true, since = "TODO")
+    @NonNull
+    default ChunkCoordinator create(
+            final long maxIterationTime,
+            final int initialBatchSize,
+            final @NonNull Consumer<BlockVector2> chunkConsumer,
+            final @NonNull World world,
+            final @NonNull Collection<BlockVector2> requestedChunks,
+            final @NonNull Runnable whenDone,
+            final @NonNull Consumer<Throwable> throwableConsumer,
+            final boolean unloadAfter,
+            final @NonNull Collection<ProgressSubscriber> progressSubscribers
+    ) {
+        return create(
+                maxIterationTime,
+                initialBatchSize,
+                chunkConsumer,
+                world,
+                requestedChunks,
+                whenDone,
+                throwableConsumer,
+                unloadAfter,
+                progressSubscribers,
+                false
+        );
+    }
+
     @NonNull ChunkCoordinator create(
             final long maxIterationTime,
             final int initialBatchSize,

--- a/Core/src/main/java/com/plotsquared/core/queue/ChunkCoordinatorBuilder.java
+++ b/Core/src/main/java/com/plotsquared/core/queue/ChunkCoordinatorBuilder.java
@@ -58,6 +58,7 @@ public class ChunkCoordinatorBuilder {
     private long maxIterationTime = Settings.QUEUE.MAX_ITERATION_TIME; // A little over 1 tick;
     private int initialBatchSize = Settings.QUEUE.INITIAL_BATCH_SIZE;
     private boolean unloadAfter = true;
+    private boolean forceSync = false;
 
     @Inject
     public ChunkCoordinatorBuilder(@NonNull ChunkCoordinatorFactory chunkCoordinatorFactory) {
@@ -197,6 +198,18 @@ public class ChunkCoordinatorBuilder {
         return this;
     }
 
+    /**
+     * Set whether the chunks coordinator should be forced to be synchronous. This is not necessarily synchronous to the server,
+     * and simply effectively makes {@link ChunkCoordinator#start()} ()} a blocking operation.
+     *
+     * @param forceSync force sync or not
+     * @since TODO
+     */
+    public @NonNull ChunkCoordinatorBuilder forceSync(final boolean forceSync) {
+        this.forceSync = forceSync;
+        return this;
+    }
+
     public @NonNull ChunkCoordinatorBuilder withProgressSubscriber(ProgressSubscriber progressSubscriber) {
         this.progressSubscribers.add(progressSubscriber);
         return this;
@@ -227,7 +240,8 @@ public class ChunkCoordinatorBuilder {
                         this.whenDone,
                         this.throwableConsumer,
                         this.unloadAfter,
-                        this.progressSubscribers
+                        this.progressSubscribers,
+                        this.forceSync
                 );
     }
 

--- a/Core/src/main/java/com/plotsquared/core/queue/QueueCoordinator.java
+++ b/Core/src/main/java/com/plotsquared/core/queue/QueueCoordinator.java
@@ -40,14 +40,12 @@ import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
-
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 public abstract class QueueCoordinator {
@@ -117,7 +115,8 @@ public abstract class QueueCoordinator {
     public abstract void setModified(long modified);
 
     /**
-     * Returns true if the queue should be forced to be synchronous when enqueued.
+     * Returns true if the queue should be forced to be synchronous when enqueued. This is not necessarily synchronous to the
+     * server, and simply effectively makes {@link QueueCoordinator#enqueue()} a blocking operation.
      *
      * @return is force sync
      */
@@ -126,7 +125,8 @@ public abstract class QueueCoordinator {
     }
 
     /**
-     * Set whether the queue should be forced to be synchronous
+     * Set whether the queue should be forced to be synchronous. This is not necessarily synchronous to the server, and simply
+     * effectively makes {@link QueueCoordinator#enqueue()} a blocking operation.
      *
      * @param forceSync force sync or not
      */


### PR DESCRIPTION
 - Fixes asyncCatchOp errors due to chunk coordinators defaulting to forceSync "true"
 - Details that forceSync is *not* necessarily synchronous to the server main thread, and instead sets that enqueue/start methods are synchronous (blocking)
 - Fixes #3667