### PR TITLE
Properly drop unsupported biomes from biome list

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/generator/BukkitPlotGenerator.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/generator/BukkitPlotGenerator.java
@@ -53,7 +53,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class BukkitPlotGenerator extends ChunkGenerator implements GeneratorWrapper<ChunkGenerator> {
 
@@ -439,7 +438,8 @@ public class BukkitPlotGenerator extends ChunkGenerator implements GeneratorWrap
         static {
             BIOMES = Arrays.stream(Biome.values())
                     .filter(b -> Registry.BIOME.get(b.getKey()) != null)
-                    .collect(Collectors.toList());
+                    .filter(b -> b != Biome.CUSTOM)
+                    .toList();
         }
 
         @Override

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/generator/BukkitPlotGenerator.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/generator/BukkitPlotGenerator.java
@@ -37,6 +37,7 @@ import com.sk89q.worldedit.math.BlockVector2;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.HeightMap;
+import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.World;
 import org.bukkit.block.Biome;
@@ -50,9 +51,12 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+
+import static java.util.function.Predicate.not;
 
 public class BukkitPlotGenerator extends ChunkGenerator implements GeneratorWrapper<ChunkGenerator> {
 
@@ -436,9 +440,15 @@ public class BukkitPlotGenerator extends ChunkGenerator implements GeneratorWrap
         private static final List<Biome> BIOMES;
 
         static {
+            Set<Biome> disabledBiomes = EnumSet.of(Biome.CUSTOM);
+            if (PlotSquared.platform().serverVersion()[1] <= 19) {
+                final Biome cherryGrove = Registry.BIOME.get(NamespacedKey.minecraft("cherry_grove"));
+                if (cherryGrove != null) {
+                    disabledBiomes.add(cherryGrove);
+                }
+            }
             BIOMES = Arrays.stream(Biome.values())
-                    .filter(b -> Registry.BIOME.get(b.getKey()) != null)
-                    .filter(b -> b != Biome.CUSTOM)
+                    .filter(not(disabledBiomes::contains))
                     .toList();
         }
 


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #4066

## Description
<!-- Please describe what this pull request does. -->

We need to remove CUSTOM generally and cherry_grove on pre 1.20 versions.

Tested on 1.20 and 1.19.4.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
