### PR TITLE
Revert "feat: check merge limits when completing auto-merge (#3868)" - Fixes a bug in 6.10.4

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Auto.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Auto.java
@@ -142,14 +142,6 @@ public class Auto extends SubCommand {
                 }
             }
         }
-        int maxMerge = Permissions.hasPermissionRange(player, Permission.PERMISSION_MERGE, Settings.Limit.MAX_PLOTS);
-        if (sizeX * sizeZ > maxMerge) {
-            player.sendMessage(
-                    TranslatableCaption.of("permission.no_permission"),
-                    Template.of("node", Permission.PERMISSION_MERGE + "." + (sizeX * sizeZ))
-            );
-            return false;
-        }
         return true;
     }
 

--- a/Core/src/main/java/com/plotsquared/core/command/Merge.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Merge.java
@@ -124,7 +124,7 @@ public class Merge extends SubCommand {
             return false;
         }
         final int size = plot.getConnectedPlots().size();
-        int max = Permissions.hasPermissionRange(player, Permission.PERMISSION_MERGE, Settings.Limit.MAX_PLOTS);
+        int max = Permissions.hasPermissionRange(player, "plots.merge", Settings.Limit.MAX_PLOTS);
         PlotMergeEvent event =
                 this.eventDispatcher.callMerge(plot, direction, max, player);
         if (event.getEventResult() == Result.DENY) {


### PR DESCRIPTION
The prior PR merged only works if the actor has basic merge permissions, which may not always be set.

Closes https://github.com/IntellectualSites/PlotSquared/issues/3875