### PR TITLE
fix: Don't fail post processing compilation on non-ascii charmap

### DIFF
--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -105,5 +105,6 @@ tasks {
         opt.links("https://jd.adventure.kyori.net/api/4.9.3/")
         opt.links("https://google.github.io/guice/api-docs/" + libs.guice.get().versionConstraint.toString() + "/javadoc/")
         opt.links("https://checkerframework.org/api/")
+        opt.encoding("UTF-8")
     }
 }

--- a/Core/build.gradle.kts
+++ b/Core/build.gradle.kts
@@ -64,5 +64,6 @@ tasks {
         opt.links("https://google.github.io/guice/api-docs/" + libs.guice.get().versionConstraint.toString() + "/javadoc/")
         opt.links("https://checkerframework.org/api/")
         opt.links("https://javadoc.io/doc/com.intellectualsites.informative-annotations/informative-annotations/latest/")
+        opt.encoding("UTF-8")
     }
 }


### PR DESCRIPTION
Title says all, we now no longer fail at compile time, specifically at javadoc generation step, if the charmap uses non ascii stuff, which we do quite a bunch in the codebase.