### PR TITLE
Fix home command reset

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/database/SQLManager.java
+++ b/Core/src/main/java/com/plotsquared/core/database/SQLManager.java
@@ -2401,7 +2401,8 @@ public class SQLManager implements AbstractDB {
         addPlotTask(plot, new UniqueStatement("setPosition") {
             @Override
             public void set(PreparedStatement statement) throws SQLException {
-                statement.setString(1, position == null ? "" : position);
+                // Please see the table creation statement. There is the default value of "default"
+                statement.setString(1, position == null ? "DEFAULT" : position);
                 statement.setInt(2, getId(plot));
             }
 

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -1483,7 +1483,7 @@ public class Plot {
      */
     public void setHome(BlockLoc location) {
         Plot plot = this.getBasePlot(false);
-        if (BlockLoc.ZERO.equals(location) || BlockLoc.MINY.equals(location)) {
+        if (location != null && (BlockLoc.ZERO.equals(location) || BlockLoc.MINY.equals(location))) {
             return;
         }
         plot.getSettings().setPosition(location);


### PR DESCRIPTION
## Overview
This PR should fix the missing reset happening while /p sethome none was executed. I had help with @TheMeinerLP which found the underlying solution together with me, as I am not a great developer with basic sql knowledge yet.

Fixes #4294 

## Description
- We fixed the setposition method with the default value and added a comment too to give other developers a hint to look it up on the statement. Also we added a location not null check because the issue lies within the equals implementation.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
