### PR TITLE
refactor: adjust specific Nullable annotations used

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/generator/LegacyBlockStatePopulator.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/generator/LegacyBlockStatePopulator.java
@@ -33,7 +33,6 @@ import org.bukkit.Chunk;
 import org.bukkit.World;
 import org.bukkit.generator.BlockPopulator;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Random;
 
@@ -51,7 +50,7 @@ final class LegacyBlockStatePopulator extends BlockPopulator {
     }
 
     @Override
-    public void populate(@NotNull final World world, @NotNull final Random random, @NotNull final Chunk source) {
+    public void populate(@NonNull final World world, @NonNull final Random random, @NonNull final Chunk source) {
         int chunkMinX = source.getX() << 4;
         int chunkMinZ = source.getZ() << 4;
         PlotArea area = Location.at(world.getName(), chunkMinX, 0, chunkMinZ).getPlotArea();

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/fawe/FaweRegionManager.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/fawe/FaweRegionManager.java
@@ -36,8 +36,7 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Set;
 
@@ -46,10 +45,7 @@ public class FaweRegionManager extends BukkitRegionManager {
     private final FaweDelegateRegionManager delegate = new FaweDelegateRegionManager();
 
     @Inject
-    public FaweRegionManager(
-            @NonNull WorldUtil worldUtil, @NonNull GlobalBlockQueue blockQueue, @NonNull
-            ProgressSubscriberFactory subscriberFactory
-    ) {
+    public FaweRegionManager(WorldUtil worldUtil, GlobalBlockQueue blockQueue, ProgressSubscriberFactory subscriberFactory) {
         super(worldUtil, blockQueue, subscriberFactory);
     }
 
@@ -76,9 +72,9 @@ public class FaweRegionManager extends BukkitRegionManager {
 
     @Override
     public boolean handleClear(
-            @NotNull Plot plot,
+            @NonNull Plot plot,
             @Nullable Runnable whenDone,
-            @NotNull PlotManager manager,
+            @NonNull PlotManager manager,
             final @Nullable PlotPlayer<?> player
     ) {
         if (!Settings.FAWE_Components.CLEAR || !(manager instanceof HybridPlotManager)) {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/fawe/FaweSchematicHandler.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/fawe/FaweSchematicHandler.java
@@ -29,7 +29,7 @@ import com.plotsquared.core.util.SchematicHandler;
 import com.plotsquared.core.util.WorldUtil;
 import com.plotsquared.core.util.task.RunnableVal;
 import com.sk89q.jnbt.CompoundTag;
-import org.jetbrains.annotations.NotNull;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.io.InputStream;
 import java.net.URL;
@@ -40,7 +40,7 @@ public class FaweSchematicHandler extends SchematicHandler {
     private final FaweDelegateSchematicHandler delegate = new FaweDelegateSchematicHandler();
 
     @Inject
-    public FaweSchematicHandler(@NotNull WorldUtil worldUtil, @NotNull ProgressSubscriberFactory subscriberFactory) {
+    public FaweSchematicHandler(WorldUtil worldUtil, ProgressSubscriberFactory subscriberFactory) {
         super(worldUtil, subscriberFactory);
     }
 
@@ -75,7 +75,7 @@ public class FaweSchematicHandler extends SchematicHandler {
     }
 
     @Override
-    public Schematic getSchematic(@NotNull InputStream is) {
+    public Schematic getSchematic(@NonNull InputStream is) {
         return delegate.getSchematic(is);
     }
 

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/ClickStripTransform.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/ClickStripTransform.java
@@ -21,16 +21,15 @@ package com.plotsquared.core.configuration.caption;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.EnumSet;
 import java.util.Set;
 
 final class ClickStripTransform implements ComponentTransform {
 
-    private final Set<ClickEvent.@NotNull Action> actionsToStrip;
+    private final Set<ClickEvent.@NonNull Action> actionsToStrip;
 
-    public ClickStripTransform(final Set<ClickEvent.@NotNull Action> actionsToStrip) {
+    public ClickStripTransform(final Set<ClickEvent.@NonNull Action> actionsToStrip) {
         this.actionsToStrip = EnumSet.copyOf(actionsToStrip);
     }
 

--- a/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
@@ -93,10 +93,10 @@ public class HybridPlotWorld extends ClassicPlotWorld {
     @Inject
     public HybridPlotWorld(
             @Assisted("world") final String worldName,
-            @Nullable @Assisted("id") final String id,
+            @javax.annotation.Nullable @Assisted("id") final String id,
             @Assisted final @NonNull IndependentPlotGenerator generator,
-            @Nullable @Assisted("min") final PlotId min,
-            @Nullable @Assisted("max") final PlotId max,
+            @javax.annotation.Nullable @Assisted("min") final PlotId min,
+            @javax.annotation.Nullable @Assisted("max") final PlotId max,
             @WorldConfig final @NonNull YamlConfiguration worldConfiguration,
             final @NonNull GlobalBlockQueue blockQueue
     ) {

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotTitle.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotTitle.java
@@ -18,7 +18,8 @@
  */
 package com.plotsquared.core.plot;
 
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import java.util.Objects;
 
 public class PlotTitle {


### PR DESCRIPTION
 - Fixes #3860
 - Guice requires javax annotations be used for Inject annotated constructors
