### PR TITLE
feat: Allow admin done permission to override requiring plot complexity calculation

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Done.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Done.java
@@ -94,7 +94,7 @@ public class Done extends SubCommand {
                 TagResolver.resolver("plot", Tag.inserting(Component.text(plot.getId().toString())))
         );
         final Settings.Auto_Clear doneRequirements = Settings.AUTO_CLEAR.get("done");
-        if (PlotSquared.platform().expireManager() == null || doneRequirements == null) {
+        if (PlotSquared.platform().expireManager() == null || doneRequirements == null || player.hasPermission(Permission.PERMISSION_ADMIN_COMMAND_DONE)) {
             finish(plot, player, true);
             plot.removeRunning();
         } else {


### PR DESCRIPTION
## Overview
Let admins always be able to set plots as done

## Description
The permission `plots.admin.command.done` already exists but is only used to check if you have plot perms, it's very useful to allow admins with the permissions to not require doing plot calculations.

Also removed `PlotSquared.platform().expireManager() == null` condition on same line because it can never return null.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
