### PR TITLE
Fix: permission check for integer flags

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/player/BukkitPlayer.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/player/BukkitPlayer.java
@@ -158,6 +158,7 @@ public class BukkitPlayer extends PlotPlayer<Player> {
         }
         final String[] nodes = stub.split("\\.");
         final StringBuilder n = new StringBuilder();
+        // Wildcard check from less specific permission to more specific permission
         for (int i = 0; i < (nodes.length - 1); i++) {
             n.append(nodes[i]).append(".");
             if (!stub.equals(n + Permission.PERMISSION_STAR.toString())) {
@@ -166,9 +167,11 @@ public class BukkitPlayer extends PlotPlayer<Player> {
                 }
             }
         }
+        // Wildcard check for the full permission
         if (hasPermission(stub + ".*")) {
             return Integer.MAX_VALUE;
         }
+        // Permission value cache for iterative check
         int max = 0;
         if (CHECK_EFFECTIVE) {
             boolean hasAny = false;

--- a/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
@@ -105,7 +105,7 @@ public final class FlagCommand extends Command {
                 int numeric = Integer.parseInt(value);
                 perm = perm.substring(0, perm.length() - value.length() - 1);
                 boolean result = false;
-                if (numeric > 0) {
+                if (numeric >= 0) {
                     int checkRange = PlotSquared.get().getPlatform().equalsIgnoreCase("bukkit") ?
                             numeric :
                             Settings.Limit.MAX_PLOTS;

--- a/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
@@ -103,6 +103,7 @@ public final class FlagCommand extends Command {
         if (flag instanceof IntegerFlag && MathMan.isInteger(value)) {
             try {
                 int numeric = Integer.parseInt(value);
+                // Getting full permission without ".<amount>" at the end
                 perm = perm.substring(0, perm.length() - value.length() - 1);
                 boolean result = false;
                 if (numeric >= 0) {

--- a/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
@@ -522,7 +522,7 @@ public class Settings extends Config {
         @Comment("Should the limit be global (over multiple worlds)")
         public static boolean GLOBAL =
                 false;
-        @Comment({"The max range of permissions to check for, e.g. plots.plot.127",
+        @Comment({"The max range of integer permissions to check for, e.g. 'plots.plot.127' or 'plots.set.flag.mob-cap.127'",
                 "The value covers the permission range to check, you need to assign the permission to players/groups still",
                 "Modifying the value does NOT change the amount of plots players can claim"})
         public static int MAX_PLOTS = 127;

--- a/Core/src/main/java/com/plotsquared/core/permissions/PermissionHolder.java
+++ b/Core/src/main/java/com/plotsquared/core/permissions/PermissionHolder.java
@@ -100,6 +100,7 @@ public interface PermissionHolder {
         }
         String[] nodes = stub.split("\\.");
         StringBuilder builder = new StringBuilder();
+        // Wildcard check from less specific permission to more specific permission
         for (int i = 0; i < (nodes.length - 1); i++) {
             builder.append(nodes[i]).append(".");
             if (!stub.equals(builder + Permission.PERMISSION_STAR.toString())) {
@@ -108,6 +109,7 @@ public interface PermissionHolder {
                 }
             }
         }
+        // Wildcard check for the full permission
         if (hasPermission(stub + ".*")) {
             return Integer.MAX_VALUE;
         }


### PR DESCRIPTION
## Overview
Commands like `/p f s mob-cap 0` are now allowed, if the player hast the permission `plots.set.flag.mob-cap.0` ore higher. Zero is not a valid range for the permission check.

<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #3896

## Description
- Changing integer check to allow zero
- Adding small comments to describe the complicated algorithm
- Adding details to the `max-plots` setting description as it stands for more than just the plot-maximum (probably historically formed)

The permission check was tested in-game.

```[tasklist]
### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
