### PR TITLE
Relocate net.kyori.options (Support newer 1.20.4 builds)

### DIFF
--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -67,6 +67,7 @@ tasks.named<ShadowJar>("shadowJar") {
         exclude(dependency("org.checkerframework:"))
     }
 
+    relocate("net.kyori.option", "com.plotsquared.core.configuration.option")
     relocate("net.kyori.adventure", "com.plotsquared.core.configuration.adventure")
     relocate("net.kyori.examination", "com.plotsquared.core.configuration.examination")
     relocate("io.papermc.lib", "com.plotsquared.bukkit.paperlib")


### PR DESCRIPTION
## Overview
Paper updated adventure, which seems to now utilize net.kyori.options
We need to shade options in order to not register options twice (once for Paper, once for PS) as that throws an IllegalStateException and suppresses Adventure output.

Example stacktrace if not relocated:
```
[17:42:36 WARN]: [PlotSquared] Task #9 for PlotSquared v7.2.1-SNAPSHOT generated an exception
java.lang.ExceptionInInitializerError: null
	at com.plotsquared.core.configuration.adventure.text.serializer.gson.GsonComponentSerializerImpl$BuilderImpl.<init>(GsonComponentSerializerImpl.java:125) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.core.configuration.adventure.text.serializer.gson.GsonComponentSerializer.builder(GsonComponentSerializer.java:84) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.core.configuration.adventure.platform.bukkit.BukkitComponentSerializer.<clinit>(BukkitComponentSerializer.java:67) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.core.configuration.adventure.platform.bukkit.BukkitFacet$Message.createMessage(BukkitFacet.java:74) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.core.configuration.adventure.platform.bukkit.BukkitFacet$Message.createMessage(BukkitFacet.java:67) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.core.configuration.adventure.platform.facet.FacetAudience.createMessage(FacetAudience.java:521) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.core.configuration.adventure.platform.facet.FacetAudience.sendMessage(FacetAudience.java:191) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.core.configuration.adventure.audience.Audience.sendMessage(Audience.java:250) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.core.configuration.adventure.audience.Audience.sendMessage(Audience.java:214) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.core.configuration.adventure.audience.ForwardingAudience.sendMessage(ForwardingAudience.java:104) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.core.player.ConsolePlayer.sendMessage(ConsolePlayer.java:157) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.core.plot.PlotArea.loadFlags(PlotArea.java:416) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.core.plot.PlotArea.loadDefaultConfiguration(PlotArea.java:403) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.core.PlotSquared.loadWorld(PlotSquared.java:853) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.bukkit.generator.BukkitPlotGenerator.checkLoaded(BukkitPlotGenerator.java:169) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.bukkit.generator.BukkitPlotGenerator.getDefaultPopulators(BukkitPlotGenerator.java:142) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at net.minecraft.server.MinecraftServer.initWorld(MinecraftServer.java:682) ~[paper-1.20.4.jar:git-Paper-344]
	at org.bukkit.craftbukkit.v1_20_R3.CraftServer.createWorld(CraftServer.java:1385) ~[paper-1.20.4.jar:git-Paper-344]
	at org.bukkit.Bukkit.createWorld(Bukkit.java:815) ~[paper-api-1.20.4-R0.1-SNAPSHOT.jar:?]
	at com.plotsquared.bukkit.managers.BukkitWorldManager.handleWorldCreation(BukkitWorldManager.java:57) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.bukkit.managers.BukkitWorldManager.handleWorldCreation(BukkitWorldManager.java:41) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.bukkit.util.BukkitSetupUtils.setupWorld(BukkitSetupUtils.java:226) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.bukkit.BukkitPlatform.setGenerator(BukkitPlatform.java:1132) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.bukkit.BukkitPlatform.lambda$onEnable$0(BukkitPlatform.java:435) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.bukkit.util.task.BukkitPlotSquaredTask.runTask(BukkitPlotSquaredTask.java:39) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at com.plotsquared.core.util.task.PlotSquaredTask.run(PlotSquaredTask.java:44) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_20_R3.scheduler.CraftTask.run(CraftTask.java:101) ~[paper-1.20.4.jar:git-Paper-344]
	at org.bukkit.craftbukkit.v1_20_R3.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:480) ~[paper-1.20.4.jar:git-Paper-344]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1143) ~[paper-1.20.4.jar:git-Paper-344]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:321) ~[paper-1.20.4.jar:git-Paper-344]
	at java.lang.Thread.run(Thread.java:1583) ~[?:?]
Caused by: java.lang.IllegalStateException: Key adventure:json/emit/rgb has already been used. Option keys must be unique.
	at net.kyori.option.OptionImpl.option(OptionImpl.java:49) ~[option-1.0.0.jar:?]
	at net.kyori.option.Option.booleanOption(Option.java:52) ~[option-1.0.0.jar:?]
	at com.plotsquared.core.configuration.adventure.text.serializer.json.JSONOptions.<clinit>(JSONOptions.java:53) ~[plotsquared-bukkit-7.3.1-SNAPSHOT.jar:?]
	... 31 more
```

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
