### PR TITLE
Support MiniMessage in plot-title flag

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/util/StringMan.java
+++ b/Core/src/main/java/com/plotsquared/core/util/StringMan.java
@@ -36,7 +36,8 @@ import java.util.regex.Pattern;
 
 public class StringMan {
 
-    private static final Pattern STRING_SPLIT_PATTERN = Pattern.compile("(?<quoted>\"[\\w ]+\")|(?<single>\\w+)");
+    // Stolen from https://stackoverflow.com/a/366532/12620913 | Debug: https://regex101.com/r/DudJLb/1
+    private static final Pattern STRING_SPLIT_PATTERN = Pattern.compile("[^\\s\"]+|\"([^\"]*)\"");
 
     public static String replaceFromMap(String string, Map<String, String> replacements) {
         StringBuilder sb = new StringBuilder(string);
@@ -355,7 +356,7 @@ public class StringMan {
         var matcher = StringMan.STRING_SPLIT_PATTERN.matcher(message);
         List<String> splitMessages = new ArrayList<>();
         while (matcher.find()) {
-            splitMessages.add(matcher.group(0).replaceAll("\"", ""));
+            splitMessages.add(matcher.group(matcher.groupCount() - 1).replaceAll("\"", ""));
         }
         return splitMessages;
     }

--- a/Core/src/test/java/com/plotsquared/core/plot/FlagTest.java
+++ b/Core/src/test/java/com/plotsquared/core/plot/FlagTest.java
@@ -101,7 +101,7 @@ public class FlagTest {
     public void shouldSuccessfullyParseTitleFlagWithTitleEmptyAndSubTitleSingleWord() {
         Assertions.assertDoesNotThrow(() -> {
             var title = PlotTitleFlag.TITLE_FLAG_DEFAULT.parse("\"\" \"single\"").getValue();
-            Assertions.assertEquals(" ", title.title());
+            Assertions.assertEquals("", title.title());
             Assertions.assertEquals("single", title.subtitle());
         }, "Should not throw a FlagParseException");
     }

--- a/Core/src/test/java/com/plotsquared/core/util/StringManTest.java
+++ b/Core/src/test/java/com/plotsquared/core/util/StringManTest.java
@@ -32,7 +32,9 @@ public class StringManTest {
                 new Message("title", List.of("title")),
                 new Message("title \"sub title\"", List.of("title", "sub title")),
                 new Message("\"a title\" subtitle", List.of("a title", "subtitle")),
-                new Message("\"title\" \"subtitle\"", List.of("title", "subtitle"))
+                new Message("\"title\" \"subtitle\"", List.of("title", "subtitle")),
+                new Message("\"How <bold>bold</bold> of you\" \"to assume I like <rainbow>rainbows</rainbow>\"",
+                        List.of("How <bold>bold</bold> of you", "to assume I like <rainbow>rainbows</rainbow>"))
         );
 
         for (Message message : messages) {


### PR DESCRIPTION
## Description
Fixes an issue, that StringMan only supports A-Z and 0-9 as characters, which intereferes with MiniMessages syntax including ":", "<" ">" "#" and is a quite useless limitation either way.
Fixed the shouldSuccessfullyParseTitleFlagWithTitleEmptyAndSubTitleSingleWord-Test, as the current behaviour didn't make much sense at all.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
