### PR TITLE
Remove static print out of legacy schematic URL

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Download.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Download.java
@@ -20,7 +20,6 @@ package com.plotsquared.core.command;
 
 import com.google.inject.Inject;
 import com.plotsquared.core.configuration.Settings;
-import com.plotsquared.core.configuration.caption.StaticCaption;
 import com.plotsquared.core.configuration.caption.TranslatableCaption;
 import com.plotsquared.core.permissions.Permission;
 import com.plotsquared.core.player.PlotPlayer;
@@ -202,7 +201,6 @@ public class Download extends SubCommand {
                                                     .tag("delete", Tag.preProcessParsed("Not available"))
                                                     .build()
                                     );
-                                    player.sendMessage(StaticCaption.of(value.toString()));
                                 }
                             }
                     ));


### PR DESCRIPTION
Ultimately, we're printing the URL twice, as seen on the bug report. Removing the static print, removes the white non-clickable URL from the prin

Fixes #4306
