### PR TITLE
Don't kill owned road entities (leashed / named)

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -853,7 +853,7 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
                                 LivingEntity livingEntity = (LivingEntity) entity;
                                 List<MetadataValue> meta = entity.getMetadata("shulkerPlot");
                                 if (!meta.isEmpty()) {
-                                    if (livingEntity.isLeashed()) {
+                                    if (livingEntity.isLeashed() && !Settings.Enabled_Components.KILL_OWNED_ROAD_MOBS) {
                                         continue;
                                     }
                                     List<MetadataValue> keep = entity.getMetadata("keep");

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -849,7 +849,7 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
                             // managed elsewhere
                             continue;
                         case "SHULKER":
-                            if (Settings.Enabled_Components.KILL_ROAD_MOBS) {
+                            if (Settings.Enabled_Components.KILL_ROAD_MOBS && (Settings.Enabled_Components.KILL_NAMED_ROAD_MOBS || entity.getCustomName() == null)) {
                                 LivingEntity livingEntity = (LivingEntity) entity;
                                 List<MetadataValue> meta = entity.getMetadata("shulkerPlot");
                                 if (!meta.isEmpty()) {
@@ -973,7 +973,9 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
                                                 || !entity.hasMetadata("keep")) {
                                             Entity passenger = entity.getPassenger();
                                             if ((Settings.Enabled_Components.KILL_OWNED_ROAD_MOBS
-                                                    || !((passenger instanceof Player) || livingEntity.isLeashed())) && entity.getMetadata("keep").isEmpty()) {
+                                                    || !((passenger instanceof Player) || livingEntity.isLeashed()))
+                                                    && (Settings.Enabled_Components.KILL_NAMED_ROAD_MOBS || entity.getCustomName() == null)
+                                                    && entity.getMetadata("keep").isEmpty()) {
                                                 if (entity.hasMetadata("ps-tmp-teleport")) {
                                                     continue;
                                                 }
@@ -983,8 +985,9 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
                                         }
                                     } else {
                                         Entity passenger = entity.getPassenger();
-                                        if ((Settings.Enabled_Components.KILL_OWNED_ROAD_MOBS
-                                                || !(passenger instanceof Player)) && entity.getMetadata("keep").isEmpty()) {
+                                        if ((Settings.Enabled_Components.KILL_OWNED_ROAD_MOBS || !(passenger instanceof Player))
+                                                && (Settings.Enabled_Components.KILL_NAMED_ROAD_MOBS && entity.getCustomName() != null)
+                                                && entity.getMetadata("keep").isEmpty()) {
                                             if (entity.hasMetadata("ps-tmp-teleport")) {
                                                 continue;
                                             }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -973,7 +973,7 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
                                                 || !entity.hasMetadata("keep")) {
                                             Entity passenger = entity.getPassenger();
                                             if ((Settings.Enabled_Components.KILL_OWNED_ROAD_MOBS
-                                                    || !(passenger instanceof Player)) && entity.getMetadata("keep").isEmpty()) {
+                                                    || !((passenger instanceof Player) || livingEntity.isLeashed())) && entity.getMetadata("keep").isEmpty()) {
                                                 if (entity.hasMetadata("ps-tmp-teleport")) {
                                                     continue;
                                                 }

--- a/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
@@ -759,6 +759,8 @@ public class Settings extends Config {
         @Comment("Also kill any road mobs that are being ridden, or are leashed")
         public static boolean
                 KILL_OWNED_ROAD_MOBS = false;
+        @Comment("Also kill any road mobs that are being named")
+        public static boolean KILL_NAMED_ROAD_MOBS = false;
         @Comment("Kill items on roads (Stick, Paper, etc.)")
         public static boolean KILL_ROAD_ITEMS = false;
         @Comment("Kill vehicles on roads (Boat, Minecart, etc.)")

--- a/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
@@ -759,7 +759,7 @@ public class Settings extends Config {
         @Comment("Also kill any road mobs that are being ridden, or are leashed")
         public static boolean
                 KILL_OWNED_ROAD_MOBS = false;
-        @Comment("Also kill any road mobs that are being named")
+        @Comment("Also kill any road mobs that are named")
         public static boolean KILL_NAMED_ROAD_MOBS = false;
         @Comment("Kill items on roads (Stick, Paper, etc.)")
         public static boolean KILL_ROAD_ITEMS = false;


### PR DESCRIPTION
## Overview

Fixes #3824

## Description
Fixes a bug, where leashed entities got killed on the road, with "KILL_ROAD_MOBS" set to true and "KILL_OWNED_ROAD_MOBS" set to false. This PR restores the behaviour described in the settings comment at the value "KILL_OWNED_ROAD_MOBS".

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [ ] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [ ] Ensure that the pull request title represents the desired changelog entry.
- [ ] New public fields and methods are annotated with `@since TODO`.
- [ ] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
