### PR TITLE
Fix maximum plot number check in `/plot continue` counting the current plot twice

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Continue.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Continue.java
@@ -73,7 +73,7 @@ public class Continue extends SubCommand {
             return false;
         }
         int size = plot.getConnectedPlots().size();
-        if (Settings.Done.COUNTS_TOWARDS_LIMIT && (player.getAllowedPlots()
+        if (!Settings.Done.COUNTS_TOWARDS_LIMIT && (player.getAllowedPlots()
                 < player.getPlotCount() + size)) {
             player.sendMessage(
                     TranslatableCaption.of("permission.cant_claim_more_plots"),


### PR DESCRIPTION
## Overview
This PR fixes a problem with `/plot continue` incorrectly failing with "You can't claim more than x plots."

## Description
<!-- Please describe what this pull request does. -->
When `done.counts-towards-limit` is set to `true` in the config, running `/plot continue` on a plot marked as done fails with "You can't claim more than [...] plots." if the player has the maximum amount of plots assigned to them.
Turns out the check for `done.counts-towards-limit` was inverted in the Continue command and thus the plot was counted twice towards the maximum when the setting is `true` and not at all when the setting is `false`. (Only in the continue command)
This PR fixes this issue.


## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
