### PR TITLE
fix: use correct uuid type in `/grant` 

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Grant.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Grant.java
@@ -32,7 +32,6 @@ import com.plotsquared.core.util.TabCompletions;
 import com.plotsquared.core.util.task.RunnableVal;
 import com.plotsquared.core.util.task.RunnableVal2;
 import com.plotsquared.core.util.task.RunnableVal3;
-import com.plotsquared.core.uuid.UUIDMapping;
 import net.kyori.adventure.text.minimessage.Template;
 
 import java.util.Collection;
@@ -40,6 +39,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
@@ -88,8 +88,8 @@ public class Grant extends Command {
                                 Template.of("value", String.valueOf(uuids))
                         );
                     } else {
-                        final UUIDMapping uuid = uuids.toArray(new UUIDMapping[0])[0];
-                        PlotPlayer<?> pp = PlotSquared.platform().playerManager().getPlayerIfExists(uuid.getUuid());
+                        final UUID uuid = uuids.iterator().next();
+                        PlotPlayer<?> pp = PlotSquared.platform().playerManager().getPlayerIfExists(uuid);
                         if (pp != null) {
                             try (final MetaDataAccess<Integer> access = pp.accessPersistentMetaData(
                                     PlayerMetaDataKeys.PERSISTENT_GRANTED_PLOTS)) {
@@ -103,7 +103,7 @@ public class Grant extends Command {
                                 }
                             }
                         } else {
-                            DBFunc.getPersistentMeta(uuid.getUuid(), new RunnableVal<>() {
+                            DBFunc.getPersistentMeta(uuid, new RunnableVal<>() {
                                 @Override
                                 public void run(Map<String, byte[]> value) {
                                     final byte[] array = value.get("grantedPlots");
@@ -128,7 +128,7 @@ public class Grant extends Command {
                                         boolean replace = array != null;
                                         String key = "grantedPlots";
                                         byte[] rawData = Ints.toByteArray(amount);
-                                        DBFunc.addPersistentMeta(uuid.getUuid(), key, rawData, replace);
+                                        DBFunc.addPersistentMeta(uuid, key, rawData, replace);
                                         player.sendMessage(
                                                 TranslatableCaption.of("grants.added"),
                                                 Template.of("grants", String.valueOf(amount))


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #3756

## Description
<!-- Please describe what this pull request does. -->

The `toArray` call tried to cast the values to the wrong type, causing an exception that was just ignored by `CompletableFuture` fun.
Just using the iterator instead, we can access the first element without doing type unsafe things.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
