### PR TITLE
Update the plot sign when a plot has been purchased

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Buy.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Buy.java
@@ -126,6 +126,7 @@ public class Buy extends Command {
                 plot.removeFlag(event.getFlag());
             }
             plot.setOwner(player.getUUID());
+            plot.getPlotModificationManager().setSign(player.getName());
             player.sendMessage(
                     TranslatableCaption.of("working.claimed"),
                     Template.of("plot", plot.getId().toString())


### PR DESCRIPTION
## Overview
Updates the plot sign when a plot has been purchased

Fixes #3790

## Description
Only a tiny change but I added a call to set the sign to contain the new name of the plot owner upon purchase.
Not only I require this for my server but it's an overall annoyance that has been rectified.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
