### PR TITLE
Declare explicit runtime dependency on 'junit-platform-launcher'

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,7 @@ subprojects {
     dependencies {
         // Tests
         testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
+        testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.1")
     }
 
     plugins.withId("java") {


### PR DESCRIPTION
Fixes a deprecation warning in 8.5: https://docs.gradle.org/8.2.1/userguide/upgrading_version_8.html#test_framework_implementation_dependencies