### PR TITLE
Ignore cancelled projectile launch events

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/ProjectileEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/ProjectileEventListener.java
@@ -89,7 +89,7 @@ public class ProjectileEventListener implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onProjectileLaunch(ProjectileLaunchEvent event) {
         Projectile entity = event.getEntity();
         ProjectileSource shooter = entity.getShooter();


### PR DESCRIPTION
## Overview

Fixes #3592

## Description

Changed it so PlotSquared ignores cancelled projectile launch events. Other plugins can then allow projectiles to be launched by cancelling the event, and then later uncancelling the event.

It looks like most of PlotSquared's event listeners use the event priority HIGHEST, but I left that untouched in case any other plugins rely on the current (default) priority.

I could also make it so elytra can be used by anyone anywhere in plot worlds, but I don't know if you guys find that desirable.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
