### PR TITLE
refactor: replace usages of switch over keyed enums

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -233,10 +233,17 @@ public class BlockEventListener implements Listener {
             plot.debug("Prevented block physics and resent block change because disable-physics = true");
             return;
         }
-        if (event.getChangedType() == Material.COMPARATOR || PHYSICS_BLOCKS.contains(event.getChangedType())) {
+        if (event.getChangedType() == Material.COMPARATOR) {
             if (!plot.getFlag(RedstoneFlag.class)) {
                 event.setCancelled(true);
                 plot.debug("Prevented comparator update because redstone = false");
+            }
+            return;
+        }
+        if (PHYSICS_BLOCKS.contains(event.getChangedType())) {
+            if (plot.getFlag(DisablePhysicsFlag.class)) {
+                event.setCancelled(true);
+                plot.debug("Prevented block physics because disable-physics = true");
             }
             return;
         }
@@ -682,28 +689,29 @@ public class BlockEventListener implements Listener {
             event.setCancelled(true);
             return;
         }
-        if (Tag.ICE.isTagged(block.getType())) {
+        Material blockType = block.getType();
+        if (Tag.ICE.isTagged(blockType)) {
             if (!plot.getFlag(IceMeltFlag.class)) {
                 plot.debug("Ice could not melt because ice-melt = false");
                 event.setCancelled(true);
             }
             return;
         }
-        if (Tag.SNOW.isTagged(block.getType())) {
+        if (Tag.SNOW.isTagged(blockType)) {
             if (!plot.getFlag(SnowMeltFlag.class)) {
                 plot.debug("Snow could not melt because snow-melt = false");
                 event.setCancelled(true);
             }
             return;
         }
-        if (block.getType() == Material.FARMLAND) {
+        if (blockType == Material.FARMLAND) {
             if (!plot.getFlag(SoilDryFlag.class)) {
                 plot.debug("Soil could not dry because soil-dry = false");
                 event.setCancelled(true);
             }
             return;
         }
-        if (Tag.CORAL_BLOCKS.isTagged(block.getType())) {
+        if (Tag.CORAL_BLOCKS.isTagged(blockType) || Tag.CORALS.isTagged(blockType)) {
             if (!plot.getFlag(CoralDryFlag.class)) {
                 plot.debug("Coral could not dry because coral-dry = false");
                 event.setCancelled(true);

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -72,6 +72,7 @@ import net.kyori.adventure.text.minimessage.Template;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
@@ -113,11 +114,20 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 @SuppressWarnings("unused")
 public class BlockEventListener implements Listener {
 
+    private static final Set<Material> PISTONS = Set.of(
+            Material.PISTON,
+            Material.STICKY_PISTON
+    );
+    private static final Set<Material> PHYSICS_BLOCKS = Set.of(
+            Material.TURTLE_EGG,
+            Material.TURTLE_SPAWN_EGG
+    );
     private final PlotAreaManager plotAreaManager;
     private final WorldEdit worldEdit;
 
@@ -223,48 +233,24 @@ public class BlockEventListener implements Listener {
             plot.debug("Prevented block physics and resent block change because disable-physics = true");
             return;
         }
-        switch (event.getChangedType()) {
-            case COMPARATOR: {
-                if (!plot.getFlag(RedstoneFlag.class)) {
-                    event.setCancelled(true);
-                    plot.debug("Prevented comparator update because redstone = false");
-                }
-                return;
+        if (event.getChangedType() == Material.COMPARATOR || PHYSICS_BLOCKS.contains(event.getChangedType())) {
+            if (!plot.getFlag(RedstoneFlag.class)) {
+                event.setCancelled(true);
+                plot.debug("Prevented comparator update because redstone = false");
             }
-            case ANVIL:
-            case DRAGON_EGG:
-            case GRAVEL:
-            case SAND:
-            case TURTLE_EGG:
-            case TURTLE_HELMET:
-            case TURTLE_SPAWN_EGG: {
-                if (plot.getFlag(DisablePhysicsFlag.class)) {
+            return;
+        }
+        if (Settings.Redstone.DETECT_INVALID_EDGE_PISTONS) {
+            if (PISTONS.contains(block.getType())) {
+                org.bukkit.block.data.Directional piston = (org.bukkit.block.data.Directional) block.getBlockData();
+                final BlockFace facing = piston.getFacing();
+                location = location.add(facing.getModX(), facing.getModY(), facing.getModZ());
+                Plot newPlot = area.getOwnedPlotAbs(location);
+                if (!plot.equals(newPlot)) {
                     event.setCancelled(true);
-                    plot.debug("Prevented block physics because disable-physics = true");
+                    plot.debug("Prevented piston update because of invalid edge piston detection");
                 }
-                return;
             }
-            default:
-                if (Settings.Redstone.DETECT_INVALID_EDGE_PISTONS) {
-                    switch (block.getType()) {
-                        case PISTON, STICKY_PISTON -> {
-                            org.bukkit.block.data.Directional piston = (org.bukkit.block.data.Directional) block.getBlockData();
-                            switch (piston.getFacing()) {
-                                case EAST -> location = location.add(1, 0, 0);
-                                case SOUTH -> location = location.add(-1, 0, 0);
-                                case WEST -> location = location.add(0, 0, 1);
-                                case NORTH -> location = location.add(0, 0, -1);
-                            }
-                            Plot newPlot = area.getOwnedPlotAbs(location);
-                            if (!plot.equals(newPlot)) {
-                                event.setCancelled(true);
-                                plot.debug("Prevented piston update because of invalid edge piston detection");
-                                return;
-                            }
-                        }
-                    }
-                }
-                break;
         }
     }
 
@@ -555,21 +541,18 @@ public class BlockEventListener implements Listener {
             event.setCancelled(true);
             return;
         }
-        switch (event.getNewState().getType()) {
-            case SNOW:
-            case SNOW_BLOCK:
-                if (!plot.getFlag(SnowFormFlag.class)) {
-                    plot.debug("Snow could not form because snow-form = false");
-                    event.setCancelled(true);
-                }
-                return;
-            case ICE:
-            case FROSTED_ICE:
-            case PACKED_ICE:
-                if (!plot.getFlag(IceFormFlag.class)) {
-                    plot.debug("Ice could not form because ice-form = false");
-                    event.setCancelled(true);
-                }
+        if (Tag.SNOW.isTagged(event.getNewState().getType())) {
+            if (!plot.getFlag(SnowFormFlag.class)) {
+                plot.debug("Snow could not form because snow-form = false");
+                event.setCancelled(true);
+            }
+            return;
+        }
+        if (Tag.ICE.isTagged(event.getNewState().getType())) {
+            if (!plot.getFlag(IceFormFlag.class)) {
+                plot.debug("Ice could not form because ice-form = false");
+                event.setCancelled(true);
+            }
         }
     }
 
@@ -590,18 +573,12 @@ public class BlockEventListener implements Listener {
             return;
         }
         Class<? extends BooleanFlag<?>> flag;
-        switch (event.getNewState().getType()) {
-            case SNOW:
-            case SNOW_BLOCK:
-                flag = SnowFormFlag.class;
-                break;
-            case ICE:
-            case FROSTED_ICE:
-            case PACKED_ICE:
-                flag = IceFormFlag.class;
-                break;
-            default:
-                return; // other blocks are ignored by this event
+        if (Tag.SNOW.isTagged(event.getNewState().getType())) {
+            flag = SnowFormFlag.class;
+        } else if (Tag.ICE.isTagged(event.getNewState().getType())) {
+            flag = IceFormFlag.class;
+        } else {
+            return;
         }
         boolean allowed = plot.getFlag(flag);
         Entity entity = event.getEntity();
@@ -705,50 +682,32 @@ public class BlockEventListener implements Listener {
             event.setCancelled(true);
             return;
         }
-        switch (block.getType()) {
-            case ICE:
-                if (!plot.getFlag(IceMeltFlag.class)) {
-                    plot.debug("Ice could not melt because ice-melt = false");
-                    event.setCancelled(true);
-                }
-                break;
-            case SNOW:
-                if (!plot.getFlag(SnowMeltFlag.class)) {
-                    plot.debug("Snow could not melt because snow-melt = false");
-                    event.setCancelled(true);
-                }
-                break;
-            case FARMLAND:
-                if (!plot.getFlag(SoilDryFlag.class)) {
-                    plot.debug("Soil could not dry because soil-dry = false");
-                    event.setCancelled(true);
-                }
-                break;
-            case TUBE_CORAL_BLOCK:
-            case BRAIN_CORAL_BLOCK:
-            case BUBBLE_CORAL_BLOCK:
-            case FIRE_CORAL_BLOCK:
-            case HORN_CORAL_BLOCK:
-            case TUBE_CORAL:
-            case BRAIN_CORAL:
-            case BUBBLE_CORAL:
-            case FIRE_CORAL:
-            case HORN_CORAL:
-            case TUBE_CORAL_FAN:
-            case BRAIN_CORAL_FAN:
-            case BUBBLE_CORAL_FAN:
-            case FIRE_CORAL_FAN:
-            case HORN_CORAL_FAN:
-            case BRAIN_CORAL_WALL_FAN:
-            case BUBBLE_CORAL_WALL_FAN:
-            case FIRE_CORAL_WALL_FAN:
-            case HORN_CORAL_WALL_FAN:
-            case TUBE_CORAL_WALL_FAN:
-                if (!plot.getFlag(CoralDryFlag.class)) {
-                    plot.debug("Coral could not dry because coral-dry = false");
-                    event.setCancelled(true);
-                }
-                break;
+        if (Tag.ICE.isTagged(block.getType())) {
+            if (!plot.getFlag(IceMeltFlag.class)) {
+                plot.debug("Ice could not melt because ice-melt = false");
+                event.setCancelled(true);
+            }
+            return;
+        }
+        if (Tag.SNOW.isTagged(block.getType())) {
+            if (!plot.getFlag(SnowMeltFlag.class)) {
+                plot.debug("Snow could not melt because snow-melt = false");
+                event.setCancelled(true);
+            }
+            return;
+        }
+        if (block.getType() == Material.FARMLAND) {
+            if (!plot.getFlag(SoilDryFlag.class)) {
+                plot.debug("Soil could not dry because soil-dry = false");
+                event.setCancelled(true);
+            }
+            return;
+        }
+        if (Tag.CORAL_BLOCKS.isTagged(block.getType())) {
+            if (!plot.getFlag(CoralDryFlag.class)) {
+                plot.debug("Coral could not dry because coral-dry = false");
+                event.setCancelled(true);
+            }
         }
     }
 

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener117.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener117.java
@@ -33,6 +33,7 @@ import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.plot.flag.implementations.CopperOxideFlag;
 import com.plotsquared.core.plot.flag.implementations.MiscInteractFlag;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
@@ -46,10 +47,30 @@ import org.bukkit.event.block.BlockReceiveGameEvent;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 @SuppressWarnings("unused")
 public class BlockEventListener117 implements Listener {
+
+    private static final Set<Material> COPPER_OXIDIZING = Set.of(
+            Material.COPPER_BLOCK,
+            Material.EXPOSED_COPPER,
+            Material.WEATHERED_COPPER,
+            Material.OXIDIZED_COPPER,
+            Material.CUT_COPPER,
+            Material.EXPOSED_CUT_COPPER,
+            Material.WEATHERED_CUT_COPPER,
+            Material.OXIDIZED_CUT_COPPER,
+            Material.CUT_COPPER_STAIRS,
+            Material.EXPOSED_CUT_COPPER_STAIRS,
+            Material.WEATHERED_CUT_COPPER_STAIRS,
+            Material.OXIDIZED_CUT_COPPER_STAIRS,
+            Material.CUT_COPPER_SLAB,
+            Material.EXPOSED_CUT_COPPER_SLAB,
+            Material.WEATHERED_CUT_COPPER_SLAB,
+            Material.OXIDIZED_CUT_COPPER_SLAB
+    );
 
     @Inject
     public BlockEventListener117() {
@@ -155,27 +176,11 @@ public class BlockEventListener117 implements Listener {
         if (plot == null) {
             return;
         }
-        switch (event.getNewState().getType()) {
-            case COPPER_BLOCK:
-            case EXPOSED_COPPER:
-            case WEATHERED_COPPER:
-            case OXIDIZED_COPPER:
-            case CUT_COPPER:
-            case EXPOSED_CUT_COPPER:
-            case WEATHERED_CUT_COPPER:
-            case OXIDIZED_CUT_COPPER:
-            case CUT_COPPER_STAIRS:
-            case EXPOSED_CUT_COPPER_STAIRS:
-            case WEATHERED_CUT_COPPER_STAIRS:
-            case OXIDIZED_CUT_COPPER_STAIRS:
-            case CUT_COPPER_SLAB:
-            case EXPOSED_CUT_COPPER_SLAB:
-            case WEATHERED_CUT_COPPER_SLAB:
-            case OXIDIZED_CUT_COPPER_SLAB:
-                if (!plot.getFlag(CopperOxideFlag.class)) {
-                    plot.debug("Copper could not oxide because copper-oxide = false");
-                    event.setCancelled(true);
-                }
+        if (COPPER_OXIDIZING.contains(event.getNewState().getType())) {
+            if (!plot.getFlag(CopperOxideFlag.class)) {
+                plot.debug("Copper could not oxide because copper-oxide = false");
+                event.setCancelled(true);
+            }
         }
     }
 

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
@@ -140,8 +140,8 @@ public class EntitySpawnListener implements Listener {
                 if (type == EntityType.DROPPED_ITEM) {
                     if (Settings.Enabled_Components.KILL_ROAD_ITEMS) {
                         event.setCancelled(true);
-                        return;
                     }
+                    return;
                 }
                 if (type.isAlive()) {
                     event.setCancelled(true);

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
@@ -131,17 +131,17 @@ public class EntitySpawnListener implements Listener {
             return;
         }
         Plot plot = location.getOwnedPlotAbs();
+        EntityType type = entity.getType();
         if (plot == null) {
-            EntityType type = entity.getType();
             if (!area.isMobSpawning()) {
-                switch (type) {
-                    case DROPPED_ITEM:
-                        if (Settings.Enabled_Components.KILL_ROAD_ITEMS) {
-                            event.setCancelled(true);
-                            return;
-                        }
-                    case PLAYER:
+                if (type == EntityType.PLAYER) {
+                    return;
+                }
+                if (type == EntityType.DROPPED_ITEM) {
+                    if (Settings.Enabled_Components.KILL_ROAD_ITEMS) {
+                        event.setCancelled(true);
                         return;
+                    }
                 }
                 if (type.isAlive()) {
                     event.setCancelled(true);
@@ -155,15 +155,16 @@ public class EntitySpawnListener implements Listener {
         if (Settings.Done.RESTRICT_BUILDING && DoneFlag.isDone(plot)) {
             event.setCancelled(true);
         }
-        switch (entity.getType()) {
-            case ENDER_CRYSTAL:
-                if (BukkitEntityUtil.checkEntity(entity, plot)) {
-                    event.setCancelled(true);
-                }
-            case SHULKER:
-                if (!entity.hasMetadata("shulkerPlot")) {
-                    entity.setMetadata("shulkerPlot", new FixedMetadataValue((Plugin) PlotSquared.platform(), plot.getId()));
-                }
+        if (type == EntityType.ENDER_CRYSTAL) {
+            if (BukkitEntityUtil.checkEntity(entity, plot)) {
+                event.setCancelled(true);
+            }
+            return;
+        }
+        if (type == EntityType.SHULKER) {
+            if (!entity.hasMetadata("shulkerPlot")) {
+                entity.setMetadata("shulkerPlot", new FixedMetadataValue((Plugin) PlotSquared.platform(), plot.getId()));
+            }
         }
     }
 

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
@@ -244,8 +244,8 @@ public class PaperListener implements Listener {
                     if (Settings.Enabled_Components.KILL_ROAD_ITEMS) {
                         event.setShouldAbortSpawn(true);
                         event.setCancelled(true);
-                        return;
                     }
+                    return;
                 }
                 if (type.isAlive()) {
                     event.setShouldAbortSpawn(true);

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
@@ -237,15 +237,15 @@ public class PaperListener implements Listener {
         if (plot == null) {
             EntityType type = event.getType();
             if (!area.isMobSpawning()) {
-                switch (type) {
-                    case DROPPED_ITEM:
-                        if (Settings.Enabled_Components.KILL_ROAD_ITEMS) {
-                            event.setShouldAbortSpawn(true);
-                            event.setCancelled(true);
-                            return;
-                        }
-                    case PLAYER:
+                if (type == EntityType.PLAYER) {
+                    return;
+                }
+                if (type == EntityType.DROPPED_ITEM) {
+                    if (Settings.Enabled_Components.KILL_ROAD_ITEMS) {
+                        event.setShouldAbortSpawn(true);
+                        event.setCancelled(true);
                         return;
+                    }
                 }
                 if (type.isAlive()) {
                     event.setShouldAbortSpawn(true);

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -89,6 +89,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.FluidCollisionMode;
 import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
@@ -166,6 +167,20 @@ import java.util.regex.Pattern;
 @SuppressWarnings("unused")
 public class PlayerEventListener extends PlotListener implements Listener {
 
+    private static final Set<Material> MINECARTS = Set.of(
+            Material.MINECART,
+            Material.TNT_MINECART,
+            Material.CHEST_MINECART,
+            Material.COMMAND_BLOCK_MINECART,
+            Material.FURNACE_MINECART,
+            Material.HOPPER_MINECART
+    );
+    private static final Set<Material> BOOKS = Set.of(
+            Material.BOOK,
+            Material.KNOWLEDGE_BOOK,
+            Material.WRITABLE_BOOK,
+            Material.WRITTEN_BOOK
+    );
     private final EventDispatcher eventDispatcher;
     private final WorldEdit worldEdit;
     private final PlotAreaManager plotAreaManager;
@@ -880,34 +895,26 @@ public class PlayerEventListener extends PlotListener implements Listener {
                 oldLore = lore.toString();
             }
         }
+        Material itemType = newItem.getType();
         if (!"[(+NBT)]".equals(newLore) || (current.equals(newItem) && newLore.equals(oldLore))) {
-            switch (newItem.getType()) {
-                case LEGACY_BANNER:
-                case PLAYER_HEAD:
-                    if (newMeta != null) {
-                        break;
-                    }
-                default:
-                    return;
+            if (newMeta == null || (itemType != Material.LEGACY_BANNER && itemType != Material.PLAYER_HEAD)) {
+                return;
             }
         }
         Block block = player.getTargetBlock(null, 7);
         org.bukkit.block.BlockState state = block.getState();
         Material stateType = state.getType();
-        Material itemType = newItem.getType();
         if (stateType != itemType) {
-            switch (stateType) {
-                case LEGACY_STANDING_BANNER:
-                case LEGACY_WALL_BANNER:
-                    if (itemType == Material.LEGACY_BANNER) {
-                        break;
-                    }
-                case LEGACY_SKULL:
-                    if (itemType == Material.LEGACY_SKULL_ITEM) {
-                        break;
-                    }
-                default:
+            if (stateType == Material.LEGACY_WALL_BANNER || stateType == Material.LEGACY_STANDING_BANNER) {
+                if (itemType != Material.LEGACY_BANNER) {
                     return;
+                }
+            } else if (stateType == Material.LEGACY_SKULL) {
+                if (itemType != Material.LEGACY_SKULL_ITEM) {
+                    return;
+                }
+            } else {
+                return;
             }
         }
         Location location = BukkitUtil.adapt(state.getLocation());
@@ -1133,14 +1140,21 @@ public class PlayerEventListener extends PlotListener implements Listener {
                     //Allow all players to eat while also allowing the block place event ot be fired
                     return;
                 }
-                switch (type) {
-                    case ACACIA_BOAT, BIRCH_BOAT, CHEST_MINECART, COMMAND_BLOCK_MINECART, DARK_OAK_BOAT, FURNACE_MINECART, HOPPER_MINECART, JUNGLE_BOAT, MINECART, OAK_BOAT, SPRUCE_BOAT, TNT_MINECART -> eventType = PlayerBlockEventType.PLACE_VEHICLE;
-                    case FIREWORK_ROCKET, FIREWORK_STAR -> eventType = PlayerBlockEventType.SPAWN_MOB;
-                    case BOOK, KNOWLEDGE_BOOK, WRITABLE_BOOK, WRITTEN_BOOK -> eventType = PlayerBlockEventType.READ;
-                    case ARMOR_STAND -> {
-                        location = BukkitUtil.adapt(block.getRelative(event.getBlockFace()).getLocation());
-                        eventType = PlayerBlockEventType.PLACE_MISC;
-                    }
+                if (type == Material.ARMOR_STAND) {
+                    location = BukkitUtil.adapt(block.getRelative(event.getBlockFace()).getLocation());
+                    eventType = PlayerBlockEventType.PLACE_MISC;
+                }
+                if (Tag.ITEMS_BOATS.isTagged(type) || MINECARTS.contains(type)) {
+                    eventType = PlayerBlockEventType.PLACE_VEHICLE;
+                    break;
+                }
+                if (type == Material.FIREWORK_ROCKET || type == Material.FIREWORK_STAR) {
+                    eventType = PlayerBlockEventType.SPAWN_MOB;
+                    break;
+                }
+                if (BOOKS.contains(type)) {
+                    eventType = PlayerBlockEventType.READ;
+                    break;
                 }
                 break;
             }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -852,10 +852,10 @@ public class PlayerEventListener extends PlotListener implements Listener {
         if ((slot > 8) || !event.getEventName().equals("InventoryCreativeEvent")) {
             return;
         }
-        ItemStack current = inv.getItemInHand();
+        ItemStack oldItem = inv.getItemInHand();
+        ItemMeta oldMeta = oldItem.getItemMeta();
         ItemStack newItem = event.getCursor();
         ItemMeta newMeta = newItem.getItemMeta();
-        ItemMeta oldMeta = newItem.getItemMeta();
 
         if (event.getClick() == ClickType.CREATIVE) {
             final Plot plot = pp.getCurrentPlot();
@@ -896,7 +896,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             }
         }
         Material itemType = newItem.getType();
-        if (!"[(+NBT)]".equals(newLore) || (current.equals(newItem) && newLore.equals(oldLore))) {
+        if (!"[(+NBT)]".equals(newLore) || (oldItem.equals(newItem) && newLore.equals(oldLore))) {
             if (newMeta == null || (itemType != Material.LEGACY_BANNER && itemType != Material.PLAYER_HEAD)) {
                 return;
             }
@@ -953,7 +953,7 @@ public class PlayerEventListener extends PlotListener implements Listener {
             }
         }
         if (cancelled) {
-            if ((current.getType() == newItem.getType()) && (current.getDurability() == newItem
+            if ((oldItem.getType() == newItem.getType()) && (oldItem.getDurability() == newItem
                     .getDurability())) {
                 event.setCursor(
                         new ItemStack(newItem.getType(), newItem.getAmount(), newItem.getDurability()));


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

As [announced by md_5](https://www.spigotmc.org/threads/spigot-bungeecord-1-19.559742/#post-4422235) the API around Keyed enums is planned to change. To prevent issues in future, this PR replaces usages of switch over such enums.

The affected places were identified using the Search Structurally feature from IntelliJ.

There also are a few places which I assume were wrong before (mostly missing breaks/returns), so this should be reviewed carefully.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
