### PR TITLE
Deprecate PlotId#copy

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/DatabaseCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DatabaseCommand.java
@@ -176,7 +176,7 @@ public class DatabaseCommand extends SubCommand {
                                                         );
                                                 worldFile.renameTo(newFile);
                                             }
-                                            plot.setId(newId.copy());
+                                            plot.setId(newId);
                                             plot.setArea(pa);
                                             plots.add(plot);
                                             continue;

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -1836,8 +1836,8 @@ public class Plot {
         }
         // Swap cached
         final PlotId temp = PlotId.of(this.getId().getX(), this.getId().getY());
-        this.id = plot.getId().copy();
-        plot.id = temp.copy();
+        this.id = plot.getId();
+        plot.id = temp;
         this.area.removePlot(this.getId());
         plot.area.removePlot(plot.getId());
         this.area.addPlotAbs(this);
@@ -1863,7 +1863,7 @@ public class Plot {
             return false;
         }
         this.area.removePlot(this.id);
-        this.id = plot.getId().copy();
+        this.id = plot.getId();
         this.area.addPlotAbs(this);
         DBFunc.movePlot(this, plot);
         TaskManager.runTaskLater(whenDone, TaskTime.ticks(1L));

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotId.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotId.java
@@ -110,9 +110,11 @@ public final class PlotId {
      * Get a copy of the plot ID
      *
      * @return Plot ID copy
+     * @deprecated PlotId is immutable, copy is not required.
      */
+    @Deprecated(forRemoval = true, since = "TODO")
     public @NonNull PlotId copy() {
-        return of(this.getX(), this.getY());
+        return this;
     }
 
     /**


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

PlotId is immutable for a long time already, the copy-method therefore isn't needed anymore and should be removed in future.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
