### PR TITLE
Introduce base plot count placeholder

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/placeholder/PAPIPlaceholders.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/placeholder/PAPIPlaceholders.java
@@ -20,6 +20,8 @@ package com.plotsquared.bukkit.placeholder;
 
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.player.PlotPlayer;
+import com.plotsquared.core.plot.flag.implementations.DoneFlag;
+import com.plotsquared.core.util.query.PlotQuery;
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.entity.Player;
@@ -81,6 +83,20 @@ public class PAPIPlaceholders extends PlaceholderExpansion {
             }
 
             return String.valueOf(pl.getPlotCount(identifier));
+        }
+
+        if (identifier.startsWith("base_plot_count_")) {
+            identifier = identifier.substring("base_plot_count_".length());
+            if (identifier.isEmpty()) {
+                return "";
+            }
+
+            return String.valueOf(PlotQuery.newQuery()
+                    .ownedBy(pl)
+                    .inWorld(identifier)
+                    .whereBasePlot()
+                    .thatPasses(plot -> !DoneFlag.isDone(plot))
+                    .count());
         }
 
         // PlotSquared placeholders

--- a/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
+++ b/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
@@ -31,9 +31,11 @@ import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.flag.GlobalFlagContainer;
 import com.plotsquared.core.plot.flag.PlotFlag;
+import com.plotsquared.core.plot.flag.implementations.DoneFlag;
 import com.plotsquared.core.plot.flag.implementations.ServerPlotFlag;
 import com.plotsquared.core.util.EventDispatcher;
 import com.plotsquared.core.util.PlayerManager;
+import com.plotsquared.core.util.query.PlotQuery;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -95,6 +97,12 @@ public final class PlaceholderRegistry {
             }
             return Integer.toString(player.getAllowedPlots());
         });
+        this.createPlaceholder("base_plot_count", player -> Integer.toString(PlotQuery.newQuery()
+                .ownedBy(player)
+                .whereBasePlot()
+                .thatPasses(plot -> !DoneFlag.isDone(plot))
+                .count())
+        );
         this.createPlaceholder("plot_count", player -> Integer.toString(player.getPlotCount()));
         this.createPlaceholder("currentplot_alias", (player, plot) -> {
             if (plot.getAlias().isEmpty()) {


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #4314

## Description
<!-- Please describe what this pull request does. -->

This introduces a new placeholder `%plotsquared_base_plot_count%` that gives the number of base plots, i.e. considering connected plots as one.

To keep in sync with `%plotsquared_plot_count%`, I also added a world-specific variant.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
