### PR TITLE
feat: Add 1.19 music disk to the /plot music GUI

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Music.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Music.java
@@ -62,7 +62,7 @@ public class Music extends SubCommand {
             .asList("music_disc_13", "music_disc_cat", "music_disc_blocks", "music_disc_chirp",
                     "music_disc_far", "music_disc_mall", "music_disc_mellohi", "music_disc_stal",
                     "music_disc_strad", "music_disc_ward", "music_disc_11", "music_disc_wait", "music_disc_otherside",
-                    "music_disc_pigstep"
+                    "music_disc_pigstep", "music_disc_5"
             );
 
     private final InventoryUtil inventoryUtil;


### PR DESCRIPTION
## Overview

## Description
Adds the added music disk from 1.19 to the music GUI.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [ ] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
