### PR TITLE
Add source documentation to javadocs and add dependency tab

### DIFF
--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -105,6 +105,10 @@ tasks {
         opt.links("https://jd.adventure.kyori.net/api/4.9.3/")
         opt.links("https://google.github.io/guice/api-docs/" + libs.guice.get().versionConstraint.toString() + "/javadoc/")
         opt.links("https://checkerframework.org/api/")
+        opt.isLinkSource = true
+        opt.bottom(File("$rootDir/javadocfooter.html").readText())
+        opt.isUse = true
         opt.encoding("UTF-8")
+        opt.keyWords()
     }
 }

--- a/Core/build.gradle.kts
+++ b/Core/build.gradle.kts
@@ -71,6 +71,10 @@ tasks {
         opt.links("https://google.github.io/guice/api-docs/" + libs.guice.get().versionConstraint.toString() + "/javadoc/")
         opt.links("https://checkerframework.org/api/")
         opt.links("https://javadoc.io/doc/com.intellectualsites.informative-annotations/informative-annotations/latest/")
+        opt.isLinkSource = true
+        opt.bottom(File("$rootDir/javadocfooter.html").readText())
+        opt.isUse = true
         opt.encoding("UTF-8")
+        opt.keyWords()
     }
 }

--- a/Core/src/main/java/com/plotsquared/core/events/PlayerAutoPlotEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlayerAutoPlotEvent.java
@@ -114,7 +114,7 @@ public class PlayerAutoPlotEvent extends PlotEvent implements CancellablePlotEve
     }
 
     /**
-     * @deprecated for removal. Use {@link PlayerAutoPlotEvent#setSizeX(int)} )}
+     * @deprecated for removal. Use {@link PlayerAutoPlotEvent#setSizeX(int)}
      */
     @Deprecated(forRemoval = true, since = "6.1.0")
     public void setSize_x(int sizeX) {
@@ -130,7 +130,7 @@ public class PlayerAutoPlotEvent extends PlotEvent implements CancellablePlotEve
     }
 
     /**
-     * @deprecated for removal. Use {@link PlayerAutoPlotEvent#setSizeZ(int)} )}
+     * @deprecated for removal. Use {@link PlayerAutoPlotEvent#setSizeZ(int)}
      */
     @Deprecated(forRemoval = true, since = "6.1.0")
     public void setSize_z(int sizeZ) {

--- a/javadocfooter.html
+++ b/javadocfooter.html
@@ -1,0 +1,4 @@
+Javadocs generated for
+<a rel="noopener nofollow noreferrer" href="https://github.com/IntellectualSites/PlotSquared/" target="_blank"> PlotSquared</a> |
+<a rel="noopener nofollow noreferrer" href="https://intellectualsites.github.io/plotsquared-documentation/"> Documentation </a> |
+Visit us on our <a rel="noopener nofollow noreferrer" href="https://discord.gg/intellectualsites"> Discord server</a> :)


### PR DESCRIPTION
- isLinkSource generates HTML files for all classes to facilitate browsing javadocs without the need to change between source code and back
- isUse adds a dedicated "USE" tab to the navbar to visualize class dependencies
- keywords adds some optional metadata for search engines
- bottom adds a footer, to be considered, but I found it a funny idea :)