### PR TITLE
feat: configurable accounting for bedrock layer when setting components

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/generator/ClassicPlotManager.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/ClassicPlotManager.java
@@ -143,7 +143,7 @@ public class ClassicPlotManager extends SquarePlotManager {
                     classicPlotWorld,
                     plot.getRegions(),
                     blocks,
-                    classicPlotWorld.getMinBuildHeight(),
+                    classicPlotWorld.getMinComponentHeight(),
                     classicPlotWorld.getMaxBuildHeight() - 1,
                     actor,
                     queue
@@ -204,7 +204,7 @@ public class ClassicPlotManager extends SquarePlotManager {
                     classicPlotWorld,
                     plot.getRegions(),
                     blocks,
-                    classicPlotWorld.getMinBuildHeight(),
+                    classicPlotWorld.getMinComponentHeight(),
                     classicPlotWorld.PLOT_HEIGHT - 1,
                     actor,
                     queue
@@ -379,7 +379,7 @@ public class ClassicPlotManager extends SquarePlotManager {
             }
         }
 
-        int yStart = classicPlotWorld.getMinBuildHeight() + (classicPlotWorld.PLOT_BEDROCK ? 1 : 0);
+        int yStart = classicPlotWorld.getMinComponentHeight();
         if (!plot.isMerged(Direction.NORTH)) {
             int z = bot.getZ();
             for (int x = bot.getX(); x < top.getX(); x++) {

--- a/Core/src/main/java/com/plotsquared/core/generator/ClassicPlotWorld.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/ClassicPlotWorld.java
@@ -52,6 +52,7 @@ public abstract class ClassicPlotWorld extends SquarePlotWorld {
     public BlockBucket ROAD_BLOCK = new BlockBucket(BlockTypes.QUARTZ_BLOCK);
     public boolean PLOT_BEDROCK = true;
     public boolean PLACE_TOP_BLOCK = true;
+    public boolean COMPONENT_BELOW_BEDROCK = false;
 
     public ClassicPlotWorld(
             final @NonNull String worldName,
@@ -129,6 +130,9 @@ public abstract class ClassicPlotWorld extends SquarePlotWorld {
                 ),
                 new ConfigurationNode("plot.bedrock", this.PLOT_BEDROCK, TranslatableCaption.of("setup.bedrock_boolean"),
                         ConfigurationUtil.BOOLEAN
+                ),
+                new ConfigurationNode("world.component_below_bedrock", this.COMPONENT_BELOW_BEDROCK, TranslatableCaption.of(
+                        "setup.component_below_bedrock_boolean"), ConfigurationUtil.BOOLEAN
                 )};
     }
 
@@ -150,6 +154,14 @@ public abstract class ClassicPlotWorld extends SquarePlotWorld {
         this.PLACE_TOP_BLOCK = config.getBoolean("wall.place_top_block");
         this.WALL_HEIGHT = Math.min(getMaxGenHeight() - (PLACE_TOP_BLOCK ? 1 : 0), config.getInt("wall.height"));
         this.CLAIMED_WALL_BLOCK = createCheckedBlockBucket(config.getString("wall.block_claimed"), CLAIMED_WALL_BLOCK);
+        this.COMPONENT_BELOW_BEDROCK = config.getBoolean("world.component_below_bedrock");
+    }
+
+    @Override
+    public int getMinComponentHeight() {
+        return COMPONENT_BELOW_BEDROCK && PLOT_BEDROCK && getMinGenHeight() >= getMinBuildHeight()
+                ? getMinGenHeight() + 1
+                : getMinBuildHeight();
     }
 
     int schematicStartHeight() {

--- a/Core/src/main/java/com/plotsquared/core/generator/ClassicPlotWorld.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/ClassicPlotWorld.java
@@ -159,8 +159,8 @@ public abstract class ClassicPlotWorld extends SquarePlotWorld {
 
     @Override
     public int getMinComponentHeight() {
-        return COMPONENT_BELOW_BEDROCK && PLOT_BEDROCK && getMinGenHeight() >= getMinBuildHeight()
-                ? getMinGenHeight() + 1
+        return COMPONENT_BELOW_BEDROCK && getMinGenHeight() >= getMinBuildHeight()
+                ? getMinGenHeight() + (PLOT_BEDROCK ? 1 : 0)
                 : getMinBuildHeight();
     }
 

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
@@ -1454,6 +1454,8 @@ public abstract class PlotArea implements ComponentLike {
 
     /**
      * Get the maximum height that changes to plot components (wall filling, air, all etc.) may operate to
+     *
+     * @since TODO
      */
     public int getMaxComponentHeight() {
         return this.maxBuildHeight;
@@ -1461,6 +1463,8 @@ public abstract class PlotArea implements ComponentLike {
 
     /**
      * Get the minimum height that changes to plot components (wall filling, air, all etc.) may operate to
+     *
+     * @since TODO
      */
     public int getMinComponentHeight() {
         return this.minBuildHeight;

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
@@ -1455,7 +1455,7 @@ public abstract class PlotArea implements ComponentLike {
     /**
      * Get the maximum height that changes to plot components (wall filling, air, all etc.) may operate to
      */
-    public int getMixComponentHeight() {
+    public int getMaxComponentHeight() {
         return this.maxBuildHeight;
     }
 

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
@@ -1453,6 +1453,20 @@ public abstract class PlotArea implements ComponentLike {
     }
 
     /**
+     * Get the maximum height that changes to plot components (wall filling, air, all etc.) may operate to
+     */
+    public int getMixComponentHeight() {
+        return this.maxBuildHeight;
+    }
+
+    /**
+     * Get the minimum height that changes to plot components (wall filling, air, all etc.) may operate to
+     */
+    public int getMinComponentHeight() {
+        return this.minBuildHeight;
+    }
+
+    /**
      * Get the maximum height players may build in. Exclusive.
      */
     public int getMaxBuildHeight() {

--- a/Core/src/main/resources/lang/messages_en.json
+++ b/Core/src/main/resources/lang/messages_en.json
@@ -165,6 +165,7 @@
   "setup.wall_height": "<gold>Wall height</gold>",
   "setup.min_gen_height": "<gold>Minimum height from which to generate (for 1.18+ can be negative).</gold>",
   "setup.bedrock_boolean": "<gold>Whether a bedrock layer under the plot should be generated or not</gold>",
+  "setup.component_below_bedrock_boolean": "<gold>Whether a component change e.g. /plot set walls should edit the bedrock layer or below</gold>",
   "setup.singleplotarea_void_world": "<gold>Void world</gold>",
   "plotareatype.plot_area_type_normal": "<gray>Standard plot generation</gray>",
   "plotareatype.plot_area_type_augmented": "<gray>Plot generation with vanilla terrain</gray>",


### PR DESCRIPTION
 - Add configuration option to force plot components to be set only above bedrock level
 - Account for build height < gen height where it is not wanted for components to be set at/below bedrock