### PR TITLE
Items no longer despawn on road when natural_mob_spawning = true and kill-road-items = false

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
@@ -140,6 +140,12 @@ public class EntitySpawnListener implements Listener {
                     event.setCancelled(true);
                 }
             }
+            if (type == EntityType.DROPPED_ITEM) {
+                if (Settings.Enabled_Components.KILL_ROAD_ITEMS) {
+                    event.setCancelled(true);
+                }
+                return;
+            }
             if (!area.isMiscSpawnUnowned() && !type.isAlive()) {
                 event.setCancelled(true);
             }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
@@ -126,25 +126,19 @@ public class EntitySpawnListener implements Listener {
         Plot plot = location.getOwnedPlotAbs();
         EntityType type = entity.getType();
         if (plot == null) {
-            if (!area.isMobSpawning()) {
-                if (type == EntityType.PLAYER) {
-                    return;
-                }
-                if (type == EntityType.DROPPED_ITEM) {
-                    if (Settings.Enabled_Components.KILL_ROAD_ITEMS) {
-                        event.setCancelled(true);
-                    }
-                    return;
-                }
-                if (type.isAlive()) {
-                    event.setCancelled(true);
-                }
-            }
             if (type == EntityType.DROPPED_ITEM) {
                 if (Settings.Enabled_Components.KILL_ROAD_ITEMS) {
                     event.setCancelled(true);
                 }
                 return;
+            }
+            if (!area.isMobSpawning()) {
+                if (type == EntityType.PLAYER) {
+                    return;
+                }
+                if (type.isAlive()) {
+                    event.setCancelled(true);
+                }
             }
             if (!area.isMiscSpawnUnowned() && !type.isAlive()) {
                 event.setCancelled(true);

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
@@ -229,15 +229,15 @@ public class PaperListener implements Listener {
         Plot plot = location.getOwnedPlotAbs();
         if (plot == null) {
             EntityType type = event.getType();
+            // PreCreatureSpawnEvent **should** not be called for DROPPED_ITEM, just for the sake of consistency
+            if (type == EntityType.DROPPED_ITEM) {
+                if (Settings.Enabled_Components.KILL_ROAD_ITEMS) {
+                    event.setCancelled(true);
+                }
+                return;
+            }
             if (!area.isMobSpawning()) {
                 if (type == EntityType.PLAYER) {
-                    return;
-                }
-                if (type == EntityType.DROPPED_ITEM) {
-                    if (Settings.Enabled_Components.KILL_ROAD_ITEMS) {
-                        event.setShouldAbortSpawn(true);
-                        event.setCancelled(true);
-                    }
                     return;
                 }
                 if (type.isAlive()) {


### PR DESCRIPTION
## Overview
Fixes #3725 

## Description
EntitySpawnEvent is now cancelled correctly

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
