### PR TITLE
Add a meta to hold current process of plot merge

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -341,7 +341,7 @@ public class BlockEventListener implements Listener {
             return;
         }
         Plot plot = area.getPlot(location);
-        if (plot != null) {
+        if (plot != null && !plot.isMerging()) {
             BukkitPlayer plotPlayer = BukkitUtil.adapt(player);
             // == rather than <= as we only care about the "ground level" not being destroyed
             if (event.getBlock().getY() == area.getMinGenHeight()) {

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -1245,6 +1245,32 @@ public class Plot {
     }
 
     /**
+     * Sets the plot into merging process
+     */
+    public void setMerging() {
+        for (Plot plot : this.getConnectedPlots()) {
+            plot.setMeta("merging", true);
+        }
+    }
+
+    /**
+     * @return the current state of merging process
+     */
+    public Boolean isMerging() {
+        Boolean value = (Boolean) this.getMeta("merging");
+        return value != null && value;
+    }
+
+    /**
+     * Removes the merging process
+     */
+    public void removeMerging() {
+        for (Plot plot : this.getConnectedPlots()) {
+            plot.deleteMeta("merging");
+        }
+    }
+
+    /**
      * Decrement the number of tracked tasks this plot is running<br>
      * - Used to track/limit the number of things a player can do on the plot at once
      *

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
@@ -582,6 +582,8 @@ public final class PlotModificationManager {
                 Plot other = current.getRelative(Direction.NORTH);
                 if (other != null && other.isOwner(uuid) && (other.getBasePlot(false).equals(current.getBasePlot(false))
                         || (plots = other.getConnectedPlots()).size() <= max && frontier.addAll(plots) && (max -= plots.size()) != -1)) {
+                    current.setMerging();
+                    other.setMerging();
                     current.mergePlot(other, removeRoads, queue);
                     merged.add(current.getId());
                     merged.add(other.getId());
@@ -593,12 +595,16 @@ public final class PlotModificationManager {
                         ids.add(other.getId());
                         this.plot.getManager().finishPlotMerge(ids, queue);
                     }
+                    current.removeMerging();
+                    other.removeMerging();
                 }
             }
             if (max >= 0 && (dir == Direction.ALL || dir == Direction.EAST) && !current.isMerged(Direction.EAST)) {
                 Plot other = current.getRelative(Direction.EAST);
                 if (other != null && other.isOwner(uuid) && (other.getBasePlot(false).equals(current.getBasePlot(false))
                         || (plots = other.getConnectedPlots()).size() <= max && frontier.addAll(plots) && (max -= plots.size()) != -1)) {
+                    current.setMerging();
+                    other.setMerging();
                     current.mergePlot(other, removeRoads, queue);
                     merged.add(current.getId());
                     merged.add(other.getId());
@@ -610,12 +616,16 @@ public final class PlotModificationManager {
                         ids.add(other.getId());
                         this.plot.getManager().finishPlotMerge(ids, queue);
                     }
+                    current.removeMerging();
+                    other.removeMerging();
                 }
             }
             if (max >= 0 && (dir == Direction.ALL || dir == Direction.SOUTH) && !current.isMerged(Direction.SOUTH)) {
                 Plot other = current.getRelative(Direction.SOUTH);
                 if (other != null && other.isOwner(uuid) && (other.getBasePlot(false).equals(current.getBasePlot(false))
                         || (plots = other.getConnectedPlots()).size() <= max && frontier.addAll(plots) && (max -= plots.size()) != -1)) {
+                    current.setMerging();
+                    other.setMerging();
                     current.mergePlot(other, removeRoads, queue);
                     merged.add(current.getId());
                     merged.add(other.getId());
@@ -627,12 +637,16 @@ public final class PlotModificationManager {
                         ids.add(other.getId());
                         this.plot.getManager().finishPlotMerge(ids, queue);
                     }
+                    current.removeMerging();
+                    other.removeMerging();
                 }
             }
             if (max >= 0 && (dir == Direction.ALL || dir == Direction.WEST) && !current.isMerged(Direction.WEST)) {
                 Plot other = current.getRelative(Direction.WEST);
                 if (other != null && other.isOwner(uuid) && (other.getBasePlot(false).equals(current.getBasePlot(false))
                         || (plots = other.getConnectedPlots()).size() <= max && frontier.addAll(plots) && (max -= plots.size()) != -1)) {
+                    current.setMerging();
+                    other.setMerging();
                     current.mergePlot(other, removeRoads, queue);
                     merged.add(current.getId());
                     merged.add(other.getId());
@@ -644,6 +658,8 @@ public final class PlotModificationManager {
                         ids.add(other.getId());
                         this.plot.getManager().finishPlotMerge(ids, queue);
                     }
+                    current.removeMerging();
+                    other.removeMerging();
                 }
             }
         }


### PR DESCRIPTION
## Overview
Fixes #3056

## Description
Fixes the current duping problem when plots are merged in survival. 

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
