### PR TITLE
Fix default flags registration for third parties

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
@@ -180,8 +180,7 @@ public abstract class PlotArea implements ComponentLike {
         this.worldConfiguration = worldConfiguration;
     }
 
-    private static Collection<PlotFlag<?, ?>> parseFlags(List<String> flagStrings) {
-        final Collection<PlotFlag<?, ?>> flags = new ArrayList<>();
+    private static void parseFlags(FlagContainer flagContainer, List<String> flagStrings) {
         for (final String key : flagStrings) {
             final String[] split;
             if (key.contains(";")) {
@@ -193,7 +192,7 @@ public abstract class PlotArea implements ComponentLike {
                     GlobalFlagContainer.getInstance().getFlagFromString(split[0]);
             if (flagInstance != null) {
                 try {
-                    flags.add(flagInstance.parse(split[1]));
+                    flagContainer.addFlag(flagInstance.parse(split[1]));
                 } catch (final FlagParseException e) {
                     LOGGER.warn(
                             "Failed to parse default flag with key '{}' and value '{}'. "
@@ -204,9 +203,10 @@ public abstract class PlotArea implements ComponentLike {
                     );
                     e.printStackTrace();
                 }
+            } else {
+                flagContainer.addUnknownFlag(split[0], split[1]);
             }
         }
-        return flags;
     }
 
     @NonNull
@@ -405,7 +405,7 @@ public abstract class PlotArea implements ComponentLike {
                 }
             }
         }
-        this.getFlagContainer().addAll(parseFlags(flags));
+        parseFlags(this.getFlagContainer(), flags);
         ConsolePlayer.getConsole().sendMessage(
                 TranslatableCaption.of("flags.area_flags"),
                 TagResolver.resolver("flags", Tag.inserting(Component.text(flags.toString())))
@@ -427,7 +427,7 @@ public abstract class PlotArea implements ComponentLike {
             }
         }
         this.roadFlags = roadflags.size() > 0;
-        this.getRoadFlagContainer().addAll(parseFlags(roadflags));
+        parseFlags(this.getRoadFlagContainer(), roadflags);
         ConsolePlayer.getConsole().sendMessage(
                 TranslatableCaption.of("flags.road_flags"),
                 TagResolver.resolver("flags", Tag.inserting(Component.text(roadflags.toString())))


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->
Fixes default flags registration from addons, which are registered after the default flags are loaded from the PS configuration.

Fixes https://github.com/IntellectualSites/plothider/issues/124

## Description
<!-- Please describe what this pull request does. -->
- Register default flags as unknown flags to handle addons that add their flags later in the process.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
