### PR TITLE
fix: account for mismatched road-schematic heights

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
@@ -298,7 +298,10 @@ public class HybridPlotWorld extends ClassicPlotWorld {
         int roadSchemHeight;
 
         if (schematic1 != null) {
-            roadSchemHeight = schematic1.getClipboard().getDimensions().getY();
+            roadSchemHeight = Math.max(
+                    schematic1.getClipboard().getDimensions().getY(),
+                    schematic2.getClipboard().getDimensions().getY()
+            );
             maxSchematicHeight = Math.max(roadSchemHeight, maxSchematicHeight);
             if (maxSchematicHeight == worldGenHeight) {
                 SCHEM_Y = getMinGenHeight();


### PR DESCRIPTION
Intersection and sideroad schematics can be of different heights. Ensure we get the maximum of the two for road schematic height