### PR TITLE
Fix `#isAccessible()` deprecation in `HybridPlotWorld`

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
@@ -189,7 +189,7 @@ public class HybridPlotWorld extends ClassicPlotWorld {
                 }
                 Object value;
                 try {
-                    final boolean accessible = field.isAccessible();
+                    final boolean accessible = field.canAccess(this);
                     field.setAccessible(true);
                     value = field.get(this);
                     field.setAccessible(accessible);


### PR DESCRIPTION
- Fixes https://github.com/IntellectualSites/PlotSquared/issues/4165

## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #4165 

## Description
Fix `#isAccessible()` deprecation in `HybridPlotWorld`

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
