### PR TITLE
Fix "set block timer" error after "/plot download" with legacy-webinterface setting

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Download.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Download.java
@@ -181,6 +181,7 @@ public class Download extends SubCommand {
                         schematicHandler.upload(compoundTag, null, null, new RunnableVal<>() {
                             @Override
                             public void run(URL value) {
+                                plot.removeRunning();
                                 player.sendMessage(
                                         TranslatableCaption.of("web.generation_link_success"),
                                         Template.of("download", value.toString()),


### PR DESCRIPTION
## Overview

Fixes "a set block timer is bound to either the current plot or you [...]" message which occurs when trying to run any /plot command after downloading a plot with `/plot download` when `web.legacy-webinterface` is `true` in `settings.yml`.

## Description
Add a missing call to `plot.removeRunning()` in `Download.java`s `upload` method. Only the code path when `Settings.Web.LEGACY_WEBINTERFACE` is true was missing the running task reset call.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [ ] ~New public fields and methods are annotated with `@since TODO`.~
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
