### PR TITLE
docs: Publish javadocs to GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
       - name: Publish core javadoc
+        if: ${{ runner.os == 'Linux' && env.STATUS == 'release' && github.event_name == 'push' && github.ref == 'refs/heads/v6'}}
         uses: cpina/github-action-push-to-another-repository@main
         env:
           SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
@@ -52,6 +53,7 @@ jobs:
           target-branch: main
           target-directory: core
       - name: Publish bukkit javadoc
+        if: ${{ runner.os == 'Linux' && env.STATUS == 'release' && github.event_name == 'push' && github.ref == 'refs/heads/v6'}}
         uses: cpina/github-action-push-to-another-repository@main
         env:
           SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,3 +40,25 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+      - name: Publish core javadoc
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+        with:
+          source-directory: 'Core/build/docs/javadoc'
+          destination-github-username: 'IntellectualSites'
+          destination-repository-name: 'plotsquared-javadocs'
+          user-email: ${{ secrets.USER_EMAIL }}
+          target-branch: main
+          target-directory: core
+      - name: Publish bukkit javadoc
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+        with:
+          source-directory: 'Bukkit/build/docs/javadoc'
+          destination-github-username: 'IntellectualSites'
+          destination-repository-name: 'plotsquared-javadocs'
+          user-email: ${{ secrets.USER_EMAIL }}
+          target-branch: main
+          target-directory: bukkit

--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -99,7 +99,7 @@ tasks {
         val opt = options as StandardJavadocDocletOptions
         opt.links("https://jd.papermc.io/paper/1.18/")
         opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-bukkit/" + libs.worldeditBukkit.get().versionConstraint.toString())
-    //    opt.links("https://javadoc.io/doc/com.plotsquared/PlotSquared-Core/latest/")
+        opt.links("https://intellectualsites.github.io/plotsquared-javadocs/core/index.html")
         opt.links("https://jd.adventure.kyori.net/api/4.9.3/")
         opt.links("https://google.github.io/guice/api-docs/" + libs.guice.get().versionConstraint.toString() + "/javadoc/")
         opt.links("https://checkerframework.org/api/")

--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -99,7 +99,7 @@ tasks {
         val opt = options as StandardJavadocDocletOptions
         opt.links("https://jd.papermc.io/paper/1.18/")
         opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-bukkit/" + libs.worldeditBukkit.get().versionConstraint.toString())
-        opt.links("https://javadoc.io/doc/com.plotsquared/PlotSquared-Core/latest/")
+    //    opt.links("https://javadoc.io/doc/com.plotsquared/PlotSquared-Core/latest/")
         opt.links("https://jd.adventure.kyori.net/api/4.9.3/")
         opt.links("https://google.github.io/guice/api-docs/" + libs.guice.get().versionConstraint.toString() + "/javadoc/")
         opt.links("https://checkerframework.org/api/")

--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -99,7 +99,7 @@ tasks {
         val opt = options as StandardJavadocDocletOptions
         opt.links("https://jd.papermc.io/paper/1.18/")
         opt.links("https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-bukkit/" + libs.worldeditBukkit.get().versionConstraint.toString())
-        opt.links("https://intellectualsites.github.io/plotsquared-javadocs/core/index.html")
+        opt.links("https://intellectualsites.github.io/plotsquared-javadocs/core/")
         opt.links("https://jd.adventure.kyori.net/api/4.9.3/")
         opt.links("https://google.github.io/guice/api-docs/" + libs.guice.get().versionConstraint.toString() + "/javadoc/")
         opt.links("https://checkerframework.org/api/")


### PR DESCRIPTION
## Overview

## Description
Temporarily pause fetching of javadoc.io, exchange to our URL later on. Additionally I plan to change the deployment schedule to publish them on release only.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [ ] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [ ] Ensure that the pull request title represents the desired changelog entry.
- [ ] New public fields and methods are annotated with `@since TODO`.
- [ ] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
