### PR TITLE
Migrate 'EntityUtil#capNumeral' to an enhanced switch

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/util/EntityUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/EntityUtil.java
@@ -42,7 +42,7 @@ public class EntityUtil {
     }
 
     private static int capNumeral(final @NonNull String flagName) {
-        int i = switch (flagName) {
+        return switch (flagName) {
             case "mob-cap" -> CAP_MOB;
             case "hostile-cap" -> CAP_MONSTER;
             case "animal-cap" -> CAP_ANIMAL;
@@ -50,7 +50,6 @@ public class EntityUtil {
             case "misc-cap" -> CAP_MISC;
             default -> CAP_ENTITY;
         };
-        return i;
     }
 
     @SuppressWarnings("unchecked")

--- a/Core/src/main/java/com/plotsquared/core/util/EntityUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/EntityUtil.java
@@ -42,27 +42,14 @@ public class EntityUtil {
     }
 
     private static int capNumeral(final @NonNull String flagName) {
-        int i;
-        switch (flagName) {
-            case "mob-cap":
-                i = CAP_MOB;
-                break;
-            case "hostile-cap":
-                i = CAP_MONSTER;
-                break;
-            case "animal-cap":
-                i = CAP_ANIMAL;
-                break;
-            case "vehicle-cap":
-                i = CAP_VEHICLE;
-                break;
-            case "misc-cap":
-                i = CAP_MISC;
-                break;
-            case "entity-cap":
-            default:
-                i = CAP_ENTITY;
-        }
+        int i = switch (flagName) {
+            case "mob-cap" -> CAP_MOB;
+            case "hostile-cap" -> CAP_MONSTER;
+            case "animal-cap" -> CAP_ANIMAL;
+            case "vehicle-cap" -> CAP_VEHICLE;
+            case "misc-cap" -> CAP_MISC;
+            default -> CAP_ENTITY;
+        };
         return i;
     }
 


### PR DESCRIPTION
This must have been missed when cleaning up for v7, because all other switches follow this pattern.