### PR TITLE
Feat: adding "last" argument for Visit cmd to choose the highest number

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Visit.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Visit.java
@@ -318,14 +318,20 @@ public class Visit extends Command {
     }
 
     private boolean isInvalidPageNr(String arg) {
-        if (MathMan.isInteger(arg)) return false;
-        if (arg.equals("last") || arg.equals("n")) return false;
+        if (MathMan.isInteger(arg)) {
+            return false;
+        } else if (arg.equals("last") || arg.equals("n")) {
+            return false;
+        }
         return true;
     }
 
     private int getPageNr(String arg) {
-        if (MathMan.isInteger(arg)) return Integer.parseInt(arg);
-        if (arg.equals("last") || arg.equals("n")) return -1;
+        if (MathMan.isInteger(arg)) {
+            return Integer.parseInt(arg);
+        } else if (arg.equals("last") || arg.equals("n")) {
+            return -1;
+        }
         return Integer.MIN_VALUE;
     }
 

--- a/Core/src/main/java/com/plotsquared/core/command/Visit.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Visit.java
@@ -348,20 +348,22 @@ public class Visit extends Command {
             case 1 -> {
                 completions.addAll(
                         TabCompletions.completeAreas(args[1]));
+                completions.addAll(TabCompletions.asCompletions("last"));
                 if (args[1].isEmpty()) {
                     // if no input is given, only suggest 1 - 3
                     completions.addAll(
-                            TabCompletions.asCompletions("1", "2", "3", "last"));
+                            TabCompletions.asCompletions("1", "2", "3"));
                     break;
                 }
                 completions.addAll(
                         TabCompletions.completeNumbers(args[1], 10, 999));
             }
             case 2 -> {
+                completions.addAll(TabCompletions.asCompletions("last"));
                 if (args[2].isEmpty()) {
                     // if no input is given, only suggest 1 - 3
                     completions.addAll(
-                            TabCompletions.asCompletions("1", "2", "3", "last"));
+                            TabCompletions.asCompletions("1", "2", "3"));
                     break;
                 }
                 completions.addAll(

--- a/Core/src/main/java/com/plotsquared/core/command/Visit.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Visit.java
@@ -77,11 +77,6 @@ public class Visit extends Command {
             query.whereBasePlot();
         }
 
-        // "last" or "n" argument
-        if (page == Integer.MAX_VALUE) {
-            page = unsorted.size();
-        }
-
         // without specified argument
         if (page == Integer.MIN_VALUE) {
             page = 1;
@@ -100,10 +95,15 @@ public class Visit extends Command {
 
         final List<Plot> plots = query.asList();
 
+        // Conversion of reversed page argument
+        if (page < 0) {
+            page = (plots.size() + 1) + page;
+        }
+
         if (plots.isEmpty()) {
             player.sendMessage(TranslatableCaption.of("invalid.found_no_plots"));
             return;
-        } else if (plots.size() < page || page < 1) {
+        } else if (page > plots.size() || page < 1) {
             player.sendMessage(
                     TranslatableCaption.of("invalid.number_not_in_range"),
                     TagResolver.builder()
@@ -194,7 +194,7 @@ public class Visit extends Command {
         int page = Integer.MIN_VALUE;
 
         switch (args.length) {
-            // /p v <user> <area> <page>
+            // /p v <player> <area> <page>
             case 3:
                 if (isInvalidPageNr(args[2])) {
                     sendInvalidPageNrMsg(player);
@@ -325,7 +325,7 @@ public class Visit extends Command {
 
     private int getPageNr(String arg) {
         if (MathMan.isInteger(arg)) return Integer.parseInt(arg);
-        if (arg.equals("last") || arg.equals("n")) return Integer.MAX_VALUE;
+        if (arg.equals("last") || arg.equals("n")) return -1;
         return Integer.MIN_VALUE;
     }
 


### PR DESCRIPTION
## Overview
With this PR it is allowed to use the `last` or `n` argument to choose the highest possible (last) plot number of the target. For this purpose, parts of the algorithm were also outsourced to a private method and extended.

If this is accepted so far, I can build the same for the Home command: `/p h last`.

**EDIT (21.12.2023):** Support for inverted plot numbers has also been added.

## Description
**Examples:**
- `/p v <username> last`
- `/p v <username> <area> last`
--> Teleports the player to the **x** plot of `<username>` if he has a total of **x**.

**EDIT (21.12.2023):**
- `/p v <username> -#`
- `/p v <username> <area> -#`

![grafik](https://github.com/IntellectualSites/PlotSquared/assets/4140635/a18485ff-5c1a-4c4c-8733-45703f702d9a)

```[tasklist]
### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
