### PR TITLE
Minor cleanup of the plot analyze code

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/generator/HybridUtils.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridUtils.java
@@ -189,13 +189,13 @@ public class HybridUtils {
                 if (X == ctx) {
                     maxX = tx & 15;
                 } else {
-                    maxX = 16;
+                    maxX = 15;
                 }
                 int maxZ;
                 if (Z == ctz) {
                     maxZ = tz & 15;
                 } else {
-                    maxZ = 16;
+                    maxZ = 15;
                 }
 
                 int chunkBlockX = X << 4;
@@ -221,7 +221,7 @@ public class HybridUtils {
                 }
             });
 
-            final Runnable run = () -> TaskManager.runTaskAsync(() -> {
+            final Runnable run = () -> {
                 int size = width * length;
                 int[] changes = new int[size];
                 int[] faces = new int[size];
@@ -296,7 +296,7 @@ public class HybridUtils {
                 analysis.variety_sd = (int) (MathMan.getSD(variety, analysis.variety) * 100);
                 whenDone.value = analysis;
                 whenDone.run();
-            });
+            };
             queue.setCompleteTask(run);
             queue.enqueue();
         });


### PR DESCRIPTION
 - No need to wrap the final analysis into another async method. It's already contained in an async task
 - Don't overstretch a chunk boundary when setting blocks to newBlocks array
