### PR TITLE
Feat(API): Mutable Location in PlayerTeleportToPlotEvent

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/events/PlayerTeleportToPlotEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlayerTeleportToPlotEvent.java
@@ -21,10 +21,7 @@ package com.plotsquared.core.events;
 import com.plotsquared.core.location.Location;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.Objects;
-import java.util.function.Consumer;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Called when a player teleports to a plot
@@ -34,23 +31,21 @@ public class PlayerTeleportToPlotEvent extends PlotPlayerEvent implements Cancel
     private final TeleportCause cause;
     private Result eventResult;
     private final Location from;
-    private Location location;
+    private LocationTransformer locationTransformer;
 
 
     /**
      * PlayerTeleportToPlotEvent: Called when a player teleports to a plot
      *
-     * @param player   That was teleported
-     * @param from     The origin location, from where the teleport was triggered (players location most likely)
-     * @param location The initial location where the player will be teleported to
-     * @param plot     Plot to which the player was teleported
-     * @param cause    Why the teleport is being completed
+     * @param player That was teleported
+     * @param from   The origin location, from where the teleport was triggered (players location most likely)
+     * @param plot   Plot to which the player was teleported
+     * @param cause  Why the teleport is being completed
      * @since 6.1.0
      */
-    public PlayerTeleportToPlotEvent(PlotPlayer<?> player, Location from, Location location, Plot plot, TeleportCause cause) {
+    public PlayerTeleportToPlotEvent(PlotPlayer<?> player, Location from, Plot plot, TeleportCause cause) {
         super(player, plot);
         this.from = from;
-        this.location = location;
         this.cause = cause;
     }
 
@@ -75,26 +70,24 @@ public class PlayerTeleportToPlotEvent extends PlotPlayerEvent implements Cancel
     }
 
     /**
-     * Get the current location where the player will be teleported to.
-     * Defaults to {@link Plot#getHome(Consumer)} or {@link Plot#getDefaultHome(boolean, Consumer)}
+     * Gets the currently applied {@link LocationTransformer} or null, if none was set
      *
-     * @return Location
+     * @return LocationTransformer
      * @since TODO
      */
