### PR TITLE
Address deprecated 'Project.buildDir' in build scripts

### DIFF
--- a/Core/build.gradle.kts
+++ b/Core/build.gradle.kts
@@ -57,8 +57,8 @@ tasks.processResources {
 
     doLast {
         copy {
-            from(File("$rootDir/LICENSE"))
-            into("$buildDir/resources/main/")
+            from(layout.buildDirectory.file("$rootDir/LICENSE"))
+            into(layout.buildDirectory.dir("resources/main"))
         }
     }
 }


### PR DESCRIPTION
Deprecated since Gradle 8.3