### PR TITLE
Reduce `/plot home` overhead

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/HomeCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/HomeCommand.java
@@ -35,9 +35,6 @@ import com.plotsquared.core.util.query.PlotQuery;
 import com.plotsquared.core.util.query.SortingStrategy;
 import com.plotsquared.core.util.task.RunnableVal2;
 import com.plotsquared.core.util.task.RunnableVal3;
-import jdk.jfr.Category;
-import jdk.jfr.Event;
-import jdk.jfr.Label;
 import net.kyori.adventure.text.minimessage.Template;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -62,24 +59,13 @@ public class HomeCommand extends Command {
         this.plotAreaManager = plotAreaManager;
     }
 
-    @Label("Home Query")
-    @Category("PlotSquared")
-    static class HomeQueryEvent extends Event {
-        @Label("Result Size")
-        public int size;
-    }
-
     private void home(
             final @NonNull PlotPlayer<?> player,
             final @NonNull PlotQuery query, final int page,
             final RunnableVal3<Command, Runnable, Runnable> confirm,
             final RunnableVal2<Command, CommandResult> whenDone
     ) {
-        final HomeQueryEvent event = new HomeQueryEvent();
-        event.begin();
         List<Plot> plots = query.asList();
-        event.size = plots.size();
-        event.commit();
         if (plots.isEmpty()) {
             player.sendMessage(TranslatableCaption.of("invalid.found_no_plots"));
             return;

--- a/Core/src/main/java/com/plotsquared/core/command/HomeCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/HomeCommand.java
@@ -35,6 +35,9 @@ import com.plotsquared.core.util.query.PlotQuery;
 import com.plotsquared.core.util.query.SortingStrategy;
 import com.plotsquared.core.util.task.RunnableVal2;
 import com.plotsquared.core.util.task.RunnableVal3;
+import jdk.jfr.Category;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
 import net.kyori.adventure.text.minimessage.Template;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -59,13 +62,24 @@ public class HomeCommand extends Command {
         this.plotAreaManager = plotAreaManager;
     }
 
+    @Label("Home Query")
+    @Category("PlotSquared")
+    static class HomeQueryEvent extends Event {
+        @Label("Result Size")
+        public int size;
+    }
+
     private void home(
             final @NonNull PlotPlayer<?> player,
             final @NonNull PlotQuery query, final int page,
             final RunnableVal3<Command, Runnable, Runnable> confirm,
             final RunnableVal2<Command, CommandResult> whenDone
     ) {
+        final HomeQueryEvent event = new HomeQueryEvent();
+        event.begin();
         List<Plot> plots = query.asList();
+        event.size = plots.size();
+        event.commit();
         if (plots.isEmpty()) {
             player.sendMessage(TranslatableCaption.of("invalid.found_no_plots"));
             return;

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -68,9 +68,6 @@ import com.plotsquared.core.util.task.TaskTime;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.world.biome.BiomeType;
-import jdk.jfr.Category;
-import jdk.jfr.Event;
-import jdk.jfr.Label;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.minimessage.MiniMessage;
@@ -2297,25 +2294,6 @@ public class Plot {
         return this.area.getPlotAbs(this.id.getRelative(direction));
     }
 
-    @Label("Connected Plots Search")
-    @Category("PlotSquared")
-    static class ConnectedPlotsEvent extends Event {
-
-        public ConnectedPlotsEvent(final int x, final int y) {
-            this.x = x;
-            this.y = y;
-        }
-
-        @Label("Plot Id X")
-        public int x;
-        @Label("Plot Id Y")
-        public int y;
-        @Label("Merged  Plots Count")
-        public int mergedSize;
-        @Label("Connected Plots Cache Miss")
-        public boolean cacheMiss;
-    }
-
     /**
      * Gets a set of plots connected (and including) this plot<br>
      * - This result is cached globally
@@ -2323,19 +2301,13 @@ public class Plot {
      * @return a Set of Plots connected to this Plot
      */
     public Set<Plot> getConnectedPlots() {
-        ConnectedPlotsEvent event = new ConnectedPlotsEvent(this.id.getX(), this.id.getY());
-        event.begin();
         if (this.settings == null) {
-            event.commit();
             return Collections.singleton(this);
         }
         if (!this.isMerged()) {
-            event.commit();
             return Collections.singleton(this);
         }
         if (this.connectedCache != null && this.connectedCache.contains(this)) {
-            event.mergedSize = this.connectedCache.size();
-            event.commit();
             return this.connectedCache;
         }
 
@@ -2443,9 +2415,6 @@ public class Plot {
             }
         }
         this.connectedCache = tmpSet;
-        event.mergedSize = tmpSet.size();
-        event.cacheMiss = true;
-        event.commit();
         return tmpSet;
     }
 

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -68,6 +68,9 @@ import com.plotsquared.core.util.task.TaskTime;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.world.biome.BiomeType;
+import jdk.jfr.Category;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.minimessage.MiniMessage;
@@ -2288,6 +2291,25 @@ public class Plot {
         return this.area.getPlotAbs(this.id.getRelative(direction));
     }
 
+    @Label("Connected Plots Search")
+    @Category("PlotSquared")
+    static class ConnectedPlotsEvent extends Event {
+
+        public ConnectedPlotsEvent(final int x, final int y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        @Label("Plot Id X")
+        public int x;
+        @Label("Plot Id Y")
+        public int y;
+        @Label("Merged  Plots Count")
+        public int mergedSize;
+        @Label("Connected Plots Cache Miss")
+        public boolean cacheMiss;
+    }
+
     /**
      * Gets a set of plots connected (and including) this plot<br>
      * - This result is cached globally
@@ -2295,13 +2317,19 @@ public class Plot {
      * @return a Set of Plots connected to this Plot
      */
     public Set<Plot> getConnectedPlots() {
+        ConnectedPlotsEvent event = new ConnectedPlotsEvent(this.id.getX(), this.id.getY());
+        event.begin();
         if (this.settings == null) {
+            event.commit();
             return Collections.singleton(this);
         }
         if (!this.isMerged()) {
+            event.commit();
             return Collections.singleton(this);
         }
         if (connected_cache != null && connected_cache.contains(this)) {
+            event.mergedSize = connected_cache.size();
+            event.commit();
             return connected_cache;
         }
         regions_cache = null;
@@ -2410,6 +2438,9 @@ public class Plot {
             }
         }
         connected_cache = tmpSet;
+        event.mergedSize = tmpSet.size();
+        event.cacheMiss = true;
+        event.commit();
         return tmpSet;
     }
 

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -1303,6 +1303,7 @@ public class Plot {
             DBFunc.delete(current);
             current.setOwnerAbs(null);
             current.settings = null;
+            current.clearCache();
             for (final PlotPlayer<?> pp : players) {
                 this.plotListener.plotEntry(pp, current);
             }
@@ -1873,6 +1874,7 @@ public class Plot {
         this.area.removePlot(this.id);
         this.id = plot.getId();
         this.area.addPlotAbs(this);
+        clearCache();
         DBFunc.movePlot(this, plot);
         TaskManager.runTaskLater(whenDone, TaskTime.ticks(1L));
         return true;

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -578,7 +578,14 @@ public class Plot {
             return false;
         }
         final Set<Plot> connected = getConnectedPlots();
-        return connected.stream().anyMatch(current -> uuid.equals(current.getOwner()));
+        for (Plot current : connected) {
+            // can skip ServerPlotFlag check in getOwner()
+            // as flags are synchronized between plots
+            if (uuid.equals(current.getOwnerAbs())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
@@ -327,6 +327,7 @@ public final class PlotModificationManager {
         ArrayList<PlotId> ids = new ArrayList<>(plots.size());
         for (Plot current : plots) {
             current.setHome(null);
+            current.clearCache();
             ids.add(current.getId());
         }
         this.plot.clearRatings();
@@ -478,8 +479,7 @@ public final class PlotModificationManager {
                 this.plot.updateWorldBorder();
             }
         }
-        Plot.connected_cache = null;
-        Plot.regions_cache = null;
+        this.plot.clearCache();
         this.plot.getTrusted().clear();
         this.plot.getMembers().clear();
         this.plot.getDenied().clear();
@@ -630,6 +630,7 @@ public final class PlotModificationManager {
         if (queue.size() > 0) {
             queue.enqueue();
         }
+        visited.forEach(Plot::clearCache);
         return toReturn;
     }
 

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
@@ -263,6 +263,7 @@ public final class PlotModificationManager {
                     return;
                 }
                 Plot current = queue.poll();
+                current.clearCache();
                 if (plot.getArea().getTerrain() != PlotAreaTerrainType.NONE) {
                     try {
                         PlotSquared.platform().regionManager().regenerateRegion(

--- a/Core/src/main/java/com/plotsquared/core/util/query/GlobalPlotProvider.java
+++ b/Core/src/main/java/com/plotsquared/core/util/query/GlobalPlotProvider.java
@@ -23,9 +23,9 @@ import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.plot.world.PlotAreaManager;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 
 class GlobalPlotProvider implements PlotProvider {
 
@@ -37,7 +37,7 @@ class GlobalPlotProvider implements PlotProvider {
 
     @Override
     public Collection<Plot> getPlots() {
-        final Set<Plot> plots = new HashSet<>();
+        final List<Plot> plots = new ArrayList<>();
         for (final PlotArea plotArea : this.plotAreaManager.getAllPlotAreas()) {
             plots.addAll(plotArea.getPlots());
         }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

This fixes issues with extremly slow `/plot home` command usages when having many plots and large merged plots.
The `/plot home` command requires to check for every existing plot whether the player is an owner, means the caches were recalculated for almost every plot.

There are also less significant but not insignificant performance improvements by using an ArrayList instead of a HashSet to collect all the plots (we do not have duplicates there anyways) and using getOwnerAbs instead of getOwner. getOwner additionally checks the server-plot flag, but we don't need to do that for each connected plot as we do it for the current plot before already, avoiding HashMap lookups.

Note these changes aren't really perfect, in best case we can come up with a solution to query plots from a specific owner more efficiently at some point, without having to go through all plots.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