-    public Location getLocation() {
-        return this.location;
+    public @Nullable LocationTransformer getLocationTransformer() {
+        return this.locationTransformer;
     }
 
     /**
-     * Set the new location where the player should be teleported to.
-     * <b>Must</b> be not-null. If your intention is to cancel this teleport, see {@link #setEventResult(Result)}
-     * @param location The new location
+     * Sets the {@link LocationTransformer} to mutate the location where the player will be teleported to.
+     * May be {@code null}, if any previous set transformations should be discarded.
+     *
+     * @param locationTransformer The new transformer
      * @since TODO
      */
-    public void setLocation(@NotNull Location location) {
-        Objects.requireNonNull(location, "PlayerTeleportToPlotEvent#location may never be null. " +
-                "If you intend to cancel the teleport, use PlayerTeleportToPlotEvent#setEventResult");
-        this.location = location;
+    public void setLocationTransformer(@Nullable LocationTransformer locationTransformer) {
+        this.locationTransformer = locationTransformer;
     }
 
     @Override
@@ -105,6 +98,19 @@ public class PlayerTeleportToPlotEvent extends PlotPlayerEvent implements Cancel
     @Override
     public void setEventResult(Result e) {
         this.eventResult = e;
+    }
+
+    public interface LocationTransformer {
+
+        /**
+         * Transforms an input location {@code origin} to a new location
+         *
+         * @param origin The origin location which should be transformed
+         * @return The transformed location
+         * @since TODO
+         */
+        Location transform(Location origin);
+
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/events/PlayerTeleportToPlotEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlayerTeleportToPlotEvent.java
@@ -23,6 +23,8 @@ import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.function.UnaryOperator;
+
 /**
  * Called when a player teleports to a plot
  */
@@ -31,7 +33,7 @@ public class PlayerTeleportToPlotEvent extends PlotPlayerEvent implements Cancel
     private final TeleportCause cause;
     private Result eventResult;
     private final Location from;
-    private LocationTransformer locationTransformer;
+    private UnaryOperator<Location> locationTransformer;
 
 
     /**
@@ -70,23 +72,23 @@ public class PlayerTeleportToPlotEvent extends PlotPlayerEvent implements Cancel
     }
 
     /**
-     * Gets the currently applied {@link LocationTransformer} or null, if none was set
+     * Gets the currently applied {@link UnaryOperator<Location> transformer} or null, if none was set
      *
      * @return LocationTransformer
      * @since TODO
      */
-    public @Nullable LocationTransformer getLocationTransformer() {
+    public @Nullable UnaryOperator<Location> getLocationTransformer() {
         return this.locationTransformer;
     }
 
     /**
-     * Sets the {@link LocationTransformer} to mutate the location where the player will be teleported to.
+     * Sets the {@link UnaryOperator<Location> transformer} to mutate the location where the player will be teleported to.
      * May be {@code null}, if any previous set transformations should be discarded.
      *
      * @param locationTransformer The new transformer
      * @since TODO
      */
-    public void setLocationTransformer(@Nullable LocationTransformer locationTransformer) {
+    public void setLocationTransformer(@Nullable UnaryOperator<Location> locationTransformer) {
         this.locationTransformer = locationTransformer;
     }
 
@@ -98,19 +100,6 @@ public class PlayerTeleportToPlotEvent extends PlotPlayerEvent implements Cancel
     @Override
     public void setEventResult(Result e) {
         this.eventResult = e;
-    }
-
-    public interface LocationTransformer {
-
-        /**
-         * Transforms an input location {@code origin} to a new location
-         *
-         * @param origin The origin location which should be transformed
-         * @return The transformed location
-         * @since TODO
-         */
-        Location transform(Location origin);
-
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/events/PlayerTeleportToPlotEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlayerTeleportToPlotEvent.java
@@ -21,28 +21,36 @@ package com.plotsquared.core.events;
 import com.plotsquared.core.location.Location;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  * Called when a player teleports to a plot
  */
 public class PlayerTeleportToPlotEvent extends PlotPlayerEvent implements CancellablePlotEvent {
 
-    private final Location from;
     private final TeleportCause cause;
     private Result eventResult;
+    private final Location from;
+    private Location location;
+
 
     /**
      * PlayerTeleportToPlotEvent: Called when a player teleports to a plot
      *
-     * @param player That was teleported
-     * @param from   Start location
-     * @param plot   Plot to which the player was teleported
-     * @param cause  Why the teleport is being completed
+     * @param player   That was teleported
+     * @param from     The origin location, from where the teleport was triggered (players location most likely)
+     * @param location The initial location where the player will be teleported to
+     * @param plot     Plot to which the player was teleported
+     * @param cause    Why the teleport is being completed
      * @since 6.1.0
      */
-    public PlayerTeleportToPlotEvent(PlotPlayer<?> player, Location from, Plot plot, TeleportCause cause) {
+    public PlayerTeleportToPlotEvent(PlotPlayer<?> player, Location from, Location location, Plot plot, TeleportCause cause) {
         super(player, plot);
         this.from = from;
+        this.location = location;
         this.cause = cause;
     }
 
@@ -57,12 +65,36 @@ public class PlayerTeleportToPlotEvent extends PlotPlayerEvent implements Cancel
     }
 
     /**
-     * Get the from location
+     * Get the location, from where the teleport was triggered
+     * (the players current location when executing the home command for example)
      *
      * @return Location
      */
     public Location getFrom() {
         return this.from;
+    }
+
+    /**
+     * Get the current location where the player will be teleported to.
+     * Defaults to {@link Plot#getHome(Consumer)} or {@link Plot#getDefaultHome(boolean, Consumer)}
+     *
+     * @return Location
+     * @since TODO
+     */
+    public Location getLocation() {
+        return this.location;
+    }
+
+    /**
+     * Set the new location where the player should be teleported to.
+     * <b>Must</b> be not-null. If your intention is to cancel this teleport, see {@link #setEventResult(Result)}
+     * @param location The new location
+     * @since TODO
+     */
+    public void setLocation(@NotNull Location location) {
+        Objects.requireNonNull(location, "PlayerTeleportToPlotEvent#location may never be null. " +
+                "If you intend to cancel the teleport, use PlayerTeleportToPlotEvent#setEventResult");
+        this.location = location;
     }
 
     @Override

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -2627,8 +2627,8 @@ public class Plot {
         }
 
         final Consumer<Location> locationConsumer = calculatedLocation -> {
-            Location location = event.getLocationTransformer() == null ?
-                    calculatedLocation : event.getLocationTransformer().transform(calculatedLocation);
+            Location location = event.getLocationTransformer() == null ? calculatedLocation :
+                    Objects.requireNonNullElse(event.getLocationTransformer().apply(calculatedLocation), calculatedLocation);
             if (Settings.Teleport.DELAY == 0 || player.hasPermission("plots.teleport.delay.bypass")) {
                 player.sendMessage(TranslatableCaption.of("teleport.teleported_to_plot"));
                 player.teleport(location, cause);

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -2615,17 +2615,20 @@ public class Plot {
      */
     public void teleportPlayer(final PlotPlayer<?> player, TeleportCause cause, Consumer<Boolean> resultConsumer) {
         Plot plot = this.getBasePlot(false);
+
+        PlayerTeleportToPlotEvent event = this.eventDispatcher.callTeleport(player, player.getLocation(), plot, cause);
+        if (event.getEventResult() == Result.DENY) {
+            player.sendMessage(
+                    TranslatableCaption.of("events.event_denied"),
+                    TagResolver.resolver("value", Tag.inserting(Component.text("Teleport")))
+            );
+            resultConsumer.accept(false);
+            return;
+        }
+
         final Consumer<Location> locationConsumer = calculatedLocation -> {
-            PlayerTeleportToPlotEvent event = this.eventDispatcher.callTeleport(player, player.getLocation(), calculatedLocation, plot, cause);
-            if (event.getEventResult() == Result.DENY) {
-                player.sendMessage(
-                        TranslatableCaption.of("events.event_denied"),
-                        TagResolver.resolver("value", Tag.inserting(Component.text("Teleport")))
-                );
-                resultConsumer.accept(false);
-                return;
-            }
-            Location location = event.getLocation();
+            Location location = event.getLocationTransformer() == null ?
+                    calculatedLocation : event.getLocationTransformer().transform(calculatedLocation);
             if (Settings.Teleport.DELAY == 0 || player.hasPermission("plots.teleport.delay.bypass")) {
                 player.sendMessage(TranslatableCaption.of("teleport.teleported_to_plot"));
                 player.teleport(location, cause);

--- a/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
+++ b/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
@@ -158,9 +158,8 @@ public class EventDispatcher {
         return event;
     }
 
-    public PlayerTeleportToPlotEvent callTeleport(PlotPlayer<?> player, Location from, Location location, Plot plot,
-                                                  TeleportCause cause) {
-        PlayerTeleportToPlotEvent event = new PlayerTeleportToPlotEvent(player, from, location, plot, cause);
+    public PlayerTeleportToPlotEvent callTeleport(PlotPlayer<?> player, Location from, Plot plot, TeleportCause cause) {
+        PlayerTeleportToPlotEvent event = new PlayerTeleportToPlotEvent(player, from, plot, cause);
         callEvent(event);
         return event;
     }

--- a/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
+++ b/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
@@ -158,8 +158,9 @@ public class EventDispatcher {
         return event;
     }
 
-    public PlayerTeleportToPlotEvent callTeleport(PlotPlayer<?> player, Location from, Plot plot, TeleportCause cause) {
-        PlayerTeleportToPlotEvent event = new PlayerTeleportToPlotEvent(player, from, plot, cause);
+    public PlayerTeleportToPlotEvent callTeleport(PlotPlayer<?> player, Location from, Location location, Plot plot,
+                                                  TeleportCause cause) {
+        PlayerTeleportToPlotEvent event = new PlayerTeleportToPlotEvent(player, from, location, plot, cause);
         callEvent(event);
         return event;
     }


### PR DESCRIPTION
## Overview
In case of some more abstract plot layouts (e.g. floating balloons in the sky), the event now provides the ability to set the location for any teleport programmatically. 

Example:
```java
@Subscribe
public void scootRightOver(PlayerTeleportToPlotEvent event) {
    if (event.getCause() == TeleportCause.COMMAND_HOME) {
        event.setLocation(event.getLocation().add(-15, 0, 0));
    }
}
```

I did not deprecate the constructor nor the event dispatcher method itself. Events should not be called by end-users either way. If no location is passed, weird behavior can occur when trying to mutate the original location (which is null in case of those deprecated methods)

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
