### PR TITLE
Default flags using BlockCategories don't throw an error anymore

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/PlotSquared.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotSquared.java
@@ -73,6 +73,7 @@ import com.plotsquared.core.util.task.TaskManager;
 import com.plotsquared.core.uuid.UUIDPipeline;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.math.BlockVector2;
+import com.sk89q.worldedit.world.block.BlockCategory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -108,6 +109,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
@@ -152,6 +154,7 @@ public class PlotSquared {
     private File storageFile;
     private EventDispatcher eventDispatcher;
     private PlotListener plotListener;
+    private Queue<Runnable> worldEditReadyQueue = new ArrayDeque<>();
 
     /**
      * Initialize PlotSquared with the desired Implementation class.
@@ -1572,6 +1575,23 @@ public class PlotSquared {
 
     public @NonNull PlotListener getPlotListener() {
         return this.plotListener;
+    }
+
+    public Queue<Runnable> worldEditReadyQueue() {
+        return worldEditReadyQueue;
+    }
+
+    /**
+     * Queue a task to be run when WorldEdit is ready or run instantly if WorldEdit is already ready.
+     *
+     * @param action The action to run
+     */
+    public void queueWorldEditAction(Runnable action) {
+        if (BlockCategory.REGISTRY.keySet().isEmpty()) {
+            worldEditReadyQueue.add(action);
+        } else {
+            action.run();
+        }
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/listener/WESubscriber.java
+++ b/Core/src/main/java/com/plotsquared/core/listener/WESubscriber.java
@@ -39,6 +39,7 @@ import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.event.extent.EditSessionEvent;
+import com.sk89q.worldedit.event.platform.PlatformReadyEvent;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extent.NullExtent;
 import com.sk89q.worldedit.regions.CuboidRegion;
@@ -60,6 +61,18 @@ public class WESubscriber {
     public WESubscriber(final @NonNull PlotAreaManager plotAreaManager, final @NonNull WorldUtil worldUtil) {
         this.plotAreaManager = plotAreaManager;
         this.worldUtil = worldUtil;
+    }
+
+    /**
+     * Called when the WorldEdit platform is ready.
+     * Indicates that the registries ({@link com.sk89q.worldedit.world.block.BlockCategory#REGISTRY}) are filled properly
+     */
+    @Subscribe
+    public void onPlatformReady(PlatformReadyEvent event) {
+        Runnable task;
+        while ((task = PlotSquared.get().worldEditReadyQueue().poll()) != null) {
+            task.run();
+        }
     }
 
     @Subscribe(priority = Priority.VERY_EARLY)


### PR DESCRIPTION
## Description
Loads all worlds **after** the WorldEdit-Platform is ready to not fail loading default flags using block categories and accessing empty registries.
Hacky workaround for
> 06.06 23:15:39 [Server] WARN com.plotsquared.core.plot.flag.FlagParseException: Failed to parse flag of type 'use'. Value '#signs' was not accepted.
06.06 23:15:39 [Server] WARN [PlotSquared/PlotArea] Failed to parse default flag with key 'use' and value '#signs'. Reason: com.plotsquared.core.configuration.caption.TranslatableCaption@6ebec81d. This flag will not be added as a default flag.

(The `Reason: Class@Hash` is fixed as well) 

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [ ] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
