### PR TITLE
Add admin permission override to edit signs

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -252,7 +252,8 @@ public class PlayerEventListener implements Listener {
                 }
                 Plot plot = location.getOwnedPlot();
                 if (plot == null) {
-                    if (PlotFlagUtil.isAreaRoadFlagsAndFlagEquals(area, EditSignFlag.class, false)) {
+                    if (PlotFlagUtil.isAreaRoadFlagsAndFlagEquals(area, EditSignFlag.class, false)
+                            && !event.getPlayer().hasPermission(Permission.PERMISSION_ADMIN_INTERACT_ROAD.toString())) {
                         event.setCancelled(true);
                     }
                     return;
@@ -260,7 +261,8 @@ public class PlayerEventListener implements Listener {
                 if (plot.isAdded(event.getPlayer().getUniqueId())) {
                     return; // allow for added players
                 }
-                if (!plot.getFlag(EditSignFlag.class)) {
+                if (!plot.getFlag(EditSignFlag.class)
+                        && !event.getPlayer().hasPermission(Permission.PERMISSION_ADMIN_INTERACT_OTHER.toString())) {
                     plot.debug(event.getPlayer().getName() + " could not color the sign because of edit-sign = false");
                     event.setCancelled(true);
                 }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener1201.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener1201.java
@@ -20,6 +20,7 @@ package com.plotsquared.bukkit.listener;
 
 import com.plotsquared.bukkit.util.BukkitUtil;
 import com.plotsquared.core.location.Location;
+import com.plotsquared.core.permissions.Permission;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.plot.flag.implementations.EditSignFlag;
@@ -46,7 +47,8 @@ public class PlayerEventListener1201 implements Listener {
         }
         Plot plot = location.getOwnedPlot();
         if (plot == null) {
-            if (PlotFlagUtil.isAreaRoadFlagsAndFlagEquals(area, EditSignFlag.class, false)) {
+            if (PlotFlagUtil.isAreaRoadFlagsAndFlagEquals(area, EditSignFlag.class, false)
+                    && !event.getPlayer().hasPermission(Permission.PERMISSION_ADMIN_INTERACT_ROAD.toString())) {
                 event.setCancelled(true);
             }
             return;
@@ -54,7 +56,8 @@ public class PlayerEventListener1201 implements Listener {
         if (plot.isAdded(event.getPlayer().getUniqueId())) {
             return; // allow for added players
         }
-        if (!plot.getFlag(EditSignFlag.class)) {
+        if (!plot.getFlag(EditSignFlag.class)
+                && !event.getPlayer().hasPermission(Permission.PERMISSION_ADMIN_INTERACT_OTHER.toString())) {
             plot.debug(event.getPlayer().getName() + " could not edit the sign because of edit-sign = false");
             event.setCancelled(true);
         }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #4285

## Description
<!-- Please describe what this pull request does. -->

Uses existing permissions to allow editing signs for admins.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
