### PR TITLE
Do not remove entitys with CUSTOM spawn-reason on CreatureSpawnEvent.

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -779,6 +779,10 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
                 Iterator<Entity> iterator = entities.iterator();
                 while (iterator.hasNext()) {
                     Entity entity = iterator.next();
+                    final String spawnReason = entity.getEntitySpawnReason().name();
+                    if ("CUSTOM".equals(spawnReason)) {
+                        continue;
+                    }
                     switch (entity.getType().toString()) {
                         case "EGG":
                         case "FISHING_HOOK":
@@ -867,8 +871,7 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
                                     if (livingEntity.isLeashed() && !Settings.Enabled_Components.KILL_OWNED_ROAD_MOBS) {
                                         continue;
                                     }
-                                    List<MetadataValue> keep = entity.getMetadata("keep");
-                                    if (!keep.isEmpty()) {
+                                    if (entity.hasMetadata("keep")) {
                                         continue;
                                     }
 

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
@@ -120,7 +120,10 @@ public class EntitySpawnListener implements Listener {
         Entity entity = event.getEntity();
         Location location = BukkitUtil.adapt(entity.getLocation());
         PlotArea area = location.getPlotArea();
-        if (!location.isPlotArea()) {
+        if (!location.isPlotArea() || area == null) {
+            return;
+        }
+        if (area.isSpawnCustom() && "CUSTOM".equals(entity.getEntitySpawnReason().name())) {
             return;
         }
         Plot plot = location.getOwnedPlotAbs();


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets. -->

Use "CUSTOM" spawn reason in all entity listeners.

It was already in `EntityEventListener:173` and `PaperListener:206` but not used in `CreatureSpawnEvent` with prevented custom marked entity such as "LingeriePotion" spawned and handled by a separate Plugin

## Description
<!-- Please describe what this pull request does. -->

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
