### PR TITLE
Update top level group Id

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
     id("xyz.jpenilla.run-paper") version "2.1.0"
 }
 
-group = "com.plotsquared"
+group = "com.intellectualsites.plotsquared"
 version = "7.0.0-SNAPSHOT"
 
 if (!File("$rootDir/.git").exists()) {


### PR DESCRIPTION
For v7, I propose to change the top-level group Id, given we don't operate plotsquared.com, which is a hosting requirement for the central repository.
Existing packages remain as is.

TODO:
- [x] Freeze deployments from the default branch
- [x] Create a new staging repository within the central repository: [OSSRH-92186](https://issues.sonatype.org/browse/OSSRH-92186)
  - [x] Add the [common](https://github.com/IntellectualSites/IntellectualSites/blob/main/docs/releases/central-repository-profiles.md#release-permission) users to manage the profile: [OSSRH-92189](https://issues.sonatype.org/browse/OSSRH-92189)
- [x] Detach `com.plotsquared` from this repository on the central repository's backend.