### PR TITLE
Allow pistons to break blocks at borders

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -69,6 +69,7 @@ import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
+import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Fireball;
@@ -828,6 +829,7 @@ public class BlockEventListener implements Listener {
             }
             for (Block block1 : event.getBlocks()) {
                 Location bloc = BukkitUtil.adapt(block1.getLocation());
+                if (block1.getPistonMoveReaction() == PistonMoveReaction.BREAK) return;
                 if (bloc.isPlotArea() || bloc
                         .add(relative.getBlockX(), relative.getBlockY(), relative.getBlockZ())
                         .isPlotArea()) {
@@ -850,6 +852,7 @@ public class BlockEventListener implements Listener {
         for (Block block1 : event.getBlocks()) {
             Location bloc = BukkitUtil.adapt(block1.getLocation());
             Location newLoc = bloc.add(relative.getBlockX(), relative.getBlockY(), relative.getBlockZ());
+            if (block1.getPistonMoveReaction() == PistonMoveReaction.BREAK) return;
             if (!area.contains(bloc.getX(), bloc.getZ()) || !area.contains(newLoc)) {
                 event.setCancelled(true);
                 return;


### PR DESCRIPTION


## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->



## Description
<!-- Please describe what this pull request does. -->
Pistons are now able to break blocks when pushing against a plot border or plot area border

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
