### PR TITLE
Drop HTTP4J

### DIFF
--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -48,7 +48,6 @@ dependencies {
 
     // Our libraries
     implementation(libs.arkitektonika)
-    implementation(libs.http4j)
     implementation("com.intellectualsites.paster:Paster")
     implementation("com.intellectualsites.informative-annotations:informative-annotations")
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,6 @@ aopalliance = "1.0"
 cloud-services = "1.8.0"
 arkitektonika = "2.1.1"
 squirrelid = "0.3.1"
-http4j = "1.3"
 
 # Gradle plugins
 shadow = "7.1.2"
@@ -44,7 +43,6 @@ cloudServices = { group = "cloud.commandframework", name = "cloud-services", ver
 mvdwapi = { group = "com.intellectualsites.mvdwplaceholderapi", name = "MVdWPlaceholderAPI", version.ref = "mvdwapi" }
 squirrelid = { group = "org.enginehub", name = "squirrelid", version.ref = "squirrelid" }
 arkitektonika = { group = "com.intellectualsites.arkitektonika", name = "Arkitektonika-Client", version.ref = "arkitektonika" }
-http4j = { group = "com.intellectualsites.http", name = "HTTP4J", version.ref = "http4j" }
 
 [plugins]
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }


### PR DESCRIPTION
There's no trace that this is still needed or used. Initially, I thought this would be needed for Arkitektonika or the paste service, but both work without, too.