### PR TITLE
Address deprecated 'Times#of()' in 'PlotPlayer'

### DIFF
--- a/Core/build.gradle.kts
+++ b/Core/build.gradle.kts
@@ -72,8 +72,6 @@ tasks {
         opt.links("https://jd.advntr.dev/text-minimessage/4.14.0/")
         opt.links("https://google.github.io/guice/api-docs/" + libs.guice.get().versionConstraint.toString() + "/javadoc/")
         opt.links("https://checkerframework.org/api/")
-        opt.links("https://javadocs.dev/com.intellectualsites.informative-annotations/informative-annotations/"
-                + libs.informativeAnnotations.get().versionConstraint.toString())
         opt.isLinkSource = true
         opt.bottom(File("$rootDir/javadocfooter.html").readText())
         opt.isUse = true

--- a/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
+++ b/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
@@ -882,7 +882,7 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
         final Component titleComponent = MiniMessage.miniMessage().deserialize(title.getComponent(this), replacements);
         final Component subtitleComponent =
                 MiniMessage.miniMessage().deserialize(subtitle.getComponent(this), replacements);
-        final Title.Times times = Title.Times.of(
+        final Title.Times times = Title.Times.times(
                 Duration.of(Settings.Titles.TITLES_FADE_IN * 50L, ChronoUnit.MILLIS),
                 Duration.of(Settings.Titles.TITLES_STAY * 50L, ChronoUnit.MILLIS),
                 Duration.of(Settings.Titles.TITLES_FADE_OUT * 50L, ChronoUnit.MILLIS)


### PR DESCRIPTION
Fixes https://github.com/IntellectualSites/PlotSquared/issues/4162 with the appropriate drop-in replacement.