### PR TITLE
Fix `/plot area create <name>` without passing a specific terrain type

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/setup/PlotAreaBuilder.java
+++ b/Core/src/main/java/com/plotsquared/core/setup/PlotAreaBuilder.java
@@ -25,11 +25,17 @@ import com.plotsquared.core.plot.PlotAreaTerrainType;
 import com.plotsquared.core.plot.PlotAreaType;
 import com.plotsquared.core.plot.PlotId;
 import com.plotsquared.core.util.SetupUtils;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
 
 public class PlotAreaBuilder {
 
     private String generatorName;
     private String plotManager;
+    @Nullable
     private PlotAreaType plotAreaType;
     private PlotAreaTerrainType terrainType;
     private String worldName;
@@ -85,8 +91,10 @@ public class PlotAreaBuilder {
         return this.plotManager;
     }
 
+    @NotNull
+    @Contract(" -> !null")
     public PlotAreaType plotAreaType() {
-        return this.plotAreaType;
+        return Objects.requireNonNullElse(this.plotAreaType, PlotAreaType.NORMAL);
     }
 
     public PlotAreaTerrainType terrainType() {
@@ -127,7 +135,8 @@ public class PlotAreaBuilder {
         return this;
     }
 
-    public PlotAreaBuilder plotAreaType(PlotAreaType plotAreaType) {
+    public PlotAreaBuilder plotAreaType(@NotNull PlotAreaType plotAreaType) {
+        Objects.requireNonNull(plotAreaType, "PlotAreaType must not be null");
         this.plotAreaType = plotAreaType;
         return this;
     }


### PR DESCRIPTION
## Overview
Fixes #3023

## Description
Ensures that PlotAreaBuilder#plotAreaType always returns a non-null values as for further worldgeneration null values will ultimately fail.
The PlotAreaType is not set if not passed as a modifier by the user on `/plot area create <name> type=normal`.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
