### PR TITLE
feat: allow for custom plot limit handling

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/events/PlayerPlotLimitEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlayerPlotLimitEvent.java
@@ -46,7 +46,7 @@ public class PlayerPlotLimitEvent {
      * @param limit The amount of plots a player may claim. Must be {@code 0} or greater.
      * @since TODO
      */
-    public void setLimit(@NonNegative final int limit) {
+    public void limit(@NonNegative final int limit) {
         if (limit < 0) {
             throw new IllegalArgumentException("Player plot limit must be greater or equal 0");
         }

--- a/Core/src/main/java/com/plotsquared/core/events/PlayerPlotLimitEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlayerPlotLimitEvent.java
@@ -1,3 +1,21 @@
+/*
+ * PlotSquared, a land and world management plugin for Minecraft.
+ * Copyright (C) IntellectualSites <https://intellectualsites.com>
+ * Copyright (C) IntellectualSites team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.plotsquared.core.events;
 
 import com.plotsquared.core.player.PlotPlayer;

--- a/Core/src/main/java/com/plotsquared/core/events/PlayerPlotLimitEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlayerPlotLimitEvent.java
@@ -1,0 +1,59 @@
+package com.plotsquared.core.events;
+
+import com.plotsquared.core.player.PlotPlayer;
+import org.checkerframework.checker.index.qual.NonNegative;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Called every time after PlotSquared calculated a players plot limit based on their permission.
+ * <p>
+ * May be used to grant a player more plots based on another rank or bought feature.
+ *
+ * @since TODO
+ */
+public class PlayerPlotLimitEvent {
+
+    private final PlotPlayer<?> player;
+
+    private int limit;
+
+    public PlayerPlotLimitEvent(@NonNull final PlotPlayer<?> player, @NonNegative final int limit) {
+        this.player = player;
+        this.limit = limit;
+    }
+
+    /**
+     * Overrides the previously calculated or set plot limit for {@link #player()}.
+     *
+     * @param limit The amount of plots a player may claim. Must be {@code 0} or greater.
+     * @since TODO
+     */
+    public void setLimit(@NonNegative final int limit) {
+        if (limit < 0) {
+            throw new IllegalArgumentException("Player plot limit must be greater or equal 0");
+        }
+        this.limit = limit;
+    }
+
+    /**
+     * Returns the previous set limit, if none was overridden before this event handler the default limit based on the players
+     * permissions node is returned.
+     *
+     * @return The currently defined plot limit of this player.
+     * @since TODO
+     */
+    public @NonNegative int limit() {
+        return limit;
+    }
+
+    /**
+     * The player for which the limit is queried.
+     *
+     * @return the player.
+     * @since TODO
+     */
+    public @NonNull PlotPlayer<?> player() {
+        return player;
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
+++ b/Core/src/main/java/com/plotsquared/core/player/PlotPlayer.java
@@ -306,7 +306,8 @@ public abstract class PlotPlayer<P> implements CommandCaller, OfflinePlotPlayer,
      * @return number of allowed plots within the scope (globally, or in the player's current world as defined in the settings.yml)
      */
     public int getAllowedPlots() {
-        return hasPermissionRange("plots.plot", Settings.Limit.MAX_PLOTS);
+        final int calculatedLimit = hasPermissionRange("plots.plot", Settings.Limit.MAX_PLOTS);
+        return this.eventDispatcher.callPlayerPlotLimit(this, calculatedLimit).limit();
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
+++ b/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
@@ -30,6 +30,7 @@ import com.plotsquared.core.events.PlayerEnterPlotEvent;
 import com.plotsquared.core.events.PlayerLeavePlotEvent;
 import com.plotsquared.core.events.PlayerPlotDeniedEvent;
 import com.plotsquared.core.events.PlayerPlotHelperEvent;
+import com.plotsquared.core.events.PlayerPlotLimitEvent;
 import com.plotsquared.core.events.PlayerPlotTrustedEvent;
 import com.plotsquared.core.events.PlayerTeleportToPlotEvent;
 import com.plotsquared.core.events.PlotAutoMergeEvent;
@@ -304,6 +305,12 @@ public class EventDispatcher {
 
     public RemoveRoadEntityEvent callRemoveRoadEntity(Entity entity) {
         RemoveRoadEntityEvent event = new RemoveRoadEntityEvent(entity);
+        eventBus.post(event);
+        return event;
+    }
+
+    public PlayerPlotLimitEvent callPlayerPlotLimit(PlotPlayer<?> player, int calculatedLimit) {
+        PlayerPlotLimitEvent event = new PlayerPlotLimitEvent(player, calculatedLimit);
         eventBus.post(event);
         return event;
     }


### PR DESCRIPTION
## Overview
As the title states, plot limits are now not limited to permission nodes but also allowed to be overridden in an event. This helps integrating other systems, where plots may be added via vouchers etc.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
