### PR TITLE
Check proper locations on PortalCreateEvent

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -1756,11 +1756,11 @@ public class PlayerEventListener implements Listener {
             maxZ = Math.max(state.getZ(), maxZ);
         }
         int y = event.getBlocks().get(0).getY(); // Don't need to worry about this too much
-        for (Location location : Set.of( // Use Set to lazily avoid duplicate locations
-                Location.at(world, minX, y, maxX),
-                Location.at(world, minZ, y, maxZ),
+        for (Location location : List.of( // We don't care about duplicate locations
+                Location.at(world, minX, y, minZ),
                 Location.at(world, minX, y, maxZ),
-                Location.at(world, minZ, y, maxX)
+                Location.at(world, maxX, y, minZ),
+                Location.at(world, maxX, y, maxZ)
         )) {
             PlotArea area = location.getPlotArea();
             if (area == null) {


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #3833

## Description
<!-- Please describe what this pull request does. -->

I replaced Set.of with List.of, as creating the set is more expensive anyways and not relevant for performance here.
Additionally, I fixed the created locations: X and Z should not be mixed up, we only want to the the corners of the bounding box defined by max/min.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
