### PR TITLE
perf: avoid quadratic overhead for UUID collection

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -656,20 +656,15 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
             final @NonNull SQLiteUUIDService sqLiteUUIDService,
             final @NonNull CacheUUIDService cacheUUIDService
     ) {
-        // Load all uuids into a big chunky boi queue
-        final Queue<UUID> uuidQueue = new LinkedBlockingQueue<>();
+        // Record all unique UUID's and put them into a queue
+        final Set<UUID> uuidSet = new HashSet<>();
         PlotSquared.get().forEachPlotRaw(plot -> {
-            final Set<UUID> uuids = new HashSet<>();
-            uuids.add(plot.getOwnerAbs());
-            uuids.addAll(plot.getMembers());
-            uuids.addAll(plot.getTrusted());
-            uuids.addAll(plot.getDenied());
-            for (final UUID uuid : uuids) {
-                if (!uuidQueue.contains(uuid)) {
-                    uuidQueue.add(uuid);
-                }
-            }
+            uuidSet.add(plot.getOwnerAbs());
+            uuidSet.addAll(plot.getMembers());
+            uuidSet.addAll(plot.getTrusted());
+            uuidSet.addAll(plot.getDenied());
         });
+        final Queue<UUID> uuidQueue = new LinkedBlockingQueue<>(uuidSet);
 
         LOGGER.info("(UUID) {} UUIDs will be cached", uuidQueue.size());
 


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

The previous way to collect UUID's into the queue caused long startup times when having a lot of plots. By putting all UUID's in a set first, we can go from quadratic to linear complexity.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
