### PR TITLE
PS-3908: Cleanup deprecated methods to improve code maturity.

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Area.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Area.java
@@ -56,6 +56,7 @@ import com.plotsquared.core.util.TabCompletions;
 import com.plotsquared.core.util.WorldUtil;
 import com.plotsquared.core.util.task.RunnableVal3;
 import com.sk89q.worldedit.EditSession;
+import com.sk89q.worldedit.EditSessionBuilder;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.entity.Player;
@@ -228,12 +229,14 @@ public class Area extends SubCommand {
                 try (final ClipboardWriter clipboardWriter = BuiltInClipboardFormat.SPONGE_SCHEMATIC.getWriter(new FileOutputStream(
                         file))) {
                     final BlockArrayClipboard clipboard = new BlockArrayClipboard(selectedRegion);
-                    final EditSession editSession = WorldEdit
-                            .getInstance()
-                            .getEditSessionFactory()
-                            .getEditSession(selectedRegion.getWorld(), -1);
+
+                    EditSessionBuilder editSessionBuilder = WorldEdit.getInstance().newEditSessionBuilder();
+                    editSessionBuilder.world(selectedRegion.getWorld());
+                    final EditSession editSession = editSessionBuilder.build();
+
                     final ForwardExtentCopy forwardExtentCopy =
                             new ForwardExtentCopy(editSession, selectedRegion, clipboard, selectedRegion.getMinimumPoint());
+
                     forwardExtentCopy.setCopyingBiomes(true);
                     forwardExtentCopy.setCopyingEntities(true);
                     Operations.complete(forwardExtentCopy);

--- a/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
@@ -204,7 +204,7 @@ public class HybridPlotWorld extends ClassicPlotWorld {
                 }
                 Object value;
                 try {
-                    final boolean accessible = field.isAccessible();
+                    final boolean accessible = field.canAccess(field);
                     field.setAccessible(true);
                     value = field.get(this);
                     field.setAccessible(accessible);


### PR DESCRIPTION
## Overview
https://github.com/IntellectualSites/PlotSquared/issues/3908

Fixes #3908 
- Deprecated `isAccessible` and `getEditSessionFactory()`

## Description
Removes the deprecations and updates to the newer `editSessionBuilder` and `canAccess(...)`

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
