### PR TITLE
Fix: remove everyone command

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Remove.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Remove.java
@@ -100,15 +100,17 @@ public class Remove extends SubCommand {
                             count++;
                         }
                     } else if (uuid == DBFunc.EVERYONE) {
+                        count += plot.getTrusted().size();
                         if (plot.removeTrusted(uuid)) {
                             this.eventDispatcher.callTrusted(player, plot, uuid, false);
-                            count++;
-                        } else if (plot.removeMember(uuid)) {
+                        }
+                        count += plot.getMembers().size();
+                        if (plot.removeMember(uuid)) {
                             this.eventDispatcher.callMember(player, plot, uuid, false);
-                            count++;
-                        } else if (plot.removeDenied(uuid)) {
+                        }
+                        count += plot.getDenied().size();
+                        if (plot.removeDenied(uuid)) {
                             this.eventDispatcher.callDenied(player, plot, uuid, false);
-                            count++;
                         }
                     }
                 }


### PR DESCRIPTION
## Overview
With this PR the Remove command is fixed. When using `/p remove *` now really every player who is geadded / trusted / denied will be removed from the plot.

## Description
Revised the delete process for EVERYONE so that all trusted / added / denied players are processed. In addition, the counting of the removed players has been adjusted.

```[tasklist]
### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
