### PR TITLE
Add info about service providers to debugpaste

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -135,6 +135,7 @@ import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -1178,6 +1179,17 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
                     .append("  • Load Before: ").append(p.getDescription().getLoadBefore()).append("\n")
                     .append("  • Dependencies: ").append(p.getDescription().getDepend()).append("\n")
                     .append("  • Soft Dependencies: ").append(p.getDescription().getSoftDepend()).append("\n");
+            List<RegisteredServiceProvider<?>> providers = Bukkit.getServicesManager().getRegistrations(p);
+            if (!providers.isEmpty()) {
+                msg.append("  • Provided Services: \n");
+                for (RegisteredServiceProvider<?> provider : providers) {
+                    msg.append("    • ")
+                            .append(provider.getService().getName()).append(" = ")
+                            .append(provider.getProvider().getClass().getName())
+                            .append(" (priority: ").append(provider.getPriority()).append(")")
+                            .append("\n");
+                }
+            }
         }
         return msg.toString();
     }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

It can be useful to know which plugin provides what services when e.g. debugging issues with economy. We can add that information to the debugpaste. Example:

![ex](https://github.com/IntellectualSites/PlotSquared/assets/11150076/ce51f313-f80a-424f-bee5-f53b272bb869)

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
