### PR TITLE
Add events for plot buying

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/events/CancellablePlotEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/CancellablePlotEvent.java
@@ -26,8 +26,18 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public interface CancellablePlotEvent {
 
+    /**
+     * The currently set {@link Result} for this event (as set by potential previous event listeners).
+     *
+     * @return the current result.
+     */
     @Nullable Result getEventResult();
 
+    /**
+     * Set the {@link Result} for this event.
+     *
+     * @param eventResult the new result.
+     */
     void setEventResult(@Nullable Result eventResult);
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/events/CancellablePlotEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/CancellablePlotEvent.java
@@ -18,17 +18,24 @@
  */
 package com.plotsquared.core.events;
 
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * PlotSquared event with {@link Result} to cancel, force, or allow.
  */
 public interface CancellablePlotEvent {
 
-    Result getEventResult();
+    @Nullable Result getEventResult();
 
-    void setEventResult(Result eventResult);
+    void setEventResult(@Nullable Result eventResult);
 
+    /**
+     * @deprecated No usage and not null-safe
+     */
+    @Deprecated(since = "TODO")
     default int getEventResultRaw() {
-        return getEventResult().getValue();
+        return getEventResult() != null ? getEventResult().getValue() : -1;
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/events/PlayerBuyPlotEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlayerBuyPlotEvent.java
@@ -1,0 +1,88 @@
+/*
+ * PlotSquared, a land and world management plugin for Minecraft.
+ * Copyright (C) IntellectualSites <https://intellectualsites.com>
+ * Copyright (C) IntellectualSites team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.events;
+
+import com.plotsquared.core.player.PlotPlayer;
+import com.plotsquared.core.plot.Plot;
+import org.checkerframework.checker.index.qual.NonNegative;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Called when a user attempts to buy a plot.
+ * <p>
+ * Setting the {@link #setEventResult(Result) Result} to {@link Result#FORCE} ignores the price and players account balance and does not charge the
+ * player anything. {@link Result#DENY} blocks the purchase completely, {@link Result#ACCEPT} and {@code null} do not modify
+ * the behaviour.
+ * <p>
+ * Setting the {@link #setPrice(double) price} to {@code 0} makes the plot practically free.
+ *
+ * @since TODO
+ */
+public class PlayerBuyPlotEvent extends PlotPlayerEvent implements CancellablePlotEvent {
+
+    private Result result;
+    private double price;
+
+    public PlayerBuyPlotEvent(final PlotPlayer<?> plotPlayer, final Plot plot, @NonNegative final double price) {
+        super(plotPlayer, plot);
+        this.price = price;
+    }
+
+
+    /**
+     * Sets the price required to buy the plot.
+     *
+     * @param price the new price.
+     * @since TODO
+     */
+    public void setPrice(@NonNegative final double price) {
+        //noinspection ConstantValue - the annotation does not ensure a non-negative runtime value
+        if (price < 0) {
+            throw new IllegalArgumentException("price must be non-negative");
+        }
+        this.price = price;
+    }
+
+    /**
+     * Returns the currently set price required to buy the plot.
+     *
+     * @return the price.
+     * @since TODO
+     */
+    public @NonNegative double price() {
+        return price;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setEventResult(@Nullable final Result eventResult) {
+        this.result = eventResult;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @Nullable Result getEventResult() {
+        return this.result;
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/events/post/PostPlayerBuyPlotEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/post/PostPlayerBuyPlotEvent.java
@@ -1,0 +1,64 @@
+/*
+ * PlotSquared, a land and world management plugin for Minecraft.
+ * Copyright (C) IntellectualSites <https://intellectualsites.com>
+ * Copyright (C) IntellectualSites team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.events.post;
+
+import com.plotsquared.core.events.PlotPlayerEvent;
+import com.plotsquared.core.player.OfflinePlotPlayer;
+import com.plotsquared.core.player.PlotPlayer;
+import com.plotsquared.core.plot.Plot;
+import org.checkerframework.checker.index.qual.NonNegative;
+
+/**
+ * Called after a player has successfully bought a plot.
+ *
+ * @since TODO
+ */
+public class PostPlayerBuyPlotEvent extends PlotPlayerEvent {
+
+    private final OfflinePlotPlayer previousOwner;
+    private final double price;
+
+    public PostPlayerBuyPlotEvent(
+            final PlotPlayer<?> plotPlayer, final OfflinePlotPlayer previousOwner, final Plot plot,
+            @NonNegative final double price
+    ) {
+        super(plotPlayer, plot);
+        this.previousOwner = previousOwner;
+        this.price = price;
+    }
+
+    /**
+     * The previous owner of the bought plot.
+     *
+     * @return the previous owner.
+     */
+    public OfflinePlotPlayer previousOwner() {
+        return previousOwner;
+    }
+
+    /**
+     * Returns the price after potential modifications by {@link com.plotsquared.core.events.PlayerBuyPlotEvent}.
+     *
+     * @return the price the player had to pay to buy the plot.
+     */
+    public double price() {
+        return price;
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
+++ b/Core/src/main/java/com/plotsquared/core/util/EventDispatcher.java
@@ -25,6 +25,7 @@ import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.configuration.caption.TranslatableCaption;
 import com.plotsquared.core.events.PlayerAutoPlotEvent;
 import com.plotsquared.core.events.PlayerAutoPlotsChosenEvent;
+import com.plotsquared.core.events.PlayerBuyPlotEvent;
 import com.plotsquared.core.events.PlayerClaimPlotEvent;
 import com.plotsquared.core.events.PlayerEnterPlotEvent;
 import com.plotsquared.core.events.PlayerLeavePlotEvent;
@@ -49,6 +50,7 @@ import com.plotsquared.core.events.PlotUnlinkEvent;
 import com.plotsquared.core.events.RemoveRoadEntityEvent;
 import com.plotsquared.core.events.TeleportCause;
 import com.plotsquared.core.events.post.PostPlayerAutoPlotEvent;
+import com.plotsquared.core.events.post.PostPlayerBuyPlotEvent;
 import com.plotsquared.core.events.post.PostPlotChangeOwnerEvent;
 import com.plotsquared.core.events.post.PostPlotDeleteEvent;
 import com.plotsquared.core.events.post.PostPlotMergeEvent;
@@ -57,6 +59,7 @@ import com.plotsquared.core.listener.PlayerBlockEventType;
 import com.plotsquared.core.location.Direction;
 import com.plotsquared.core.location.Location;
 import com.plotsquared.core.permissions.Permission;
+import com.plotsquared.core.player.OfflinePlotPlayer;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
@@ -313,6 +316,17 @@ public class EventDispatcher {
         PlayerPlotLimitEvent event = new PlayerPlotLimitEvent(player, calculatedLimit);
         eventBus.post(event);
         return event;
+    }
+
+    public PlayerBuyPlotEvent callPlayerBuyPlot(PlotPlayer<?> player, Plot plot, double price) {
+        PlayerBuyPlotEvent event = new PlayerBuyPlotEvent(player, plot, price);
+        eventBus.post(event);
+        return event;
+    }
+
+    public void callPostPlayerBuyPlot(PlotPlayer<?> player, OfflinePlotPlayer previousOwner, Plot plot,
+                                      double price) {
+        eventBus.post(new PostPlayerBuyPlotEvent(player, previousOwner, plot, price));
     }
 
     public void doJoinTask(final PlotPlayer<?> player) {

--- a/Core/src/main/resources/lang/messages_en.json
+++ b/Core/src/main/resources/lang/messages_en.json
@@ -125,6 +125,7 @@
   "economy.added_balance": "<prefix><gold><money> </gold><gray>has been added to your balance.</gray>",
   "economy.removed_balance": "<prefix><gold><money> </gold><gray>has been taken from your balance.</gray>",
   "economy.removed_granted_plot": "<prefix><gray>You used <used_grants> plot grant(s), you've got </gray><gold><remaining_grants></gold> <gray>left.</gray>",
+  "economy.cannot_buy_blocked":  "<prefix><red>You are not allowed to buy this plot.</red>",
   "setup.choose_generator": "<gold>What generator do you want?</gold>",
   "setup.setup_not_started": "<prefix><gold>No setup started.</gold>",
   "setup.setup_init": "<prefix><gold>Usage: </gold><gray>/plot setup <value></gray>",


### PR DESCRIPTION
## Overview
Required for https://github.com/IntellectualSites/HoloPlots/issues/171

Usage (and my tests):
```java
@Subscribe
    public void onPlayerBuyPlot(PlayerBuyPlotEvent event) {
        // Cancel / Disallow plot buy
        event.setEventResult(Result.DENY);
        
        // Modify price
        event.setPrice(event.price() * 1.337);
        
        // Ignore player balance and set price basically to 0
        event.setEventResult(Result.FORCE);
    }

    @Subscribe
    public void onPlayerBoughtPlot(PostPlayerBuyPlotEvent event) {
        event.getPlotPlayer().sendMessage(StaticCaption.of("Have fun with your plot by " + event.previousOwner().getName() + " " +
                "for which you paid " + event.price()));
    }
```

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
