### PR TITLE
Fix: including "highestLimit" number

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/util/TabCompletions.java
+++ b/Core/src/main/java/com/plotsquared/core/util/TabCompletions.java
@@ -173,7 +173,7 @@ public final class TabCompletions {
             return Collections.emptyList();
         }
         final List<String> commands = new ArrayList<>();
-        for (int i = offset; i < highestLimit && (offset - i + amountLimit) > 0; i++) {
+        for (int i = offset; i <= highestLimit && (offset - i + amountLimit) > 0; i++) {
             commands.add(String.valueOf(i));
         }
         return asCompletions(commands.toArray(new String[0]));


### PR DESCRIPTION
## Overview
The value `highestLimit` is included to the list as it is described in the Java doc.

## Description
**Old behavior:**

[/Core/src/main/java/com/plotsquared/core/command/Visit.java#L353-L354](https://github.com/RedstoneFuture/PlotSquared/blob/e183d06e7a62904b0b8d6619c75dbc8cf43880ae/Core/src/main/java/com/plotsquared/core/command/Visit.java#L353-L354)
```java
completions.addAll(
   TabCompletions.completeNumbers(args[2], 10, 999));
```
![grafik](https://github.com/IntellectualSites/PlotSquared/assets/4140635/6ae54bc2-41f0-4175-8568-9d19baf163ac)

```[tasklist]
### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
