### PR TITLE
Add Events for Plot Move + Plot Swap

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Move.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Move.java
@@ -92,22 +92,27 @@ public class Move extends SubCommand {
         }
         final PlotMoveEvent moveEvent = this.eventDispatcher.callMove(player, plot1, tmpTargetPlot);
         final Plot targetPlot = moveEvent.destination();
+        if (!override) {
+            override = moveEvent.getEventResult() == Result.FORCE;
+        }
+
+        if (moveEvent.getEventResult() == Result.DENY) {
+            if (moveEvent.sendErrorMessage()) {
+                player.sendMessage(TranslatableCaption.of("move.event_cancelled"));
+            }
+            return CompletableFuture.completedFuture(false);
+        }
 
         if (plot1.equals(targetPlot)) {
             player.sendMessage(TranslatableCaption.of("invalid.origin_cant_be_target"));
             return CompletableFuture.completedFuture(false);
         }
-        if (!plot1.getArea().isCompatible(targetPlot.getArea()) && (!override || moveEvent.getEventResult() != Result.FORCE)) {
+        if (!plot1.getArea().isCompatible(targetPlot.getArea()) && !override) {
             player.sendMessage(TranslatableCaption.of("errors.plotworld_incompatible"));
             return CompletableFuture.completedFuture(false);
         }
         if (plot1.isMerged() || targetPlot.isMerged()) {
             player.sendMessage(TranslatableCaption.of("move.move_merged"));
-            return CompletableFuture.completedFuture(false);
-        }
-
-        if (moveEvent.getEventResult() == Result.DENY) {
-            player.sendMessage(TranslatableCaption.of("move.event_cancelled"));
             return CompletableFuture.completedFuture(false);
         }
 

--- a/Core/src/main/java/com/plotsquared/core/events/PlotMoveEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlotMoveEvent.java
@@ -35,24 +35,18 @@ import java.util.Objects;
  * <li>{@link #destination()} is the plot, where the plot will be moved to.</li>
  * </ul>
  *
+ * @see com.plotsquared.core.command.Move
  * @since TODO
  */
 public class PlotMoveEvent extends PlotPlayerEvent implements CancellablePlotEvent {
 
     private Plot destination;
+    private boolean sendErrorMessage = true;
     private Result result = Result.ACCEPT;
 
     public PlotMoveEvent(final PlotPlayer<?> initiator, final Plot plot, final Plot destination) {
         super(initiator, plot);
         this.destination = destination;
-    }
-
-    /**
-     * @return The destination for the plot to be moved to.
-     * @since TODO
-     */
-    public Plot destination() {
-        return destination;
     }
 
     /**
@@ -73,16 +67,50 @@ public class PlotMoveEvent extends PlotPlayerEvent implements CancellablePlotEve
      *
      * @param x The X coordinate of the {@link PlotId}
      * @param y The Y coordinate of the {@link PlotId}
+     * @since TODO
      */
     public void setDestination(final int x, final int y) {
         this.destination = Objects.requireNonNull(this.destination.getArea()).getPlot(PlotId.of(x, y));
     }
 
+    /**
+     * Set whether to send a generic message to the user ({@code Move was cancelled by an external plugin}). If set to {@code
+     * false}, make sure to send a message to the player yourself to avoid confusion.
+     *
+     * @param sendErrorMessage {@code true} if PlotSquared should send a generic error message to the player.
+     * @since TODO
+     */
+    public void setSendErrorMessage(final boolean sendErrorMessage) {
+        this.sendErrorMessage = sendErrorMessage;
+    }
+
+    /**
+     * @return The destination for the plot to be moved to.
+     * @since TODO
+     */
+    public Plot destination() {
+        return destination;
+    }
+
+    /**
+     * @return {@code true} if PlotSquared should send a generic error message to the player.
+     * @since TODO
+     */
+    public boolean sendErrorMessage() {
+        return sendErrorMessage;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Result getEventResult() {
         return result;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setEventResult(Result eventResult) {
         this.result = Objects.requireNonNull(eventResult);

--- a/Core/src/main/java/com/plotsquared/core/events/PlotMoveEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlotMoveEvent.java
@@ -20,13 +20,14 @@ package com.plotsquared.core.events;
 
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
+import com.plotsquared.core.plot.PlotId;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Objects;
 
 /**
  * Called when a {@link PlotPlayer} attempts to move a {@link Plot} to another {@link Plot}.
- * The Event-Result {@link Result#FORCE} does have no effect on the outcome. Only supported results are {@link Result#DENY} and
- * {@link Result#ACCEPT}.
+ *
  * <br>
  * <ul>
  * <li>{@link #getPlotPlayer()} is the initiator of the move action (most likely the command executor)</li>
@@ -38,7 +39,7 @@ import java.util.Objects;
  */
 public class PlotMoveEvent extends PlotPlayerEvent implements CancellablePlotEvent {
 
-    private final Plot destination;
+    private Plot destination;
     private Result result = Result.ACCEPT;
 
     public PlotMoveEvent(final PlotPlayer<?> initiator, final Plot plot, final Plot destination) {
@@ -54,6 +55,28 @@ public class PlotMoveEvent extends PlotPlayerEvent implements CancellablePlotEve
         return destination;
     }
 
+    /**
+     * Set the new {@link Plot} to where the plot should be moved to.
+     *
+     * @param destination The plot representing the new location.
+     * @since TODO
+     */
+    public void setDestination(@NonNull final Plot destination) {
+        this.destination = Objects.requireNonNull(destination);
+    }
+
+    /**
+     * Set the new destination based off their X and Y coordinates. Calls {@link #setDestination(Plot)} while using the
+     * {@link com.plotsquared.core.plot.PlotArea} provided by the current {@link #destination()}.
+     * <p>
+     * <b>Note:</b> the coordinates are not minecraft world coordinates, but the underlying {@link PlotId}s coordinates.
+     *
+     * @param x The X coordinate of the {@link PlotId}
+     * @param y The Y coordinate of the {@link PlotId}
+     */
+    public void setDestination(final int x, final int y) {
+        this.destination = Objects.requireNonNull(this.destination.getArea()).getPlot(PlotId.of(x, y));
+    }
 
     @Override
     public Result getEventResult() {

--- a/Core/src/main/java/com/plotsquared/core/events/PlotMoveEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlotMoveEvent.java
@@ -1,3 +1,21 @@
+/*
+ * PlotSquared, a land and world management plugin for Minecraft.
+ * Copyright (C) IntellectualSites <https://intellectualsites.com>
+ * Copyright (C) IntellectualSites team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.plotsquared.core.events;
 
 import com.plotsquared.core.player.PlotPlayer;
@@ -28,9 +46,14 @@ public class PlotMoveEvent extends PlotPlayerEvent implements CancellablePlotEve
         this.destination = destination;
     }
 
+    /**
+     * @return The destination for the plot to be moved to.
+     * @since TODO
+     */
     public Plot destination() {
         return destination;
     }
+
 
     @Override
     public Result getEventResult() {

--- a/Core/src/main/java/com/plotsquared/core/events/PlotMoveEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlotMoveEvent.java
@@ -1,0 +1,45 @@
+package com.plotsquared.core.events;
+
+import com.plotsquared.core.player.PlotPlayer;
+import com.plotsquared.core.plot.Plot;
+
+import java.util.Objects;
+
+/**
+ * Called when a {@link PlotPlayer} attempts to move a {@link Plot} to another {@link Plot}.
+ * The Event-Result {@link Result#FORCE} does have no effect on the outcome. Only supported results are {@link Result#DENY} and
+ * {@link Result#ACCEPT}.
+ * <br>
+ * <ul>
+ * <li>{@link #getPlotPlayer()} is the initiator of the move action (most likely the command executor)</li>
+ * <li>{@link #getPlot()} is the plot to be moved</li>
+ * <li>{@link #destination()} is the plot, where the plot will be moved to.</li>
+ * </ul>
+ *
+ * @since TODO
+ */
+public class PlotMoveEvent extends PlotPlayerEvent implements CancellablePlotEvent {
+
+    private final Plot destination;
+    private Result result = Result.ACCEPT;
+
+    public PlotMoveEvent(final PlotPlayer<?> initiator, final Plot plot, final Plot destination) {
+        super(initiator, plot);
+        this.destination = destination;
+    }
+
+    public Plot destination() {
+        return destination;
+    }
+
+    @Override
+    public Result getEventResult() {
+        return result;
+    }
+
+    @Override
+    public void setEventResult(Result eventResult) {
+        this.result = Objects.requireNonNull(eventResult);
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/events/PlotSwapEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlotSwapEvent.java
@@ -1,0 +1,107 @@
+package com.plotsquared.core.events;
+
+import com.plotsquared.core.player.PlotPlayer;
+import com.plotsquared.core.plot.Plot;
+import com.plotsquared.core.plot.PlotId;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Called when a player swaps {@link #getPlot() their Plot} with {@link #target() another Plot}.
+ *
+ * @see com.plotsquared.core.command.Swap
+ * @since TODO
+ */
+public class PlotSwapEvent extends PlotPlayerEvent implements CancellablePlotEvent {
+
+    private Plot target;
+    private boolean sendErrorMessage = true;
+    private Result result = Result.ACCEPT;
+
+    public PlotSwapEvent(final PlotPlayer<?> plotPlayer, final Plot plot, final Plot target) {
+        super(plotPlayer, plot);
+        this.target = target;
+    }
+
+    /**
+     * Set the plot which should be swapped with {@link #getPlot()}.
+     *
+     * @param target The target swapping plot.
+     * @since TODO
+     */
+    public void setTarget(@NonNull final Plot target) {
+        this.target = Objects.requireNonNull(target);
+    }
+
+    /**
+     * Set the new destination based off their X and Y coordinates. Calls {@link #setTarget(Plot)} while using the
+     * {@link com.plotsquared.core.plot.PlotArea} provided by the current {@link #target()}.
+     * <p>
+     * <b>Note:</b> the coordinates are not minecraft world coordinates, but the underlying {@link PlotId}s coordinates.
+     *
+     * @param x The X coordinate of the {@link PlotId}
+     * @param y The Y coordinate of the {@link PlotId}
+     * @since TODO
+     */
+    public void setTarget(final int x, final int y) {
+        this.target = Objects.requireNonNull(this.target.getArea()).getPlot(PlotId.of(x, y));
+    }
+
+    /**
+     * Set whether to send a generic message to the user ({@code Swap was cancelled by an external plugin}). If set to {@code
+     * false}, make sure to send a message to the player yourself to avoid confusion.
+     *
+     * @param sendErrorMessage {@code true} if PlotSquared should send a generic error message to the player.
+     * @since TODO
+     */
+    public void setSendErrorMessage(final boolean sendErrorMessage) {
+        this.sendErrorMessage = sendErrorMessage;
+    }
+
+    /**
+     * The target plot to swap with.
+     *
+     * @return The plot.
+     * @since TODO
+     */
+    public Plot target() {
+        return target;
+    }
+
+    /**
+     * @return {@code true} if PlotSquared should send a generic error message to the player.
+     * @since TODO
+     */
+    public boolean sendErrorMessage() {
+        return sendErrorMessage;
+    }
+
+    /**
+     * The plot issuing the swap with {@link #target()}.
+     *
+     * @return The plot.
+     */
+    @Override
+    public Plot getPlot() {
+        return super.getPlot(); // delegate for overriding the documentation
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @Nullable Result getEventResult() {
+        return this.result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setEventResult(@Nullable final Result eventResult) {
+        this.result = eventResult;
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/events/PlotSwapEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlotSwapEvent.java
@@ -1,3 +1,21 @@
+/*
+ * PlotSquared, a land and world management plugin for Minecraft.
+ * Copyright (C) IntellectualSites <https://intellectualsites.com>
+ * Copyright (C) IntellectualSites team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.plotsquared.core.events;
 
 import com.plotsquared.core.player.PlotPlayer;

--- a/Core/src/main/java/com/plotsquared/core/events/post/PostPlotMoveEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/post/PostPlotMoveEvent.java
@@ -18,7 +18,7 @@
  */
 package com.plotsquared.core.events.post;
 
-import com.plotsquared.core.events.PlotEvent;
+import com.plotsquared.core.events.PlotPlayerEvent;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotId;
@@ -29,23 +29,13 @@ import com.plotsquared.core.plot.PlotId;
  * @see com.plotsquared.core.events.PlotMoveEvent
  * @since TODO
  */
-public class PostPlotMoveEvent extends PlotEvent {
+public class PostPlotMoveEvent extends PlotPlayerEvent {
 
-    private final PlotPlayer<?> initiator;
     private final PlotId oldPlot;
 
     public PostPlotMoveEvent(final PlotPlayer<?> initiator, final PlotId oldPlot, final Plot plot) {
-        super(plot);
-        this.initiator = initiator;
+        super(initiator, plot);
         this.oldPlot = oldPlot;
-    }
-
-    /**
-     * @return The player who initiated the plot move.
-     * @since TODO
-     */
-    public PlotPlayer<?> initiator() {
-        return initiator;
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/events/post/PostPlotMoveEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/post/PostPlotMoveEvent.java
@@ -1,0 +1,33 @@
+package com.plotsquared.core.events.post;
+
+import com.plotsquared.core.events.PlotEvent;
+import com.plotsquared.core.player.PlotPlayer;
+import com.plotsquared.core.plot.Plot;
+import com.plotsquared.core.plot.PlotId;
+
+/**
+ * Called after a plot move was performed and succeeded.
+ *
+ * @see com.plotsquared.core.events.PlotMoveEvent
+ * @since TODO
+ */
+public class PostPlotMoveEvent extends PlotEvent {
+
+    private final PlotPlayer<?> initiator;
+    private final PlotId oldPlot;
+
+    public PostPlotMoveEvent(final PlotPlayer<?> initiator, final PlotId oldPlot, final Plot plot) {
+        super(plot);
+        this.initiator = initiator;
+        this.oldPlot = oldPlot;
+    }
+
+    public PlotPlayer<?> initiator() {
+        return initiator;
+    }
+
+    public PlotId oldPlot() {
+        return oldPlot;
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/events/post/PostPlotMoveEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/post/PostPlotMoveEvent.java
@@ -1,3 +1,21 @@
+/*
+ * PlotSquared, a land and world management plugin for Minecraft.
+ * Copyright (C) IntellectualSites <https://intellectualsites.com>
+ * Copyright (C) IntellectualSites team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.plotsquared.core.events.post;
 
 import com.plotsquared.core.events.PlotEvent;
@@ -22,10 +40,18 @@ public class PostPlotMoveEvent extends PlotEvent {
         this.oldPlot = oldPlot;
     }
 
+    /**
+     * @return The player who initiated the plot move.
+     * @since TODO
+     */
     public PlotPlayer<?> initiator() {
         return initiator;
     }
 
+    /**
+     * @return The id of the old plot location.
+     * @since TODO
+     */
     public PlotId oldPlot() {
         return oldPlot;
     }

--- a/Core/src/main/java/com/plotsquared/core/events/post/PostPlotSwapEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/post/PostPlotSwapEvent.java
@@ -1,0 +1,65 @@
+/*
+ * PlotSquared, a land and world management plugin for Minecraft.
+ * Copyright (C) IntellectualSites <https://intellectualsites.com>
+ * Copyright (C) IntellectualSites team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.events.post;
+
+import com.plotsquared.core.events.PlotPlayerEvent;
+import com.plotsquared.core.player.PlotPlayer;
+import com.plotsquared.core.plot.Plot;
+
+/**
+ * Called after a plot swap was performed and succeeded.
+ * <p>
+ * <b>Note:</b> {@link Plot#getId()} of the {@link #target() target Plot} will be the {@link com.plotsquared.core.plot.PlotId}
+ * of the {@link #getPlot() issuing plot} at this event stage (as the swap already happened). If you need the PlotId of the
+ * origin plot (where the player was standing on when issuing the command, e.g.) before the swap, use the {@link #target()}
+ * Plot, as the IDs in the plot objects were mutated. (The target plot is now the present origin plot)
+ *
+ * @see com.plotsquared.core.events.PlotSwapEvent
+ * @since TODO
+ */
+public class PostPlotSwapEvent extends PlotPlayerEvent {
+
+    private final Plot target;
+
+    public PostPlotSwapEvent(final PlotPlayer<?> initiator, final Plot plot, final Plot target) {
+        super(initiator, plot);
+        this.target = target;
+    }
+
+    /**
+     * The plot that initiated the plot swap.
+     *
+     * @return The plot.
+     */
+    @Override
+    public Plot getPlot() {
+        return super.getPlot(); // delegate for overriding the documentation
+    }
+
+    /**
+     * The plot that was swapped with {@link #getPlot()}. (The command argument)
+     *
+     * @return The plot.
+     * @since TODO
+     */
+    public Plot target() {
+        return target;
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
+++ b/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
@@ -45,6 +45,7 @@ import com.plotsquared.core.events.PlotEvent;
 import com.plotsquared.core.events.PlotFlagAddEvent;
 import com.plotsquared.core.events.PlotFlagRemoveEvent;
 import com.plotsquared.core.events.PlotMergeEvent;
+import com.plotsquared.core.events.PlotMoveEvent;
 import com.plotsquared.core.events.PlotRateEvent;
 import com.plotsquared.core.events.PlotUnlinkEvent;
 import com.plotsquared.core.events.RemoveRoadEntityEvent;
@@ -55,6 +56,7 @@ import com.plotsquared.core.events.post.PostPlotChangeOwnerEvent;
 import com.plotsquared.core.events.post.PostPlotClearEvent;
 import com.plotsquared.core.events.post.PostPlotDeleteEvent;
 import com.plotsquared.core.events.post.PostPlotMergeEvent;
+import com.plotsquared.core.events.post.PostPlotMoveEvent;
 import com.plotsquared.core.events.post.PostPlotUnlinkEvent;
 import com.plotsquared.core.listener.PlayerBlockEventType;
 import com.plotsquared.core.location.Direction;
@@ -334,6 +336,16 @@ public class EventDispatcher {
     public void callPostPlayerBuyPlot(PlotPlayer<?> player, OfflinePlotPlayer previousOwner, Plot plot,
                                       double price) {
         eventBus.post(new PostPlayerBuyPlotEvent(player, previousOwner, plot, price));
+    }
+
+    public PlotMoveEvent callMove(PlotPlayer<?> initiator, Plot from, Plot destination) {
+        PlotMoveEvent event = new PlotMoveEvent(initiator, from, destination);
+        callEvent(event);
+        return event;
+    }
+
+    public void callPostMove(PlotPlayer<?> initiator, PlotId old, Plot destination) {
+        callEvent(new PostPlotMoveEvent(initiator, old, destination));
     }
 
     public void doJoinTask(final PlotPlayer<?> player) {

--- a/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
+++ b/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
@@ -47,6 +47,7 @@ import com.plotsquared.core.events.PlotFlagRemoveEvent;
 import com.plotsquared.core.events.PlotMergeEvent;
 import com.plotsquared.core.events.PlotMoveEvent;
 import com.plotsquared.core.events.PlotRateEvent;
+import com.plotsquared.core.events.PlotSwapEvent;
 import com.plotsquared.core.events.PlotUnlinkEvent;
 import com.plotsquared.core.events.RemoveRoadEntityEvent;
 import com.plotsquared.core.events.TeleportCause;
@@ -57,6 +58,7 @@ import com.plotsquared.core.events.post.PostPlotClearEvent;
 import com.plotsquared.core.events.post.PostPlotDeleteEvent;
 import com.plotsquared.core.events.post.PostPlotMergeEvent;
 import com.plotsquared.core.events.post.PostPlotMoveEvent;
+import com.plotsquared.core.events.post.PostPlotSwapEvent;
 import com.plotsquared.core.events.post.PostPlotUnlinkEvent;
 import com.plotsquared.core.listener.PlayerBlockEventType;
 import com.plotsquared.core.location.Direction;
@@ -346,6 +348,16 @@ public class EventDispatcher {
 
     public void callPostMove(PlotPlayer<?> initiator, PlotId old, Plot destination) {
         callEvent(new PostPlotMoveEvent(initiator, old, destination));
+    }
+
+    public PlotSwapEvent callSwap(PlotPlayer<?> initiator, Plot plot, Plot target) {
+        PlotSwapEvent event = new PlotSwapEvent(initiator, plot, target);
+        callEvent(event);
+        return event;
+    }
+
+    public void callPostSwap(PlotPlayer<?> initiator, Plot plot, Plot target) {
+        callEvent(new PostPlotSwapEvent(initiator, plot, target));
     }
 
     public void doJoinTask(final PlotPlayer<?> player) {

--- a/Core/src/main/resources/lang/messages_en.json
+++ b/Core/src/main/resources/lang/messages_en.json
@@ -66,6 +66,7 @@
   "swap.swap_overlap": "<prefix><red>The proposed areas are not allowed to overlap.</red>",
   "swap.swap_success": "<prefix><dark_aqua>Successfully swapped plots</dark_aqua> <gold><origin></gold><dark_aqua> -> </dark_aqua><gold><target></gold>",
   "swap.swap_merged": "<prefix><red>Merged plots may not be swapped. Please unmerge the plots before performing the swap.</red>",
+  "swap.event_cancelled": "<prefix><gray>Swap was cancelled by an external plugin</gray>",
   "swap.progress_region1_copy": "<prefix><gray>Current region 1 copy progress: </gray><gold><progress></gold><gray>%</gray>",
   "swap.progress_region2_copy": "<prefix><gray>Current region 2 copy progress: </gray><gold><progress></gold><gray>%</gray>",
   "swap.progress_region1_paste": "<prefix><gray>Current region 1 paste progress: </gray><gold><progress></gold><gray>%</gray>",

--- a/Core/src/main/resources/lang/messages_en.json
+++ b/Core/src/main/resources/lang/messages_en.json
@@ -6,6 +6,7 @@
   "move.move_merged": "<prefix><red>Merged plots may not be moved. Please unmerge the plot before performing the move.</red>",
   "move.copy_success": "<prefix><dark_aqua>Successfully copied plots</dark_aqua> <gold><origin></gold><dark_aqua> -> </dark_aqua><gold><target></gold>",
   "move.requires_unowned": "<prefix><red>The location specified is already occupied.</red>",
+  "move.event_cancelled": "<prefix><gray>Move was cancelled by an external plugin</gray>",
   "debug.requires_unmerged": "<prefix><red>The plot cannot be merged.</red>",
   "debug.debug_header": "<prefix> <gold>Debug Information</gold>\n",
   "debug.debug_section": "<gray>>></gray> <gold><bold><val></bold></gold>",


### PR DESCRIPTION
## Overview
Fixes #3692 

## Description
Adds a cancellable PlotMoveEvent and informational PostPlotMoveEvent. (+ Swap)
~~Found no fitting case for handling the FORCE result, therefor marked that as not supported (just supporting DENY and ACCEPT).~~

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
