### PR TITLE
Replace licenser with spotless

### DIFF
--- a/HEADER.txt
+++ b/HEADER.txt
@@ -1,16 +1,18 @@
-PlotSquared, a land and world management plugin for Minecraft.
-Copyright (C) IntellectualSites <https://intellectualsites.com>
-Copyright (C) IntellectualSites team and contributors
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.
+/*
+ * PlotSquared, a land and world management plugin for Minecraft.
+ * Copyright (C) IntellectualSites <https://intellectualsites.com>
+ * Copyright (C) IntellectualSites team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
-import org.cadixdev.gradle.licenser.LicenseExtension
-import org.cadixdev.gradle.licenser.Licenser
 import java.net.URI
+import com.diffplug.gradle.spotless.SpotlessPlugin
 
 plugins {
     java
@@ -10,7 +9,7 @@ plugins {
     signing
 
     alias(libs.plugins.shadow)
-    alias(libs.plugins.licenser)
+    alias(libs.plugins.spotless)
     alias(libs.plugins.grgit)
     alias(libs.plugins.nexus)
 
@@ -57,7 +56,7 @@ subprojects {
         plugin<JavaLibraryPlugin>()
         plugin<MavenPublishPlugin>()
         plugin<ShadowPlugin>()
-        plugin<Licenser>()
+        plugin<SpotlessPlugin>()
         plugin<SigningPlugin>()
 
         plugin<EclipsePlugin>()
@@ -87,10 +86,11 @@ subprojects {
         attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
     }
 
-    configure<LicenseExtension> {
-        header(rootProject.file("HEADER.txt"))
-        include("**/*.java")
-        newLine.set(false)
+    spotless {
+        java {
+            licenseHeaderFile(rootProject.file("HEADER.txt"))
+            target("**/*.java")
+        }
     }
 
     java {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ http4j = "1.3"
 # Gradle plugins
 shadow = "7.1.2"
 grgit = "4.1.1"
-licenser = "0.6.1"
+spotless = "6.12.1"
 nexus = "1.1.0"
 
 [libraries]
@@ -49,5 +49,5 @@ http4j = { group = "com.intellectualsites.http", name = "HTTP4J", version.ref = 
 [plugins]
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }
 grgit = { id = "org.ajoberstar.grgit", version.ref = "grgit" }
-licenser = { id = "org.cadixdev.licenser", version.ref = "licenser" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 nexus = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus" }


### PR DESCRIPTION
We have waited almost a year that licenser cuts a release to address Gradle 8 deprecations. 

Gradle 8 is almost around the corner, public RCs are being produced and licenser hasn't cut a release yet. I see no reason to stick to licenser any longer when maintained alternatives exist as drop-in.