### PR TITLE
Fix custom biome error when a plot is cleared

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/util/SchematicHandler.java
+++ b/Core/src/main/java/com/plotsquared/core/util/SchematicHandler.java
@@ -62,6 +62,7 @@ import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionIntersection;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.biome.BiomeType;
+import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import org.apache.logging.log4j.LogManager;
@@ -771,6 +772,10 @@ public abstract class SchematicHandler {
                                     }
                                     BlockVector2 pt = BlockVector2.at(currentX, currentZ);
                                     BiomeType biome = aabb.getWorld().getBiome(pt);
+                                    // Replace empty biome with plains
+                                    if(biome == null) {
+                                        biome = BiomeTypes.PLAINS;
+                                    }
                                     String biomeStr = biome.getId();
                                     int biomeId;
                                     if (biomePalette.containsKey(biomeStr)) {


### PR DESCRIPTION
## Overview

Fixes #4012

## Description
One of my plugins are register custom biomes. But PS have some trouble to clean that from a plot

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
