### PR TITLE
feat: Move ExpireManager to Guice by removing legacy IMP references

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/PlotPlatform.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotPlatform.java
@@ -32,6 +32,7 @@ import com.plotsquared.core.inject.annotations.DefaultGenerator;
 import com.plotsquared.core.location.World;
 import com.plotsquared.core.permissions.PermissionHandler;
 import com.plotsquared.core.player.PlotPlayer;
+import com.plotsquared.core.plot.expiration.ExpireManager;
 import com.plotsquared.core.plot.world.PlotAreaManager;
 import com.plotsquared.core.queue.GlobalBlockQueue;
 import com.plotsquared.core.util.ChunkManager;
@@ -282,6 +283,15 @@ public interface PlotPlatform<P> extends LocaleHolder {
      */
     default @NonNull ChunkManager chunkManager() {
         return injector().getInstance(ChunkManager.class);
+    }
+
+    /**
+     * Get the {@link ExpireManager} implementation for the platform
+     *
+     * @return Expire manager
+     */
+    default @NonNull ExpireManager expireManager() {
+        return injector().getInstance(ExpireManager.class);
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/PlotPlatform.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotPlatform.java
@@ -289,6 +289,7 @@ public interface PlotPlatform<P> extends LocaleHolder {
      * Get the {@link ExpireManager} implementation for the platform
      *
      * @return Expire manager
+     * @since TODO
      */
     default @NonNull ExpireManager expireManager() {
         return injector().getInstance(ExpireManager.class);

--- a/Core/src/main/java/com/plotsquared/core/PlotSquared.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotSquared.java
@@ -290,11 +290,11 @@ public class PlotSquared {
 
     public void startExpiryTasks() {
         if (Settings.Enabled_Components.PLOT_EXPIRY) {
-            ExpireManager manager = new ExpireManager(this.eventDispatcher);
-            manager.runAutomatedTask();
+            ExpireManager expireManager = PlotSquared.platform().expireManager();
+            expireManager.runAutomatedTask();
             for (Settings.Auto_Clear settings : Settings.AUTO_CLEAR.getInstances()) {
                 ExpiryTask task = new ExpiryTask(settings, this.getPlotAreaManager());
-                manager.addTask(task);
+                expireManager.addTask(task);
             }
         }
     }
@@ -645,7 +645,8 @@ public class PlotSquared {
         } else {
             list = new ArrayList<>(input);
         }
-        list.sort(Comparator.comparingLong(a -> PlotSquared.platform().expireManager().getTimestamp(a.getOwnerAbs())));
+        ExpireManager expireManager = PlotSquared.platform().expireManager();
+        list.sort(Comparator.comparingLong(a -> expireManager.getTimestamp(a.getOwnerAbs())));
         return list;
     }
 

--- a/Core/src/main/java/com/plotsquared/core/PlotSquared.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotSquared.java
@@ -290,11 +290,11 @@ public class PlotSquared {
 
     public void startExpiryTasks() {
         if (Settings.Enabled_Components.PLOT_EXPIRY) {
-            ExpireManager.IMP = new ExpireManager(this.eventDispatcher);
-            ExpireManager.IMP.runAutomatedTask();
+            ExpireManager manager = new ExpireManager(this.eventDispatcher);
+            manager.runAutomatedTask();
             for (Settings.Auto_Clear settings : Settings.AUTO_CLEAR.getInstances()) {
                 ExpiryTask task = new ExpiryTask(settings, this.getPlotAreaManager());
-                ExpireManager.IMP.addTask(task);
+                manager.addTask(task);
             }
         }
     }
@@ -645,7 +645,7 @@ public class PlotSquared {
         } else {
             list = new ArrayList<>(input);
         }
-        list.sort(Comparator.comparingLong(a -> ExpireManager.IMP.getTimestamp(a.getOwnerAbs())));
+        list.sort(Comparator.comparingLong(a -> PlotSquared.platform().expireManager().getTimestamp(a.getOwnerAbs())));
         return list;
     }
 

--- a/Core/src/main/java/com/plotsquared/core/command/DebugExec.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DebugExec.java
@@ -19,6 +19,7 @@
 package com.plotsquared.core.command;
 
 import com.google.inject.Inject;
+import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.caption.StaticCaption;
 import com.plotsquared.core.configuration.caption.TranslatableCaption;
 import com.plotsquared.core.events.PlotFlagRemoveEvent;
@@ -139,10 +140,8 @@ public class DebugExec extends SubCommand {
                     return true;
                 }
                 case "start-expire" -> {
-                    if (ExpireManager.IMP == null) {
-                        ExpireManager.IMP = new ExpireManager(this.eventDispatcher);
-                    }
-                    if (ExpireManager.IMP.runAutomatedTask()) {
+                    ExpireManager manager = PlotSquared.platform().expireManager() == null ? new ExpireManager(this.eventDispatcher) : PlotSquared.platform().expireManager();
+                    if (manager.runAutomatedTask()) {
                         player.sendMessage(TranslatableCaption.of("debugexec.expiry_started"));
                     } else {
                         player.sendMessage(TranslatableCaption.of("debugexec.expiry_already_started"));
@@ -150,7 +149,7 @@ public class DebugExec extends SubCommand {
                     return true;
                 }
                 case "stop-expire" -> {
-                    if (ExpireManager.IMP == null || !ExpireManager.IMP.cancelTask()) {
+                    if (PlotSquared.platform().expireManager() == null || !PlotSquared.platform().expireManager().cancelTask()) {
                         player.sendMessage(TranslatableCaption.of("debugexec.task_halted"));
                     } else {
                         player.sendMessage(TranslatableCaption.of("debugexec.task_cancelled"));

--- a/Core/src/main/java/com/plotsquared/core/command/DebugExec.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DebugExec.java
@@ -140,8 +140,8 @@ public class DebugExec extends SubCommand {
                     return true;
                 }
                 case "start-expire" -> {
-                    ExpireManager manager = PlotSquared.platform().expireManager() == null ? new ExpireManager(this.eventDispatcher) : PlotSquared.platform().expireManager();
-                    if (manager.runAutomatedTask()) {
+                    ExpireManager expireManager = PlotSquared.platform().expireManager() == null ? new ExpireManager(this.eventDispatcher) : PlotSquared.platform().expireManager();
+                    if (expireManager.runAutomatedTask()) {
                         player.sendMessage(TranslatableCaption.of("debugexec.expiry_started"));
                     } else {
                         player.sendMessage(TranslatableCaption.of("debugexec.expiry_already_started"));

--- a/Core/src/main/java/com/plotsquared/core/command/Done.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Done.java
@@ -19,6 +19,7 @@
 package com.plotsquared.core.command;
 
 import com.google.inject.Inject;
+import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.configuration.caption.TranslatableCaption;
 import com.plotsquared.core.events.PlotDoneEvent;
@@ -29,7 +30,6 @@ import com.plotsquared.core.location.Location;
 import com.plotsquared.core.permissions.Permission;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
-import com.plotsquared.core.plot.expiration.ExpireManager;
 import com.plotsquared.core.plot.expiration.PlotAnalysis;
 import com.plotsquared.core.plot.flag.PlotFlag;
 import com.plotsquared.core.plot.flag.implementations.DoneFlag;
@@ -94,7 +94,7 @@ public class Done extends SubCommand {
                 Template.of("plot", plot.getId().toString())
         );
         final Settings.Auto_Clear doneRequirements = Settings.AUTO_CLEAR.get("done");
-        if (ExpireManager.IMP == null || doneRequirements == null) {
+        if (PlotSquared.platform().expireManager() == null || doneRequirements == null) {
             finish(plot, player, true);
             plot.removeRunning();
         } else {

--- a/Core/src/main/java/com/plotsquared/core/command/ListCmd.java
+++ b/Core/src/main/java/com/plotsquared/core/command/ListCmd.java
@@ -30,7 +30,6 @@ import com.plotsquared.core.permissions.Permission;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
-import com.plotsquared.core.plot.expiration.ExpireManager;
 import com.plotsquared.core.plot.flag.implementations.DoneFlag;
 import com.plotsquared.core.plot.flag.implementations.PriceFlag;
 import com.plotsquared.core.plot.flag.implementations.ServerPlotFlag;
@@ -240,7 +239,7 @@ public class ListCmd extends SubCommand {
                     );
                     return false;
                 }
-                if (ExpireManager.IMP == null) {
+                if (PlotSquared.platform().expireManager() == null) {
                     plotConsumer.accept(PlotQuery.newQuery().noPlots());
                 } else {
                     plotConsumer.accept(PlotQuery.newQuery().expiredPlots());

--- a/Core/src/main/java/com/plotsquared/core/command/Trim.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Trim.java
@@ -25,7 +25,6 @@ import com.plotsquared.core.configuration.caption.TranslatableCaption;
 import com.plotsquared.core.location.Location;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
-import com.plotsquared.core.plot.expiration.ExpireManager;
 import com.plotsquared.core.plot.world.PlotAreaManager;
 import com.plotsquared.core.queue.GlobalBlockQueue;
 import com.plotsquared.core.queue.QueueCoordinator;
@@ -92,8 +91,8 @@ public class Trim extends SubCommand {
         }
         TranslatableCaption.of("trim.trim_starting");
         final List<Plot> plots = PlotQuery.newQuery().inWorld(world).asList();
-        if (ExpireManager.IMP != null) {
-            plots.removeAll(ExpireManager.IMP.getPendingExpired());
+        if (PlotSquared.platform().expireManager() != null) {
+            plots.removeAll(PlotSquared.platform().expireManager().getPendingExpired());
         }
         result.value1 = new HashSet<>(PlotSquared.platform().worldUtil().getChunkChunks(world));
         result.value2 = new HashSet<>();

--- a/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
+++ b/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
@@ -36,7 +36,6 @@ import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.plot.PlotTitle;
 import com.plotsquared.core.plot.PlotWeather;
 import com.plotsquared.core.plot.comment.CommentManager;
-import com.plotsquared.core.plot.expiration.ExpireManager;
 import com.plotsquared.core.plot.flag.GlobalFlagContainer;
 import com.plotsquared.core.plot.flag.PlotFlag;
 import com.plotsquared.core.plot.flag.implementations.DenyExitFlag;
@@ -163,8 +162,8 @@ public class PlotListener {
             if ((last != null) && !last.getId().equals(plot.getId())) {
                 plotExit(player, last);
             }
-            if (ExpireManager.IMP != null) {
-                ExpireManager.IMP.handleEntry(player, plot);
+            if (PlotSquared.platform().expireManager() != null) {
+                PlotSquared.platform().expireManager().handleEntry(player, plot);
             }
             lastPlot.set(plot);
         }

--- a/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
+++ b/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
@@ -42,7 +42,6 @@ import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.plot.PlotCluster;
 import com.plotsquared.core.plot.PlotId;
 import com.plotsquared.core.plot.PlotWeather;
-import com.plotsquared.core.plot.expiration.ExpireManager;
 import com.plotsquared.core.plot.flag.implementations.DoneFlag;
 import com.plotsquared.core.plot.world.PlotAreaManager;
 import com.plotsquared.core.plot.world.SinglePlotArea;
@@ -618,8 +617,8 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
                 LOGGER.info("Plot {} was deleted + cleared due to {} getting banned", owned.getId(), getName());
             }
         }
-        if (ExpireManager.IMP != null) {
-            ExpireManager.IMP.storeDate(getUUID(), System.currentTimeMillis());
+        if (PlotSquared.platform().expireManager() != null) {
+            PlotSquared.platform().expireManager().storeDate(getUUID(), System.currentTimeMillis());
         }
         PlotSquared.platform().playerManager().removePlayer(this);
         PlotSquared.platform().unregister(this);

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -40,7 +40,6 @@ import com.plotsquared.core.location.Location;
 import com.plotsquared.core.permissions.Permission;
 import com.plotsquared.core.player.ConsolePlayer;
 import com.plotsquared.core.player.PlotPlayer;
-import com.plotsquared.core.plot.expiration.ExpireManager;
 import com.plotsquared.core.plot.expiration.PlotAnalysis;
 import com.plotsquared.core.plot.flag.FlagContainer;
 import com.plotsquared.core.plot.flag.GlobalFlagContainer;
@@ -1105,8 +1104,8 @@ public class Plot {
      * @return A boolean indicating whether or not the operation succeeded
      */
     public <V> boolean setFlag(final @NonNull PlotFlag<V, ?> flag) {
-        if (flag instanceof KeepFlag && ExpireManager.IMP != null) {
-            ExpireManager.IMP.updateExpired(this);
+        if (flag instanceof KeepFlag && PlotSquared.platform().expireManager() != null) {
+            PlotSquared.platform().expireManager().updateExpired(this);
         }
         for (final Plot plot : this.getConnectedPlots()) {
             plot.getFlagContainer().addFlag(flag);
@@ -2831,11 +2830,11 @@ public class Plot {
                     Component members = PlayerManager.getPlayerList(this.getMembers(), player);
                     Component denied = PlayerManager.getPlayerList(this.getDenied(), player);
                     String seen;
-                    if (Settings.Enabled_Components.PLOT_EXPIRY && ExpireManager.IMP != null) {
+                    if (Settings.Enabled_Components.PLOT_EXPIRY && PlotSquared.platform().expireManager() != null) {
                         if (this.isOnline()) {
                             seen = TranslatableCaption.of("info.now").getComponent(player);
                         } else {
-                            int time = (int) (ExpireManager.IMP.getAge(this, false) / 1000);
+                            int time = (int) (PlotSquared.platform().expireManager().getAge(this, false) / 1000);
                             if (time != 0) {
                                 seen = TimeUtil.secToTime(time);
                             } else {

--- a/Core/src/main/java/com/plotsquared/core/plot/expiration/ExpireManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/expiration/ExpireManager.java
@@ -60,6 +60,11 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 
 public class ExpireManager {
 
+    /**
+     * @deprecated Use {@link PlotPlatform#expireManager()} instead
+     */
+    @Deprecated(forRemoval = true, since = "TODO")
+    public static ExpireManager IMP;
     private final ConcurrentHashMap<UUID, Long> dates_cache;
     private final ConcurrentHashMap<UUID, Long> account_age_cache;
     private final EventDispatcher eventDispatcher;

--- a/Core/src/main/java/com/plotsquared/core/plot/expiration/ExpireManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/expiration/ExpireManager.java
@@ -18,6 +18,7 @@
  */
 package com.plotsquared.core.plot.expiration;
 
+import com.plotsquared.core.PlotPlatform;
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.caption.Caption;
 import com.plotsquared.core.configuration.caption.Templates;

--- a/Core/src/main/java/com/plotsquared/core/plot/expiration/ExpireManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/expiration/ExpireManager.java
@@ -60,7 +60,6 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 
 public class ExpireManager {
 
-    public static ExpireManager IMP;
     private final ConcurrentHashMap<UUID, Long> dates_cache;
     private final ConcurrentHashMap<UUID, Long> account_age_cache;
     private final EventDispatcher eventDispatcher;

--- a/Core/src/main/java/com/plotsquared/core/plot/expiration/ExpiryTask.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/expiration/ExpiryTask.java
@@ -73,8 +73,9 @@ public class ExpiryTask {
                         min = false;
                         diff = plots.size() - settings.REQUIRED_PLOTS;
                     }
+                    ExpireManager expireManager = PlotSquared.platform().expireManager();
                     List<Long> entireList =
-                            plots.stream().map(plot -> PlotSquared.platform().expireManager().getAge(plot, settings.DELETE_IF_OWNER_IS_UNKNOWN))
+                            plots.stream().map(plot -> expireManager.getAge(plot, settings.DELETE_IF_OWNER_IS_UNKNOWN))
                                     .collect(Collectors.toList());
                     List<Long> top = new ArrayList<>(diff + 1);
                     if (diff > 1000) {

--- a/Core/src/main/java/com/plotsquared/core/plot/expiration/ExpiryTask.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/expiration/ExpiryTask.java
@@ -18,6 +18,7 @@
  */
 package com.plotsquared.core.plot.expiration;
 
+import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
@@ -73,7 +74,7 @@ public class ExpiryTask {
                         diff = plots.size() - settings.REQUIRED_PLOTS;
                     }
                     List<Long> entireList =
-                            plots.stream().map(plot -> ExpireManager.IMP.getAge(plot, settings.DELETE_IF_OWNER_IS_UNKNOWN))
+                            plots.stream().map(plot -> PlotSquared.platform().expireManager().getAge(plot, settings.DELETE_IF_OWNER_IS_UNKNOWN))
                                     .collect(Collectors.toList());
                     List<Long> top = new ArrayList<>(diff + 1);
                     if (diff > 1000) {

--- a/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
+++ b/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
@@ -20,6 +20,7 @@ package com.plotsquared.core.util;
 
 import com.google.common.eventbus.EventBus;
 import com.intellectualsites.annotations.DoNotUse;
+import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.configuration.caption.TranslatableCaption;
 import com.plotsquared.core.events.PlayerAutoPlotEvent;
@@ -59,7 +60,6 @@ import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.plot.PlotId;
 import com.plotsquared.core.plot.Rating;
-import com.plotsquared.core.plot.expiration.ExpireManager;
 import com.plotsquared.core.plot.flag.PlotFlag;
 import com.plotsquared.core.plot.flag.implementations.DeviceInteractFlag;
 import com.plotsquared.core.plot.flag.implementations.MiscPlaceFlag;
@@ -300,8 +300,8 @@ public class EventDispatcher {
         if (player == null) {
             return; //possible future warning message to figure out where we are retrieving null
         }
-        if (ExpireManager.IMP != null) {
-            ExpireManager.IMP.handleJoin(player);
+        if (PlotSquared.platform().expireManager() != null) {
+            PlotSquared.platform().expireManager().handleJoin(player);
         }
         if (this.worldEdit != null) {
             if (player.getAttribute("worldedit")) {

--- a/Core/src/main/java/com/plotsquared/core/util/query/ExpiredPlotProvider.java
+++ b/Core/src/main/java/com/plotsquared/core/util/query/ExpiredPlotProvider.java
@@ -18,8 +18,8 @@
  */
 package com.plotsquared.core.util.query;
 
+import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.plot.Plot;
-import com.plotsquared.core.plot.expiration.ExpireManager;
 
 import java.util.Collection;
 
@@ -27,7 +27,7 @@ class ExpiredPlotProvider implements PlotProvider {
 
     @Override
     public Collection<Plot> getPlots() {
-        return ExpireManager.IMP.getPendingExpired();
+        return PlotSquared.platform().expireManager().getPendingExpired();
     }
 
 }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Closes #3358 

## Description
<!-- Please describe what this pull request does. -->

This PR adds a new method to `PlotPlatform` that allows it to use Guice's inject to get an implementation of the class and replaces all references to `ExpireManager.IMP` accordingly. Instances of `ExpireManager.IMP` have also been replaced with appropriate instances of `ExpireManager` to avoid confusion with the `PlotPlatform` method.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
