### PR TITLE
chore: Use WorldEdit logger interface

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -109,11 +109,11 @@ import com.plotsquared.core.uuid.CacheUUIDService;
 import com.plotsquared.core.uuid.UUIDPipeline;
 import com.plotsquared.core.uuid.offline.OfflineModeUUIDService;
 import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import io.papermc.lib.PaperLib;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.DrilldownPie;
@@ -165,7 +165,7 @@ import static com.plotsquared.core.util.ReflectionUtils.getRefClass;
 @Singleton
 public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPlatform<Player> {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + BukkitPlatform.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static final int BSTATS_ID = 1404;
 
     static {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/entity/ReplicatingEntityWrapper.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/entity/ReplicatingEntityWrapper.java
@@ -19,7 +19,7 @@
 package com.plotsquared.bukkit.entity;
 
 import com.plotsquared.core.configuration.Settings;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Art;
 import org.bukkit.DyeColor;
@@ -55,7 +55,7 @@ import java.util.List;
 
 public final class ReplicatingEntityWrapper extends EntityWrapper {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + ReplicatingEntityWrapper.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private final short depth;
     private final int hash;

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/inject/BackupModule.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/inject/BackupModule.java
@@ -26,12 +26,12 @@ import com.plotsquared.core.backup.NullBackupManager;
 import com.plotsquared.core.backup.PlayerBackupProfile;
 import com.plotsquared.core.backup.SimpleBackupManager;
 import com.plotsquared.core.inject.factory.PlayerBackupProfileFactory;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 
 public class BackupModule extends AbstractModule {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + BackupModule.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     @Override
     protected void configure() {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/inject/BukkitModule.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/inject/BukkitModule.java
@@ -65,7 +65,7 @@ import com.plotsquared.core.util.SetupUtils;
 import com.plotsquared.core.util.WorldUtil;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.extension.platform.Actor;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.command.ConsoleCommandSender;
@@ -74,7 +74,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class BukkitModule extends AbstractModule {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + BukkitModule.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private final BukkitPlatform bukkitPlatform;
 

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/queue/LimitedRegionWrapperQueue.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/queue/LimitedRegionWrapperQueue.java
@@ -27,7 +27,7 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
@@ -41,7 +41,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  */
 public class LimitedRegionWrapperQueue extends DelegateQueueCoordinator {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + LimitedRegionWrapperQueue.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private final LimitedRegion limitedRegion;
 

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
@@ -47,7 +47,7 @@ import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.Template;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
@@ -108,7 +108,7 @@ public class BukkitUtil extends WorldUtil {
     public static final BukkitAudiences BUKKIT_AUDIENCES = BukkitAudiences.create(BukkitPlatform.getPlugin(BukkitPlatform.class));
     public static final LegacyComponentSerializer LEGACY_COMPONENT_SERIALIZER = LegacyComponentSerializer.legacySection();
     public static final MiniMessage MINI_MESSAGE = MiniMessage.builder().build();
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + BukkitUtil.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
     private final Collection<BlockType> tileEntityTypes = new HashSet<>();
 
     /**

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/ContentMap.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/ContentMap.java
@@ -26,7 +26,7 @@ import com.sk89q.worldedit.bukkit.BukkitWorld;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.world.block.BaseBlock;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Chunk;
 import org.bukkit.World;
@@ -40,7 +40,7 @@ import java.util.Set;
 
 public class ContentMap {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + ContentMap.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     final Set<EntityWrapper> entities;
     final Map<PlotLoc, BaseBlock[]> allBlocks;

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/UpdateUtility.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/UpdateUtility.java
@@ -25,7 +25,7 @@ import com.google.inject.Inject;
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.PlotVersion;
 import com.plotsquared.core.configuration.Settings;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
@@ -39,7 +39,7 @@ import java.net.URL;
 
 public class UpdateUtility implements Listener {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + UpdateUtility.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     public static PlotVersion internalVersion;
     public static String spigotVersion;

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/uuid/SquirrelIdUUIDService.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/uuid/SquirrelIdUUIDService.java
@@ -22,7 +22,7 @@ import com.google.common.util.concurrent.RateLimiter;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.uuid.UUIDMapping;
 import com.plotsquared.core.uuid.UUIDService;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.enginehub.squirrelid.Profile;
@@ -41,7 +41,7 @@ import java.util.UUID;
 @SuppressWarnings("UnstableApiUsage")
 public class SquirrelIdUUIDService implements UUIDService {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + SquirrelIdUUIDService.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private final ProfileService profileService;
     private final RateLimiter rateLimiter;

--- a/Core/src/main/java/com/plotsquared/core/PlotSquared.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotSquared.java
@@ -69,7 +69,7 @@ import com.sk89q.worldedit.event.platform.PlatformReadyEvent;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.util.eventbus.EventHandler;
 import com.sk89q.worldedit.util.eventbus.Subscribe;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -117,7 +117,7 @@ import java.util.zip.ZipInputStream;
 @SuppressWarnings({"WeakerAccess"})
 public class PlotSquared {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + PlotSquared.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static @MonotonicNonNull PlotSquared instance;
 
     // Implementation

--- a/Core/src/main/java/com/plotsquared/core/command/Claim.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Claim.java
@@ -39,7 +39,7 @@ import com.plotsquared.core.util.Permissions;
 import com.plotsquared.core.util.PlotExpression;
 import com.plotsquared.core.util.task.TaskManager;
 import net.kyori.adventure.text.minimessage.Template;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -51,7 +51,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
         usage = "/plot claim")
 public class Claim extends SubCommand {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + Claim.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private final EventDispatcher eventDispatcher;
     private final EconHandler econHandler;

--- a/Core/src/main/java/com/plotsquared/core/command/MainCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/MainCommand.java
@@ -36,7 +36,7 @@ import com.plotsquared.core.util.Permissions;
 import com.plotsquared.core.util.PlotExpression;
 import com.plotsquared.core.util.task.RunnableVal2;
 import com.plotsquared.core.util.task.RunnableVal3;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Arrays;
@@ -51,7 +51,7 @@ import java.util.concurrent.CompletableFuture;
         aliases = {"plots", "p", "plotsquared", "plot2", "p2", "ps", "2", "plotme", "plotz", "ap"})
 public class MainCommand extends Command {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + MainCommand.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private static MainCommand instance;
     public Help help;

--- a/Core/src/main/java/com/plotsquared/core/command/Purge.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Purge.java
@@ -34,7 +34,7 @@ import com.plotsquared.core.util.query.PlotQuery;
 import com.plotsquared.core.util.task.TaskManager;
 import com.plotsquared.core.uuid.UUIDMapping;
 import net.kyori.adventure.text.minimessage.Template;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -53,7 +53,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
         confirmation = true)
 public class Purge extends SubCommand {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + Purge.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private final PlotAreaManager plotAreaManager;
     private final PlotListener plotListener;

--- a/Core/src/main/java/com/plotsquared/core/command/Trim.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Trim.java
@@ -39,7 +39,7 @@ import com.plotsquared.core.util.task.TaskManager;
 import com.plotsquared.core.util.task.TaskTime;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.regions.CuboidRegion;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -55,7 +55,7 @@ import java.util.Set;
         category = CommandCategory.ADMINISTRATION)
 public class Trim extends SubCommand {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + Trim.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static volatile boolean TASK = false;
 
     private final PlotAreaManager plotAreaManager;

--- a/Core/src/main/java/com/plotsquared/core/components/ComponentPresetManager.java
+++ b/Core/src/main/java/com/plotsquared/core/components/ComponentPresetManager.java
@@ -40,7 +40,7 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.world.item.ItemTypes;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.Template;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -61,7 +61,7 @@ import java.util.stream.Collectors;
 public class ComponentPresetManager {
 
     private static final MiniMessage MINI_MESSAGE = MiniMessage.builder().build();
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + ComponentPresetManager.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private final List<ComponentPreset> presets;
     private final EconHandler econHandler;

--- a/Core/src/main/java/com/plotsquared/core/configuration/Config.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Config.java
@@ -21,7 +21,7 @@ package com.plotsquared.core.configuration;
 import com.plotsquared.core.configuration.Settings.Enabled_Components;
 import com.plotsquared.core.configuration.file.YamlConfiguration;
 import com.plotsquared.core.util.StringMan;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
@@ -40,7 +40,7 @@ import java.util.Map;
 
 public class Config {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + Config.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     /**
      * Get the value for a node<br>

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/load/CaptionLoader.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/load/CaptionLoader.java
@@ -25,7 +25,7 @@ import com.plotsquared.core.configuration.caption.CaptionMap;
 import com.plotsquared.core.configuration.caption.LocalizedCaptionMap;
 import com.plotsquared.core.configuration.caption.PerUserLocaleCaptionMap;
 import com.plotsquared.core.configuration.caption.TranslatableCaption;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -54,7 +54,7 @@ import java.util.stream.Stream;
  */
 public final class CaptionLoader {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + CaptionLoader.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private static final Gson GSON;
 

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/load/ClassLoaderCaptionProvider.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/load/ClassLoaderCaptionProvider.java
@@ -18,7 +18,7 @@
  */
 package com.plotsquared.core.configuration.caption.load;
 
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -35,7 +35,7 @@ import static com.plotsquared.core.configuration.caption.load.CaptionLoader.load
 
 final class ClassLoaderCaptionProvider implements DefaultCaptionProvider {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + ClassLoaderCaptionProvider.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
     private final ClassLoader classLoader;
     private final Function<@NonNull Locale, @NonNull String> urlProvider;
 

--- a/Core/src/main/java/com/plotsquared/core/configuration/file/YamlConfiguration.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/file/YamlConfiguration.java
@@ -21,7 +21,7 @@ package com.plotsquared.core.configuration.file;
 import com.plotsquared.core.configuration.Configuration;
 import com.plotsquared.core.configuration.ConfigurationSection;
 import com.plotsquared.core.configuration.InvalidConfigurationException;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
@@ -40,7 +40,7 @@ import java.util.Map;
  */
 public class YamlConfiguration extends FileConfiguration {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + YamlConfiguration.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private static final String COMMENT_PREFIX = "# ";
     private static final String BLANK_CONFIG = "{}\n";

--- a/Core/src/main/java/com/plotsquared/core/database/SQLManager.java
+++ b/Core/src/main/java/com/plotsquared/core/database/SQLManager.java
@@ -44,7 +44,7 @@ import com.plotsquared.core.util.HashUtil;
 import com.plotsquared.core.util.StringMan;
 import com.plotsquared.core.util.task.RunnableVal;
 import com.plotsquared.core.util.task.TaskManager;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -78,7 +78,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @SuppressWarnings("SqlDialectInspection")
 public class SQLManager implements AbstractDB {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + SQLManager.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     // Public final
     public final String SET_OWNER;

--- a/Core/src/main/java/com/plotsquared/core/database/SQLite.java
+++ b/Core/src/main/java/com/plotsquared/core/database/SQLite.java
@@ -19,7 +19,7 @@
 package com.plotsquared.core.database;
 
 import com.plotsquared.core.PlotSquared;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
@@ -35,7 +35,7 @@ import java.sql.Statement;
  */
 public class SQLite extends Database {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + SQLite.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private final String dbLocation;
     private Connection connection;

--- a/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
@@ -50,7 +50,7 @@ import com.sk89q.worldedit.math.transform.AffineTransform;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BaseBlock;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -64,7 +64,7 @@ import java.util.Locale;
 
 public class HybridPlotWorld extends ClassicPlotWorld {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + HybridPlotWorld.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static final AffineTransform transform = new AffineTransform().rotateY(90);
     public boolean ROAD_SCHEMATIC_ENABLED;
     public boolean PLOT_SCHEMATIC = false;

--- a/Core/src/main/java/com/plotsquared/core/generator/HybridUtils.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridUtils.java
@@ -55,7 +55,7 @@ import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -75,7 +75,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class HybridUtils {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + HybridUtils.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static final BlockState AIR = BlockTypes.AIR.getDefaultState();
 
     public static HybridUtils manager;

--- a/Core/src/main/java/com/plotsquared/core/generator/SquarePlotManager.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/SquarePlotManager.java
@@ -28,7 +28,7 @@ import com.plotsquared.core.queue.QueueCoordinator;
 import com.plotsquared.core.util.HashUtil;
 import com.plotsquared.core.util.RegionManager;
 import com.sk89q.worldedit.regions.CuboidRegion;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -41,7 +41,7 @@ import java.util.Set;
  */
 public abstract class SquarePlotManager extends GridPlotManager {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + SquarePlotManager.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private final SquarePlotWorld squarePlotWorld;
     private final RegionManager regionManager;

--- a/Core/src/main/java/com/plotsquared/core/generator/SquarePlotWorld.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/SquarePlotWorld.java
@@ -24,14 +24,14 @@ import com.plotsquared.core.configuration.file.YamlConfiguration;
 import com.plotsquared.core.inject.annotations.WorldConfig;
 import com.plotsquared.core.plot.PlotId;
 import com.plotsquared.core.queue.GlobalBlockQueue;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public abstract class SquarePlotWorld extends GridPlotWorld {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + SquarePlotWorld.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     public int PLOT_WIDTH = 42;
     public int ROAD_WIDTH = 7;

--- a/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
+++ b/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
@@ -61,7 +61,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.Template;
 import net.kyori.adventure.title.Title;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -91,7 +91,7 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
 
     private static final String NON_EXISTENT_CAPTION = "<red>PlotSquared does not recognize the caption: ";
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + PlotPlayer.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     // Used to track debug mode
     private static final Set<PlotPlayer<?>> debugModeEnabled =

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -73,7 +73,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.Template;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -118,7 +118,7 @@ public class Plot {
     @Deprecated(forRemoval = true, since = "6.6.0")
     public static final int MAX_HEIGHT = 256;
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + Plot.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static final DecimalFormat FLAG_DECIMAL_FORMAT = new DecimalFormat("0");
     private static final MiniMessage MINI_MESSAGE = MiniMessage.builder().build();
     private static final Cleaner CLEANER = Cleaner.create();

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
@@ -60,7 +60,7 @@ import com.sk89q.worldedit.world.gamemode.GameMode;
 import com.sk89q.worldedit.world.gamemode.GameModes;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.Template;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -85,7 +85,7 @@ import java.util.function.Consumer;
  */
 public abstract class PlotArea {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + PlotArea.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static final MiniMessage MINI_MESSAGE = MiniMessage.builder().build();
     private static final DecimalFormat FLAG_DECIMAL_FORMAT = new DecimalFormat("0");
 

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
@@ -47,7 +47,7 @@ import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import net.kyori.adventure.text.minimessage.Template;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -68,7 +68,7 @@ import java.util.stream.Collectors;
  */
 public final class PlotModificationManager {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + PlotModificationManager.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private final Plot plot;
     private final ProgressSubscriberFactory subscriberFactory;

--- a/Core/src/main/java/com/plotsquared/core/plot/expiration/PlotAnalysis.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/expiration/PlotAnalysis.java
@@ -27,7 +27,7 @@ import com.plotsquared.core.util.MathMan;
 import com.plotsquared.core.util.query.PlotQuery;
 import com.plotsquared.core.util.task.RunnableVal;
 import com.plotsquared.core.util.task.TaskManager;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 
 import java.lang.reflect.Array;
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class PlotAnalysis {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + PlotAnalysis.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     public static boolean running = false;
     public int changes;

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/FlagContainer.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/FlagContainer.java
@@ -22,7 +22,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.plotsquared.core.configuration.caption.CaptionUtility;
 import com.plotsquared.core.util.AnnotationHelper;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -39,7 +39,7 @@ import java.util.Objects;
  */
 public class FlagContainer {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + FlagContainer.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private final Map<String, String> unknownFlags = new HashMap<>();
     private final Map<Class<?>, PlotFlag<?, ?>> flagMap = new HashMap<>();

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/types/BlockTypeWrapper.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/types/BlockTypeWrapper.java
@@ -24,7 +24,7 @@ import com.plotsquared.core.configuration.Settings;
 import com.sk89q.worldedit.world.block.BlockCategory;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockType;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -38,7 +38,7 @@ import java.util.Map;
  */
 public class BlockTypeWrapper {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + BlockTypeWrapper.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private static final Map<BlockType, BlockTypeWrapper> blockTypes = new HashMap<>();
     private static final Map<String, BlockTypeWrapper> blockCategories = new HashMap<>();

--- a/Core/src/main/java/com/plotsquared/core/queue/QueueProvider.java
+++ b/Core/src/main/java/com/plotsquared/core/queue/QueueProvider.java
@@ -20,13 +20,13 @@ package com.plotsquared.core.queue;
 
 import com.plotsquared.core.PlotSquared;
 import com.sk89q.worldedit.world.World;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public abstract class QueueProvider {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + PlotSquared.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     public static QueueProvider of(final @NonNull Class<? extends QueueCoordinator> primary) {
         return new QueueProvider() {

--- a/Core/src/main/java/com/plotsquared/core/util/LegacyConverter.java
+++ b/Core/src/main/java/com/plotsquared/core/util/LegacyConverter.java
@@ -25,7 +25,7 @@ import com.plotsquared.core.player.ConsolePlayer;
 import com.plotsquared.core.plot.BlockBucket;
 import com.sk89q.worldedit.world.block.BlockState;
 import net.kyori.adventure.text.minimessage.Template;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -41,7 +41,7 @@ import java.util.Map;
 public final class LegacyConverter {
 
     public static final String CONFIGURATION_VERSION = "post_flattening";
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + LegacyConverter.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static final HashMap<String, ConfigurationType> TYPE_MAP = new HashMap<>();
 
     static {

--- a/Core/src/main/java/com/plotsquared/core/util/PlotUploader.java
+++ b/Core/src/main/java/com/plotsquared/core/util/PlotUploader.java
@@ -26,7 +26,7 @@ import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.plot.Plot;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.jnbt.NBTOutputStream;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -45,7 +45,7 @@ import java.util.zip.GZIPOutputStream;
  */
 public class PlotUploader {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + PlotUploader.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static final Path TEMP_DIR = Paths.get(PlotSquared.platform().getDirectory().getPath());
     private final SchematicHandler schematicHandler;
     private final Arkitektonika arkitektonika;

--- a/Core/src/main/java/com/plotsquared/core/util/RegionManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/RegionManager.java
@@ -40,7 +40,7 @@ import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.biome.BiomeType;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -51,7 +51,7 @@ import java.util.Set;
 
 public abstract class RegionManager {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + RegionManager.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     public static RegionManager manager = null;
     protected final WorldUtil worldUtil;

--- a/Core/src/main/java/com/plotsquared/core/util/SchematicHandler.java
+++ b/Core/src/main/java/com/plotsquared/core/util/SchematicHandler.java
@@ -64,7 +64,7 @@ import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockTypes;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -107,7 +107,7 @@ import java.util.zip.GZIPOutputStream;
 
 public abstract class SchematicHandler {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + SchematicHandler.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static final Gson GSON = new Gson();
     public static SchematicHandler manager;
     private final WorldUtil worldUtil;

--- a/Core/src/main/java/com/plotsquared/core/uuid/UUIDPipeline.java
+++ b/Core/src/main/java/com/plotsquared/core/uuid/UUIDPipeline.java
@@ -26,7 +26,7 @@ import com.plotsquared.core.player.ConsolePlayer;
 import com.plotsquared.core.util.ThreadUtils;
 import com.plotsquared.core.util.task.TaskManager;
 import net.kyori.adventure.text.minimessage.MiniMessage;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -59,7 +59,7 @@ import java.util.function.Function;
  */
 public class UUIDPipeline {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + UUIDPipeline.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static final MiniMessage MINI_MESSAGE = MiniMessage.builder().build();
 
     private final Executor executor;

--- a/Core/src/test/java/com/plotsquared/core/plot/FlagTest.java
+++ b/Core/src/test/java/com/plotsquared/core/plot/FlagTest.java
@@ -26,7 +26,7 @@ import com.plotsquared.core.plot.flag.PlotFlag;
 import com.plotsquared.core.plot.flag.implementations.PlotTitleFlag;
 import com.plotsquared.core.plot.flag.implementations.UseFlag;
 import com.sk89q.worldedit.world.item.ItemType;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 
 public class FlagTest {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + FlagTest.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private ItemType testBlock;
 

--- a/Core/src/test/java/com/plotsquared/core/plot/PlotVersionTest.java
+++ b/Core/src/test/java/com/plotsquared/core/plot/PlotVersionTest.java
@@ -19,13 +19,13 @@
 package com.plotsquared.core.plot;
 
 import com.plotsquared.core.PlotVersion;
-import org.apache.logging.log4j.LogManager;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 
 public class PlotVersionTest {
 
-    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + PlotVersionTest.class.getSimpleName());
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     @Test
     public void tryParse() {


### PR DESCRIPTION
## Overview

## Description
Use WorldEdit logger implementation, inspired by a recent PR which mistakenly used it.

Untested, because sed goes brrr, however, the format change goes from `PlotSquared/<caller class>` to `FQN.<caller class>`.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [ ] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
