### PR TITLE
Strip legacy color codes if message cannot be parsed by MiniMessage

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/CaptionUtility.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/CaptionUtility.java
@@ -28,15 +28,19 @@ import com.plotsquared.core.plot.flag.implementations.PlotTitleFlag;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.ParsingException;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static com.plotsquared.core.configuration.caption.ComponentTransform.nested;
 import static com.plotsquared.core.configuration.caption.ComponentTransform.stripClicks;
 
 public class CaptionUtility {
+
+    private static final Pattern LEGACY_FORMATTING = Pattern.compile("§[a-gklmnor0-9]");
 
     // flags which values are parsed by minimessage
     private static final Set<Class<? extends PlotFlag<?, ?>>> MINI_MESSAGE_FLAGS = Set.of(
@@ -100,7 +104,14 @@ public class CaptionUtility {
      */
     public static String stripClickEvents(final @NonNull String miniMessageString) {
         // parse, transform and serialize again
-        Component component = MiniMessage.miniMessage().deserialize(miniMessageString);
+        Component component;
+        try {
+            component = MiniMessage.miniMessage().deserialize(miniMessageString);
+        } catch (ParsingException e) {
+            // if the String cannot be parsed, we try stripping legacy colors
+            String legacyStripped = LEGACY_FORMATTING.matcher(miniMessageString).replaceAll("");
+            component = MiniMessage.miniMessage().deserialize(legacyStripped);
+        }
         component = CLICK_STRIP_TRANSFORM.transform(component);
         return MiniMessage.miniMessage().serialize(component);
     }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #4076

## Description
<!-- Please describe what this pull request does. -->

Legacy color codes shouldn't be a common case, so stripping them only on exceptions is reasonable in my opinion.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
