### PR TITLE
Fix plot done success flag being false when complexity is higher than…

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Done.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Done.java
@@ -103,7 +103,7 @@ public class Done extends SubCommand {
                 public void run(PlotAnalysis value) {
                     plot.removeRunning();
                     boolean result =
-                            value.getComplexity(doneRequirements) <= doneRequirements.THRESHOLD;
+                            value.getComplexity(doneRequirements) >= doneRequirements.THRESHOLD;
                     finish(plot, player, result);
                 }
             });


### PR DESCRIPTION
… the threshold

## Overview
Partial fix for #4039 

## Description
This simple fix is to fix the condition. Allows at least other plugins to load their own settings. Partial fix as settings also need to be loaded into `Settings.AUTO_CLEAR` from the config, either new or clone of the `auto-clear.task1`. I guess that part needs discussing.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
