### PR TITLE
Better handling of offline projectile shooters

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/ProjectileEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/ProjectileEventListener.java
@@ -149,6 +149,18 @@ public class ProjectileEventListener implements Listener {
         Plot plot = area.getPlot(location);
         ProjectileSource shooter = entity.getShooter();
         if (shooter instanceof Player) {
+            if (!((Player) shooter).isOnline()) {
+                if (plot != null) {
+                    if (plot.isAdded(((Player) shooter).getUniqueId()) || plot.getFlag(ProjectilesFlag.class)) {
+                        return;
+                    }
+                }
+
+                entity.remove();
+                event.setCancelled(true);
+                return;
+            }
+
             PlotPlayer<?> pp = BukkitUtil.adapt((Player) shooter);
             if (plot == null) {
                 if (!Permissions.hasPermission(pp, Permission.PERMISSION_ADMIN_PROJECTILE_UNOWNED)) {


### PR DESCRIPTION
## Overview

Fixes #3699.

## Description

Filter out offline player shooters before constructing the PlotPlayer in the ProjectileHitEvent to avoid exceptions being thrown. If the offline player isn't added to the plot and the plot doesn't have the projectiles flag, remove the projectile and cancel the hit event.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
