### PR TITLE
fix: replace usages of snow tag

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -121,11 +121,23 @@ public class BlockEventListener implements Listener {
             Material.TURTLE_EGG,
             Material.TURTLE_SPAWN_EGG
     );
-    private static final Set<Material> SNOW = Set.of( // needed as Tag.SNOW isn't present in 1.16.5
-        Material.SNOW,
-        Material.SNOW_BLOCK,
-        Material.POWDER_SNOW
-    );
+    private static final Set<Material> SNOW;  // needed as Tag.SNOW isn't present in 1.16.5
+
+    static {
+        if (PlotSquared.platform().serverVersion()[1] < 17) {
+            SNOW = Set.of(
+                    Material.SNOW,
+                    Material.SNOW_BLOCK
+            );
+        } else {
+            SNOW = Set.of(
+                    Material.SNOW,
+                    Material.SNOW_BLOCK,
+                    Material.POWDER_SNOW // only since 1.17
+            );
+        }
+    }
+
     private final PlotAreaManager plotAreaManager;
     private final WorldEdit worldEdit;
 

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -121,6 +121,11 @@ public class BlockEventListener implements Listener {
             Material.TURTLE_EGG,
             Material.TURTLE_SPAWN_EGG
     );
+    private static final Set<Material> SNOW = Set.of( // needed as Tag.SNOW isn't present in 1.16.5
+        Material.SNOW,
+        Material.SNOW_BLOCK,
+        Material.POWDER_SNOW
+    );
     private final PlotAreaManager plotAreaManager;
     private final WorldEdit worldEdit;
 
@@ -529,7 +534,7 @@ public class BlockEventListener implements Listener {
             event.setCancelled(true);
             return;
         }
-        if (Tag.SNOW.isTagged(event.getNewState().getType())) {
+        if (SNOW.contains(event.getNewState().getType())) {
             if (!plot.getFlag(SnowFormFlag.class)) {
                 plot.debug("Snow could not form because snow-form = false");
                 event.setCancelled(true);
@@ -561,7 +566,7 @@ public class BlockEventListener implements Listener {
             return;
         }
         Class<? extends BooleanFlag<?>> flag;
-        if (Tag.SNOW.isTagged(event.getNewState().getType())) {
+        if (SNOW.contains(event.getNewState().getType())) {
             flag = SnowFormFlag.class;
         } else if (Tag.ICE.isTagged(event.getNewState().getType())) {
             flag = IceFormFlag.class;
@@ -678,7 +683,7 @@ public class BlockEventListener implements Listener {
             }
             return;
         }
-        if (Tag.SNOW.isTagged(blockType)) {
+        if (SNOW.contains(blockType)) {
             if (!plot.getFlag(SnowMeltFlag.class)) {
                 plot.debug("Snow could not melt because snow-melt = false");
                 event.setCancelled(true);


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #3757

## Description
<!-- Please describe what this pull request does. -->

The `snow` tag was only added with Minecraft 1.17, therefore we can't use it directly.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
