### PR TITLE
docs: Unify WE, P2 and Fawe abbreviations

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -270,7 +270,7 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
 
         final PlotSquared plotSquared = new PlotSquared(this, "Bukkit");
 
-        // FAWE
+        // FastAsyncWorldEdit
         if (Settings.FAWE_Components.FAWE_HOOK) {
             Plugin fawe = getServer().getPluginManager().getPlugin("FastAsyncWorldEdit");
             if (fawe != null) {
@@ -278,7 +278,7 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
                     Class.forName("com.fastasyncworldedit.bukkit.regions.plotsquared.FaweQueueCoordinator");
                     faweHook = true;
                 } catch (Exception ignored) {
-                    LOGGER.error("Incompatible version of FAWE to enable hook, please upgrade: https://ci.athion" +
+                    LOGGER.error("Incompatible version of FastAsyncWorldEdit to enable hook, please upgrade: https://ci.athion" +
                             ".net/job/FastAsyncWorldEdit/");
                 }
             }
@@ -432,7 +432,7 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
 
         plotSquared.startExpiryTasks();
 
-        // Once the server has loaded force updating all generators known to P2
+        // Once the server has loaded force updating all generators known to PlotSquared
         TaskManager.runTaskLater(() -> PlotSquared.platform().setupUtils().updateGenerators(true), TaskTime.ticks(1L));
 
         // Services are accessed in order

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/queue/GenChunk.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/queue/GenChunk.java
@@ -110,7 +110,7 @@ public class GenChunk extends ScopedQueueCoordinator {
     /**
      * Set the world and XZ of the chunk being represented via {@link ChunkWrapper}
      *
-     * @param wrap P2 ChunkWrapper
+     * @param wrap PlotSquared ChunkWrapper
      */
     public void setChunk(@NonNull ChunkWrapper wrap) {
         chunk = null;

--- a/Core/src/main/java/com/plotsquared/core/PlotPlatform.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotPlatform.java
@@ -359,9 +359,9 @@ public interface PlotPlatform<P> extends LocaleHolder {
     @NonNull String toLegacyPlatformString(@NonNull Component component);
 
     /**
-     * Returns if the FAWE-P2 hook is active/enabled
+     * Returns if the FastAsyncWorldEdit-PlotSquared hook is active/enabled
      *
-     * @return status of FAWE-P2 hook
+     * @return status of FastAsyncWorldEdit-PlotSquared hook
      */
     default boolean isFaweHooking() {
         return false;

--- a/Core/src/main/java/com/plotsquared/core/PlotSquared.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotSquared.java
@@ -1581,7 +1581,7 @@ public class PlotSquared {
     }
 
     /**
-     * Get if the {@link PlatformReadyEvent} has been sent by WE. There is no way to query this within WE itself.
+     * Get if the {@link PlatformReadyEvent} has been sent by WorldEdit. There is no way to query this within WorldEdit itself.
      */
     public boolean isWeInitialised() {
         return weInitialised;

--- a/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
@@ -44,7 +44,7 @@ public class Settings extends Config {
 
     @Comment("This value is not configurable. It shows the platform you are using.") // This is a comment
     @Final
-    public static String PLATFORM; // These values are set from P2 before loading
+    public static String PLATFORM; // These values are set from PlotSquared before loading
 
     @Comment({"Show additional information in console. It helps us at IntellectualSites to find out more about an issue.",
             "Leave it off if you don't need it, it can spam your console."})
@@ -634,10 +634,10 @@ public class Settings extends Config {
 
     }
 
-    @Comment("Enable or disable all of or parts of the FAWE-P2 hook")
+    @Comment("Enable or disable all of or parts of the FastAsyncWorldEdit-PlotSquared hook")
     public static final class FAWE_Components {
 
-        @Comment("Use FAWE for queue handling.")
+        @Comment("Use FastAsyncWorldEdit for queue handling.")
         public static boolean FAWE_HOOK = true;
         public static boolean CUBOIDS = true;
         public static boolean CLEAR = true;

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
@@ -1379,7 +1379,7 @@ public abstract class PlotArea {
     }
 
     /**
-     * Get the min height from which P2 will generate blocks. Inclusive.
+     * Get the min height from which PlotSquared will generate blocks. Inclusive.
      *
      * @since 6.6.0
      */
@@ -1388,7 +1388,7 @@ public abstract class PlotArea {
     }
 
     /**
-     * Get the max height to which P2 will generate blocks. Inclusive.
+     * Get the max height to which PlotSquared will generate blocks. Inclusive.
      *
      * @since 6.6.0
      */

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotAreaTerrainType.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotAreaTerrainType.java
@@ -44,7 +44,7 @@ public enum PlotAreaTerrainType {
     ORE,
 
     /**
-     * Generate everything using the vanilla generator but with PS roads.
+     * Generate everything using the vanilla generator but with PlotSquared roads.
      */
     ROAD,
 

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/types/ListFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/types/ListFlag.java
@@ -43,7 +43,7 @@ public abstract class ListFlag<V, F extends PlotFlag<List<V>, F>> extends PlotFl
     @Override
     public F merge(@NonNull List<V> newValue) {
         final List<V> mergedList = new ArrayList<>();
-        // If a server already used PS before this fix, we remove all present duplicates on an eventual merge
+        // If a server already used PlotSquared before this fix, we remove all present duplicates on an eventual merge
         for (final V v : getValue()) {
             if (!mergedList.contains(v)) {
                 mergedList.add(v);

--- a/Core/src/main/java/com/plotsquared/core/queue/ChunkQueueCoordinator.java
+++ b/Core/src/main/java/com/plotsquared/core/queue/ChunkQueueCoordinator.java
@@ -39,7 +39,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * Queue that is limited to a single chunk. It does not allow a delegate queue and should be treated as a cache for changes to
  * be set to. Does not support tile entities or entities.
  *
- * @deprecated This class is poorly designed and will no longer be used in P2
+ * @deprecated This class is poorly designed and will no longer be used in PlotSquared
  */
 @Deprecated(forRemoval = true, since = "6.8.0")
 public class ChunkQueueCoordinator extends ScopedQueueCoordinator {

--- a/Core/src/main/java/com/plotsquared/core/util/RegionManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/RegionManager.java
@@ -174,7 +174,7 @@ public abstract class RegionManager {
      * @param whenDone task to run when complete
      * @param manager  plot manager
      * @param actor    the player running the clear
-     * @return {@code true} if the clear worked. {@code false} if someone went wrong so P2 can then handle the clear
+     * @return {@code true} if the clear worked. {@code false} if someone went wrong so PlotSquared can then handle the clear
      */
     public abstract boolean handleClear(
             @NonNull Plot plot,

--- a/Core/src/main/java/com/plotsquared/core/util/RegionUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/RegionUtil.java
@@ -109,7 +109,7 @@ public class RegionUtil {
         return new Rectangle2D.Double(min.getX(), min.getZ(), max.getX(), max.getZ());
     }
 
-    // Because WE (not fawe) lack this for CuboidRegion
+    // Because WorldEdit (not FastAsyncWorldEdit) lack this for CuboidRegion
     public static boolean intersects(CuboidRegion region, CuboidRegion other) {
         BlockVector3 regionMin = region.getMinimumPoint();
         BlockVector3 regionMax = region.getMaximumPoint();

--- a/Core/src/main/java/com/plotsquared/core/util/TabCompletions.java
+++ b/Core/src/main/java/com/plotsquared/core/util/TabCompletions.java
@@ -167,7 +167,7 @@ public final class TabCompletions {
     }
 
     /**
-     * Get a list of completions corresponding to WorldEdit(/FAWE) patterns. This uses
+     * Get a list of completions corresponding to WorldEdit(/FastAsyncWorldEdit) patterns. This uses
      * WorldEdit's pattern completer internally.
      *
      * @param input Command input


### PR DESCRIPTION
## Overview

## Description
Unifies abbreviations used in (internal) documentation to differentiate between actual method names (yes, we have quite a bunch of "p2.doSomething") and general english vocabulary and plugin names.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [ ] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
