### PR TITLE
Don't fire 'PlotUnlinkEvent' twice on plot clear

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Clear.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Clear.java
@@ -106,7 +106,6 @@ public class Clear extends Command {
             BackupManager.backup(player, plot, () -> {
                 final long start = System.currentTimeMillis();
                 boolean result = plot.getPlotModificationManager().clear(true, false, player, () -> {
-                    plot.getPlotModificationManager().unlink();
                     TaskManager.runTask(() -> {
                         plot.removeRunning();
                         // If the state changes, then mark it as no longer done


### PR DESCRIPTION
PlotModificationManager#clear() already fires PlotUnlinkEvent, either stating clear or delete as reason.