### PR TITLE
Show old flag value in remove command

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
@@ -462,6 +462,7 @@ public final class FlagCommand extends Command {
             return;
         }
         final Plot plot = player.getLocation().getPlotAbs();
+        final PlotFlag<?, ?> flagWithOldValue = plot.getFlagContainer().getFlag(flag.getClass());
         PlotFlagRemoveEvent event = eventDispatcher.callFlagRemove(flag, plot);
         if (event.getEventResult() == Result.DENY) {
             player.sendMessage(
@@ -506,7 +507,7 @@ public final class FlagCommand extends Command {
                     if (plot.removeFlag(flag)) {
                         player.sendMessage(TranslatableCaption.of("flag.flag_removed"), Template.of("flag", args[0]), Template.of(
                                 "value",
-                                String.valueOf(flag)
+                                String.valueOf(flagWithOldValue)
                         ));
                         return;
                     } else {
@@ -544,7 +545,7 @@ public final class FlagCommand extends Command {
         }
         player.sendMessage(TranslatableCaption.of("flag.flag_removed"), Template.of("flag", args[0]), Template.of(
                 "value",
-                String.valueOf(flag)
+                String.valueOf(flagWithOldValue)
         ));
     }
 


### PR DESCRIPTION
## Overview

Fixes #3158

## Description

The call `PlotFlag<?, ?> flag = getFlag(player, args[0]);` retrieves the flag + value from the global flag container instead of the plot container, so the remove message contains the global default value. This PR fetches the flag value from the plot as well and uses that in the remove message.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
