### PR TITLE
chore: mitigate possible future sqlite driver problems

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/database/SQLManager.java
+++ b/Core/src/main/java/com/plotsquared/core/database/SQLManager.java
@@ -130,6 +130,7 @@ public class SQLManager implements AbstractDB {
     public volatile ConcurrentHashMap<PlotCluster, Queue<UniqueStatement>> clusterTasks;
     // Private
     private Connection connection;
+    private boolean supportsGetGeneratedKeys;
     private boolean closed = false;
 
     /**
@@ -154,6 +155,7 @@ public class SQLManager implements AbstractDB {
         this.worldConfiguration = worldConfiguration;
         this.database = database;
         this.connection = database.openConnection();
+        this.supportsGetGeneratedKeys = this.connection.getMetaData().supportsGetGeneratedKeys();
         this.mySQL = database instanceof MySQL;
         this.globalTasks = new ConcurrentLinkedQueue<>();
         this.notifyTasks = new ConcurrentLinkedQueue<>();
@@ -161,6 +163,12 @@ public class SQLManager implements AbstractDB {
         this.playerTasks = new ConcurrentHashMap<>();
         this.clusterTasks = new ConcurrentHashMap<>();
         this.prefix = prefix;
+
+        if (mySQL && !supportsGetGeneratedKeys) {
+            throw new SQLException("Database Driver for MySQL does not support Statement#getGeneratedKeys - which breaks " +
+                    "PlotSquared functionality");
+        }
+
         this.SET_OWNER = "UPDATE `" + this.prefix
                 + "plot` SET `owner` = ? WHERE `plot_id_x` = ? AND `plot_id_z` = ? AND `world` = ?";
         this.GET_ALL_PLOTS =
@@ -171,20 +179,32 @@ public class SQLManager implements AbstractDB {
                 "INSERT INTO `" + this.prefix + "plot_settings` (`plot_plot_id`) values ";
         this.CREATE_TIERS =
                 "INSERT INTO `" + this.prefix + "plot_%tier%` (`plot_plot_id`, `user_uuid`) values ";
-        this.CREATE_PLOT = "INSERT INTO `" + this.prefix
+        String tempCreatePlot = "INSERT INTO `" + this.prefix
                 + "plot`(`plot_id_x`, `plot_id_z`, `owner`, `world`, `timestamp`) VALUES(?, ?, ?, ?, ?)";
-
+        if (!supportsGetGeneratedKeys) {
+            tempCreatePlot += " RETURNING `id`";
+        }
+        this.CREATE_PLOT = tempCreatePlot;
         if (mySQL) {
             this.CREATE_PLOT_SAFE = "INSERT IGNORE INTO `" + this.prefix
                     + "plot`(`plot_id_x`, `plot_id_z`, `owner`, `world`, `timestamp`) SELECT ?, ?, ?, ?, ? FROM DUAL WHERE NOT EXISTS (SELECT null FROM `"
                     + this.prefix + "plot` WHERE `world` = ? AND `plot_id_x` = ? AND `plot_id_z` = ?)";
         } else {
-            this.CREATE_PLOT_SAFE = "INSERT INTO `" + this.prefix
+            String tempCreatePlotSafe = "INSERT INTO `" + this.prefix
                     + "plot`(`plot_id_x`, `plot_id_z`, `owner`, `world`, `timestamp`) SELECT ?, ?, ?, ?, ? WHERE NOT EXISTS (SELECT null FROM `"
                     + this.prefix + "plot` WHERE `world` = ? AND `plot_id_x` = ? AND `plot_id_z` = ?)";
+            if (!supportsGetGeneratedKeys) {
+                tempCreatePlotSafe += " RETURNING `id`";
+            }
+            this.CREATE_PLOT_SAFE = tempCreatePlotSafe;
         }
-        this.CREATE_CLUSTER = "INSERT INTO `" + this.prefix
+        String tempCreateCluster = "INSERT INTO `" + this.prefix
                 + "cluster`(`pos1_x`, `pos1_z`, `pos2_x`, `pos2_z`, `owner`, `world`) VALUES(?, ?, ?, ?, ?, ?)";
+        if (!supportsGetGeneratedKeys) {
+            tempCreateCluster += " RETURNING `id`";
+        }
+        this.CREATE_CLUSTER = tempCreateCluster;
+
         try {
             createTables();
         } catch (SQLException e) {
@@ -1073,9 +1093,8 @@ public class SQLManager implements AbstractDB {
 
             @Override
             public void addBatch(PreparedStatement statement) throws SQLException {
-                int inserted = statement.executeUpdate();
-                if (inserted > 0) {
-                    try (ResultSet keys = statement.getGeneratedKeys()) {
+                if (statement.execute() || statement.getUpdateCount() > 0) {
+                    try (ResultSet keys = supportsGetGeneratedKeys ? statement.getGeneratedKeys() : statement.getResultSet()) {
                         if (keys.next()) {
                             plot.temp = keys.getInt(1);
                             addPlotTask(plot, new UniqueStatement(
@@ -1145,8 +1164,8 @@ public class SQLManager implements AbstractDB {
 
             @Override
             public void addBatch(PreparedStatement statement) throws SQLException {
-                statement.executeUpdate();
-                try (ResultSet keys = statement.getGeneratedKeys()) {
+                statement.execute();
+                try (ResultSet keys = supportsGetGeneratedKeys ? statement.getGeneratedKeys() : statement.getResultSet()) {
                     if (keys.next()) {
                         plot.temp = keys.getInt(1);
                     }
@@ -3058,8 +3077,8 @@ public class SQLManager implements AbstractDB {
 
             @Override
             public void addBatch(PreparedStatement statement) throws SQLException {
-                statement.executeUpdate();
-                try (ResultSet keys = statement.getGeneratedKeys()) {
+                statement.execute();
+                try (ResultSet keys = supportsGetGeneratedKeys ? statement.getGeneratedKeys() : statement.getResultSet()) {
                     if (keys.next()) {
                         cluster.temp = keys.getInt(1);
                     }


### PR DESCRIPTION
## Overview
Just to be on the safer side, if https://github.com/xerial/sqlite-jdbc/releases/tag/3.43.0.0 is embedded again into Spigot / CB / Paper.
Checks if Statement#getGeneratedKeys is supported by the driver otherwise falls back on sqlite drivers using the RETURN statement on inserts. When using MySQL and getGeneratedKeys is not supported, well - that's a whole other story (but that's a very unlikely event).

Tested using latest paper and paper build 207 with mysql and sqlite.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
