### PR TITLE
Fix: No response to errors in plot user group modifications

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Add.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Add.java
@@ -19,6 +19,7 @@
 package com.plotsquared.core.command;
 
 import com.google.inject.Inject;
+import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.configuration.caption.TranslatableCaption;
 import com.plotsquared.core.database.DBFunc;
@@ -101,9 +102,14 @@ public class Add extends Command {
                                 Permission.PERMISSION_ADMIN_COMMAND_TRUST))) {
                             player.sendMessage(
                                     TranslatableCaption.of("errors.invalid_player"),
-                                    TagResolver.resolver("value", Tag.inserting(
-                                            PlayerManager.resolveName(uuid).toComponent(player)
-                                    ))
+                                    PlotSquared
+                                            .platform()
+                                            .playerManager()
+                                            .getUsernameCaption(uuid)
+                                            .thenApply(caption -> TagResolver.resolver(
+                                                    "value",
+                                                    Tag.inserting(caption.toComponent(player))
+                                            ))
                             );
                             iterator.remove();
                             continue;
@@ -111,9 +117,11 @@ public class Add extends Command {
                         if (plot.isOwner(uuid)) {
                             player.sendMessage(
                                     TranslatableCaption.of("member.already_added"),
-                                    TagResolver.resolver("player", Tag.inserting(
-                                            PlayerManager.resolveName(uuid).toComponent(player)
-                                    ))
+                                    PlotSquared.platform().playerManager().getUsernameCaption(uuid)
+                                            .thenApply(caption -> TagResolver.resolver(
+                                                    "player",
+                                                    Tag.inserting(caption.toComponent(player))
+                                            ))
                             );
                             iterator.remove();
                             continue;
@@ -121,9 +129,11 @@ public class Add extends Command {
                         if (plot.getMembers().contains(uuid)) {
                             player.sendMessage(
                                     TranslatableCaption.of("member.already_added"),
-                                    TagResolver.resolver("player", Tag.inserting(
-                                            PlayerManager.resolveName(uuid).toComponent(player)
-                                    ))
+                                    PlotSquared.platform().playerManager().getUsernameCaption(uuid)
+                                            .thenApply(caption -> TagResolver.resolver(
+                                                    "player",
+                                                    Tag.inserting(caption.toComponent(player))
+                                            ))
                             );
                             iterator.remove();
                             continue;

--- a/Core/src/main/java/com/plotsquared/core/command/CommandCategory.java
+++ b/Core/src/main/java/com/plotsquared/core/command/CommandCategory.java
@@ -25,6 +25,7 @@ import com.plotsquared.core.player.PlotPlayer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * CommandCategory.
@@ -82,7 +83,7 @@ public enum CommandCategory implements Caption {
     // TODO this method shouldn't be invoked
     @Deprecated
     @Override
-    public String toString() {
+    public @NotNull String toString() {
         return this.caption.getComponent(LocaleHolder.console());
     }
 
@@ -107,5 +108,6 @@ public enum CommandCategory implements Caption {
     boolean canAccess(PlotPlayer<?> player) {
         return !MainCommand.getInstance().getCommands(this, player).isEmpty();
     }
+
 
 }

--- a/Core/src/main/java/com/plotsquared/core/command/Deny.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Deny.java
@@ -117,10 +117,11 @@ public class Deny extends SubCommand {
                     } else if (plot.getDenied().contains(uuid)) {
                         player.sendMessage(
                                 TranslatableCaption.of("member.already_added"),
-                                TagResolver.resolver(
+                                PlotSquared.platform().playerManager().getUsernameCaption(uuid)
+                                        .thenApply(caption -> TagResolver.resolver(
                                         "player",
-                                        Tag.inserting(PlayerManager.resolveName(uuid).toComponent(player))
-                                )
+                                        Tag.inserting(caption.toComponent(player))
+                                ))
                         );
                         return;
                     } else {

--- a/Core/src/main/java/com/plotsquared/core/command/Owner.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Owner.java
@@ -31,7 +31,6 @@ import com.plotsquared.core.player.PlayerMetaDataKeys;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.util.EventDispatcher;
-import com.plotsquared.core.util.PlayerManager;
 import com.plotsquared.core.util.TabCompletions;
 import com.plotsquared.core.util.task.TaskManager;
 import net.kyori.adventure.text.Component;
@@ -136,10 +135,11 @@ public class Owner extends SetCommand {
             if (plot.isOwner(uuid)) {
                 player.sendMessage(
                         TranslatableCaption.of("member.already_owner"),
-                        TagResolver.resolver(
+                        PlotSquared.platform().playerManager().getUsernameCaption(uuid)
+                                .thenApply(caption -> TagResolver.resolver(
                                 "player",
-                                Tag.inserting(PlayerManager.resolveName(uuid, false).toComponent(player))
-                        )
+                                Tag.inserting(caption.toComponent(player))
+                        ))
                 );
                 return;
             }
@@ -147,10 +147,11 @@ public class Owner extends SetCommand {
                 if (other == null) {
                     player.sendMessage(
                             TranslatableCaption.of("errors.invalid_player_offline"),
-                            TagResolver.resolver(
+                            PlotSquared.platform().playerManager().getUsernameCaption(uuid)
+                                    .thenApply(caption -> TagResolver.resolver(
                                     "player",
-                                    Tag.inserting(PlayerManager.resolveName(uuid).toComponent(player))
-                            )
+                                    Tag.inserting(caption.toComponent(player))
+                            ))
                     );
                     return;
                 }

--- a/Core/src/main/java/com/plotsquared/core/command/Trust.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Trust.java
@@ -19,6 +19,7 @@
 package com.plotsquared.core.command;
 
 import com.google.inject.Inject;
+import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.configuration.caption.TranslatableCaption;
 import com.plotsquared.core.database.DBFunc;
@@ -103,10 +104,11 @@ public class Trust extends Command {
                             player.hasPermission(Permission.PERMISSION_TRUST_EVERYONE) || player.hasPermission(Permission.PERMISSION_ADMIN_COMMAND_TRUST))) {
                         player.sendMessage(
                                 TranslatableCaption.of("errors.invalid_player"),
-                                TagResolver.resolver(
+                                PlotSquared.platform().playerManager().getUsernameCaption(uuid)
+                                        .thenApply(caption -> TagResolver.resolver(
                                         "value",
-                                        Tag.inserting(PlayerManager.resolveName(uuid).toComponent(player))
-                                )
+                                        Tag.inserting(caption.toComponent(player))
+                                ))
                         );
                         iterator.remove();
                         continue;
@@ -114,10 +116,11 @@ public class Trust extends Command {
                     if (currentPlot.isOwner(uuid)) {
                         player.sendMessage(
                                 TranslatableCaption.of("member.already_added"),
-                                TagResolver.resolver(
-                                        "value",
-                                        Tag.inserting(PlayerManager.resolveName(uuid).toComponent(player))
-                                )
+                                PlotSquared.platform().playerManager().getUsernameCaption(uuid)
+                                        .thenApply(caption -> TagResolver.resolver(
+                                        "player",
+                                        Tag.inserting(caption.toComponent(player))
+                                ))
                         );
                         iterator.remove();
                         continue;
@@ -125,10 +128,11 @@ public class Trust extends Command {
                     if (currentPlot.getTrusted().contains(uuid)) {
                         player.sendMessage(
                                 TranslatableCaption.of("member.already_added"),
-                                TagResolver.resolver(
-                                        "value",
-                                        Tag.inserting(PlayerManager.resolveName(uuid).toComponent(player))
-                                )
+                                PlotSquared.platform().playerManager().getUsernameCaption(uuid)
+                                        .thenApply(caption -> TagResolver.resolver(
+                                        "player",
+                                        Tag.inserting(caption.toComponent(player))
+                                ))
                         );
                         iterator.remove();
                         continue;

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/Caption.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/Caption.java
@@ -44,4 +44,6 @@ public interface Caption {
      */
     @NonNull Component toComponent(@NonNull LocaleHolder localeHolder);
 
+    @NonNull String toString();
+
 }

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/StaticCaption.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/StaticCaption.java
@@ -51,4 +51,9 @@ public final class StaticCaption implements Caption {
         return MiniMessage.miniMessage().deserialize(this.value);
     }
 
+    @Override
+    public @NonNull String toString() {
+        return "StaticCaption(" + value + ")";
+    }
+
 }

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/TranslatableCaption.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/TranslatableCaption.java
@@ -25,6 +25,7 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Locale;
 import java.util.regex.Pattern;
@@ -130,6 +131,11 @@ public final class TranslatableCaption implements NamespacedCaption {
     @Override
     public int hashCode() {
         return Objects.hashCode(this.getNamespace(), this.getKey());
+    }
+
+    @Override
+    public @NotNull String toString() {
+        return "TranslatableCaption(" + getNamespace() + ":" + getKey() + ")";
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
+++ b/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
@@ -960,6 +960,7 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
      * @param caption          Caption to send
      * @param asyncReplacement Async variable replacement
      * @return A Future to be resolved, after the message was sent
+     * @since TODO
      */
     public final CompletableFuture<Void> sendMessage(
             @NonNull Caption caption,
@@ -975,6 +976,7 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
      * @param asyncReplacements Async variable replacements
      * @param replacements      Sync variable replacements
      * @return A Future to be resolved, after the message was sent
+     * @since TODO
      */
     public final CompletableFuture<Void> sendMessage(
             @NonNull Caption caption,

--- a/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
+++ b/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
@@ -80,6 +80,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -951,6 +952,52 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
             setMeta("lastMessageTime", System.currentTimeMillis());
             getAudience().sendMessage(component);
         }
+    }
+
+    /**
+     * Sends a message to the command caller, when the future is resolved
+     *
+     * @param caption          Caption to send
+     * @param asyncReplacement Async variable replacement
+     * @return A Future to be resolved, after the message was sent
+     */
+    public final CompletableFuture<Void> sendMessage(
+            @NonNull Caption caption,
+            CompletableFuture<@NonNull TagResolver> asyncReplacement
+    ) {
+        return sendMessage(caption, new CompletableFuture[]{asyncReplacement});
+    }
+
+    /**
+     * Sends a message to the command caller, when all futures are resolved
+     *
+     * @param caption           Caption to send
+     * @param asyncReplacements Async variable replacements
+     * @param replacements      Sync variable replacements
+     * @return A Future to be resolved, after the message was sent
+     */
+    public final CompletableFuture<Void> sendMessage(
+            @NonNull Caption caption,
+            CompletableFuture<@NonNull TagResolver>[] asyncReplacements,
+            @NonNull TagResolver... replacements
+    ) {
+        return CompletableFuture.allOf(asyncReplacements).whenComplete((unused, throwable) -> {
+            Set<TagResolver> resolvers = new HashSet<>(Arrays.asList(replacements));
+            if (throwable != null) {
+                sendMessage(
+                        TranslatableCaption.of("errors.error"),
+                        TagResolver.resolver("value", Tag.inserting(
+                                Component.text("Failed to resolve asynchronous caption replacements")
+                        ))
+                );
+                LOGGER.error("Failed to resolve asynchronous tagresolver(s) for " + caption, throwable);
+            } else {
+                for (final CompletableFuture<TagResolver> asyncReplacement : asyncReplacements) {
+                    resolvers.add(asyncReplacement.join());
+                }
+            }
+            sendMessage(caption, resolvers.toArray(TagResolver[]::new));
+        });
     }
 
     // Redefine from PermissionHolder as it's required from CommandCaller

--- a/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
@@ -174,7 +174,7 @@ public abstract class PlayerManager<P extends PlotPlayer<? extends T>, T> {
      * @since 6.4.0
      * @deprecated Don't unnecessarily block threads and utilize playerMap - see {@link #getUsernameCaption(UUID)}
      */
-    @Deprecated
+    @Deprecated(since = "TODO")
     public static @NonNull Caption resolveName(final @Nullable UUID owner) {
         return resolveName(owner, true);
     }
@@ -188,7 +188,7 @@ public abstract class PlayerManager<P extends PlotPlayer<? extends T>, T> {
      * @since 6.4.0
      * @deprecated Don't unnecessarily block threads and utilize playerMap - see {@link #getUsernameCaption(UUID)}
      */
-    @Deprecated
+    @Deprecated(since = "TODO")
     public static @NonNull Caption resolveName(final @Nullable UUID owner, final boolean blocking) {
         if (owner == null) {
             return TranslatableCaption.of("info.none");

--- a/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
@@ -28,6 +28,7 @@ import com.plotsquared.core.database.DBFunc;
 import com.plotsquared.core.player.ConsolePlayer;
 import com.plotsquared.core.player.OfflinePlotPlayer;
 import com.plotsquared.core.player.PlotPlayer;
+import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.uuid.UUIDMapping;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
@@ -37,6 +38,7 @@ import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Contract;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -216,7 +218,29 @@ public abstract class PlayerManager<P extends PlotPlayer<? extends T>, T> {
         return StaticCaption.of(name);
     }
 
-    public CompletableFuture<Caption> getUsernameCaption(@Nullable UUID uuid) {
+    /**
+     * Resolves a UUID to a formatted {@link Caption} representing the player behind the UUID.
+     * Returns a {@link CompletableFuture} instead of a plain {@link UUID} as this method may query the
+     * {@link com.plotsquared.core.uuid.UUIDPipeline ImpromptuUUIDPipeline}.
+     * <br>
+     * Special Cases:
+     * <ul>
+     *     <li>{@code null}: Resolves to a {@link TranslatableCaption} with the key {@code info.none}</li>
+     *     <li>{@link DBFunc#EVERYONE}: Resolves to a {@link TranslatableCaption} with the key {@code info.everyone}</li>
+     *     <li>{@link DBFunc#SERVER}: Resolves to a {@link TranslatableCaption} with the key {@code info.server}</li>
+     * </ul>
+     * <br>
+     * Otherwise, if the UUID is a valid UUID and not reserved by PlotSquared itself, this method first attempts to query the
+     * online players ({@link #getPlayerIfExists(UUID)}) for the specific UUID.
+     * If no online player was found for that UUID, the {@link com.plotsquared.core.uuid.UUIDPipeline ImpromptuUUIDPipeline} is
+     * queried to retrieve the known username
+     *
+     * @param uuid The UUID of the player (for example provided by {@link Plot#getOwner()}
+     * @return A CompletableFuture resolving to a Caption representing the players name of the uuid
+     * @since TODO
+     */
+    @Contract("_->!null")
+    public @NonNull CompletableFuture<Caption> getUsernameCaption(@Nullable UUID uuid) {
         if (uuid == null) {
             return CompletableFuture.completedFuture(TranslatableCaption.of("info.none"));
         }
@@ -226,8 +250,9 @@ public abstract class PlayerManager<P extends PlotPlayer<? extends T>, T> {
         if (uuid.equals(DBFunc.SERVER)) {
             return CompletableFuture.completedFuture(TranslatableCaption.of("info.server"));
         }
-        if (playerMap.containsKey(uuid)) {
-            return CompletableFuture.completedFuture(StaticCaption.of(playerMap.get(uuid).getName()));
+        P player = getPlayerIfExists(uuid);
+        if (player != null) {
+            return CompletableFuture.completedFuture(StaticCaption.of(player.getName()));
         }
         return PlotSquared.get().getImpromptuUUIDPipeline().getNames(Collections.singleton(uuid)).thenApply(mapping -> {
             if (mapping.isEmpty()) {

--- a/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
+++ b/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
@@ -47,6 +47,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 
 /**
@@ -109,9 +110,9 @@ public final class PlaceholderRegistry {
             if (plotOwner == null) {
                 return legacyComponent(TranslatableCaption.of("generic.generic_unowned"), player);
             }
-
             try {
-                return PlayerManager.resolveName(plotOwner, false).getComponent(player);
+                return PlotSquared.platform().playerManager().getUsernameCaption(plotOwner)
+                        .get(Settings.UUID.BLOCKING_TIMEOUT, TimeUnit.MILLISECONDS).getComponent(player);
             } catch (final Exception ignored) {
             }
             return legacyComponent(TranslatableCaption.of("info.unknown"), player);


### PR DESCRIPTION
## Overview
Fixes #4104

## Description
- Deprecates the old static methods to get a Caption from a users UUID
- Added new method in PlayerManager to retrieve a Caption from a users UUID non-blocking
- Removed thread-blocking and fast-timeout messages / captions
- Added utility methods to send messages to players with asynchronously resolved TagResolvers

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
