### PR TITLE
Update api.spigotmc.org from 0.1 to 0.2

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/UpdateUtility.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/UpdateUtility.java
@@ -60,7 +60,7 @@ public class UpdateUtility implements Listener {
         task = Bukkit.getScheduler().runTaskTimerAsynchronously(this.javaPlugin, () -> {
             try {
                 HttpsURLConnection connection = (HttpsURLConnection) new URL(
-                        "https://api.spigotmc.org/simple/0.1/index.php?action=getResource&id=77506")
+                        "https://api.spigotmc.org/simple/0.2/index.php?action=getResource&id=77506")
                         .openConnection();
                 connection.setRequestMethod("GET");
                 JsonObject result = new JsonParser()


### PR DESCRIPTION
https://github.com/SpigotMC/XenforoResourceManagerAPI has been updated from 0.1 to 0.2 adding more options.

While we don't use these options, consuming and up-to-date API doesn't hurt and is preferred over outdated things.

I could verify interactively, that 0.2 returns the same results as 0.1:

![Screenshot 2023-09-17 at 17 17 24](https://github.com/IntellectualSites/PlotSquared/assets/13383509/82ff09e4-eee7-4eb4-9fa0-753696036462)