### PR TITLE
Update top level group id and lowercaswe artifact names

### DIFF
--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    api(projects.plotSquaredCore)
+    api(projects.plotsquaredCore)
 
     // Metrics
     implementation("org.bstats:bstats-bukkit")
@@ -62,7 +62,7 @@ tasks.processResources {
 }
 
 tasks.named<ShadowJar>("shadowJar") {
-    dependsOn(":PlotSquared-Core:shadowJar")
+    dependsOn(":plotsquared-core:shadowJar")
     dependencies {
         exclude(dependency("org.checkerframework:"))
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -210,7 +210,7 @@ subprojects {
 }
 
 nexusPublishing {
-    repositories {
+    this.repositories {
         sonatype {
             nexusUrl.set(URI.create("https://s01.oss.sonatype.org/service/local/"))
             snapshotRepositoryUrl.set(URI.create("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
@@ -227,7 +227,7 @@ tasks {
     supportedVersions.forEach {
         register<RunServer>("runServer-$it") {
             minecraftVersion(it)
-            pluginJars(*project(":PlotSquared-Bukkit").getTasksByName("shadowJar", false).map { (it as Jar).archiveFile }
+            pluginJars(*project(":plotsquared-bukkit").getTasksByName("shadowJar", false).map { (it as Jar).archiveFile }
                     .toTypedArray())
             jvmArgs("-DPaper.IgnoreJavaVersion=true", "-Dcom.mojang.eula.agree=true")
             group = "run paper"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
     id("xyz.jpenilla.run-paper") version "2.1.0"
 }
 
-group = "com.plotsquared"
+group = "com.intellectualsites.plotsquared"
 version = "7.0.0-SNAPSHOT"
 
 if (!File("$rootDir/.git").exists()) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,7 @@ rootProject.name = "PlotSquared"
 
 include("Core", "Bukkit")
 
-project(":Core").name = "PlotSquared-Core"
-project(":Bukkit").name = "PlotSquared-Bukkit"
+project(":Core").name = "plotsquared-core"
+project(":Bukkit").name = "plotsquared-bukkit"
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
Successor of https://github.com/IntellectualSites/PlotSquared/pull/4055 with lowercased artifact names, to comply with the maven standards.

Changing the folder name of the "Bukkit" and "Core" module is undesired at this time.