### PR TITLE
Fix wrong plot id calculation for negative coordinates

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/generator/SquarePlotManager.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/SquarePlotManager.java
@@ -114,26 +114,14 @@ public abstract class SquarePlotManager extends GridPlotManager {
             end = pathWidthLower + squarePlotWorld.PLOT_WIDTH;
         }
         int size = squarePlotWorld.PLOT_WIDTH + squarePlotWorld.ROAD_WIDTH;
-        int idx;
-        if (x < 0) {
-            idx = x / size;
-            x = size + (x % size);
-        } else {
-            idx = (x / size) + 1;
-            x = x % size;
-        }
-        int idz;
-        if (z < 0) {
-            idz = z / size;
-            z = size + (z % size);
-        } else {
-            idz = (z / size) + 1;
-            z = z % size;
-        }
-        if (z <= pathWidthLower || z > end || x <= pathWidthLower || x > end) {
+        int dx = Math.floorDiv(x, size) + 1;
+        int rx = Math.floorMod(x, size);
+        int dz = Math.floorDiv(z, size) + 1;
+        int rz = Math.floorMod(z, size);
+        if (rz <= pathWidthLower || rz > end || rx <= pathWidthLower || rx > end) {
             return null;
         } else {
-            return PlotId.of(idx, idz);
+            return PlotId.of(dx, dz);
         }
     }
 
@@ -180,24 +168,10 @@ public abstract class SquarePlotManager extends GridPlotManager {
                 }
                 end = pathWidthLower + squarePlotWorld.PLOT_WIDTH;
             }
-            int dx;
-            int rx;
-            if (x < 0) {
-                dx = x / size;
-                rx = size + (x % size);
-            } else {
-                dx = (x / size) + 1;
-                rx = x % size;
-            }
-            int dz;
-            int rz;
-            if (z < 0) {
-                dz = z / size;
-                rz = size + (z % size);
-            } else {
-                dz = (z / size) + 1;
-                rz = z % size;
-            }
+            int dx = Math.floorDiv(x, size) + 1;
+            int rx = Math.floorMod(x, size);
+            int dz = Math.floorDiv(z, size) + 1;
+            int rz = Math.floorMod(z, size);
             PlotId id = PlotId.of(dx, dz);
             boolean[] merged = new boolean[]{rz <= pathWidthLower, rx > end, rz > end, rx <= pathWidthLower};
             int hash = HashUtil.hash(merged);


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #3897

## Description
<!-- Please describe what this pull request does. -->

The previous approach caused wrong results on integer division. Using floorDiv and floorMod cleans up the code and fixes the wrong roundings in edge cases.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
