### PR TITLE
feat: introduce a fishing flag

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
@@ -40,6 +40,7 @@ import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.plot.flag.FlagContainer;
 import com.plotsquared.core.plot.flag.implementations.BeaconEffectsFlag;
 import com.plotsquared.core.plot.flag.implementations.DoneFlag;
+import com.plotsquared.core.plot.flag.implementations.FishingFlag;
 import com.plotsquared.core.plot.flag.implementations.ProjectilesFlag;
 import com.plotsquared.core.plot.flag.types.BooleanFlag;
 import com.plotsquared.core.plot.world.PlotAreaManager;
@@ -348,6 +349,11 @@ public class PaperListener implements Listener {
                 event.setCancelled(true);
             }
         } else if (!plot.isAdded(pp.getUUID())) {
+            if (entity.getType().equals(EntityType.FISHING_HOOK)) {
+                if (plot.getFlag(FishingFlag.class)) {
+                    return;
+                }
+            }
             if (!plot.getFlag(ProjectilesFlag.class)) {
                 if (!pp.hasPermission(Permission.PERMISSION_ADMIN_PROJECTILE_OTHER)) {
                     pp.sendMessage(

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/ProjectileEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/ProjectileEventListener.java
@@ -28,12 +28,14 @@ import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.plot.PlotHandler;
+import com.plotsquared.core.plot.flag.implementations.FishingFlag;
 import com.plotsquared.core.plot.flag.implementations.ProjectilesFlag;
 import com.plotsquared.core.plot.world.PlotAreaManager;
 import com.plotsquared.core.util.PlotFlagUtil;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
@@ -132,6 +134,11 @@ public class ProjectileEventListener implements Listener {
                 event.setCancelled(true);
             }
         } else if (!plot.isAdded(pp.getUUID())) {
+            if (entity.getType().equals(EntityType.FISHING_HOOK)) {
+                if (plot.getFlag(FishingFlag.class)) {
+                    return;
+                }
+            }
             if (!plot.getFlag(ProjectilesFlag.class)) {
                 if (!pp.hasPermission(Permission.PERMISSION_ADMIN_PROJECTILE_OTHER)) {
                     pp.sendMessage(
@@ -187,7 +194,8 @@ public class ProjectileEventListener implements Listener {
                 return;
             }
             if (plot.isAdded(pp.getUUID()) || pp.hasPermission(Permission.PERMISSION_ADMIN_PROJECTILE_OTHER) || plot.getFlag(
-                    ProjectilesFlag.class)) {
+                    ProjectilesFlag.class) || (entity.getType().equals(EntityType.FISHING_HOOK) && plot.getFlag(
+                    FishingFlag.class))) {
                 return;
             }
             entity.remove();

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/GlobalFlagContainer.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/GlobalFlagContainer.java
@@ -48,6 +48,7 @@ import com.plotsquared.core.plot.flag.implementations.EntityChangeBlockFlag;
 import com.plotsquared.core.plot.flag.implementations.ExplosionFlag;
 import com.plotsquared.core.plot.flag.implementations.FarewellFlag;
 import com.plotsquared.core.plot.flag.implementations.FeedFlag;
+import com.plotsquared.core.plot.flag.implementations.FishingFlag;
 import com.plotsquared.core.plot.flag.implementations.FlyFlag;
 import com.plotsquared.core.plot.flag.implementations.ForcefieldFlag;
 import com.plotsquared.core.plot.flag.implementations.GamemodeFlag;
@@ -158,6 +159,7 @@ public final class GlobalFlagContainer extends FlagContainer {
         this.addFlag(EditSignFlag.EDIT_SIGN_FALSE);
         this.addFlag(EntityChangeBlockFlag.ENTITY_CHANGE_BLOCK_FALSE);
         this.addFlag(ExplosionFlag.EXPLOSION_FALSE);
+        this.addFlag(FishingFlag.FISHING_FALSE);
         this.addFlag(ForcefieldFlag.FORCEFIELD_FALSE);
         this.addFlag(GrassGrowFlag.GRASS_GROW_TRUE);
         this.addFlag(HangingBreakFlag.HANGING_BREAK_FALSE);

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/FishingFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/FishingFlag.java
@@ -1,0 +1,39 @@
+/*
+ * PlotSquared, a land and world management plugin for Minecraft.
+ * Copyright (C) IntellectualSites <https://intellectualsites.com>
+ * Copyright (C) IntellectualSites team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.plot.flag.implementations;
+
+import com.plotsquared.core.configuration.caption.TranslatableCaption;
+import com.plotsquared.core.plot.flag.types.BooleanFlag;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public class FishingFlag extends BooleanFlag<FishingFlag> {
+
+    public static final FishingFlag FISHING_TRUE = new FishingFlag(true);
+    public static final FishingFlag FISHING_FALSE = new FishingFlag(false);
+
+    private FishingFlag(boolean value) {
+        super(value, TranslatableCaption.of("flags.flag_description_projectiles"));
+    }
+
+    @Override
+    protected FishingFlag flagOf(@NonNull final Boolean value) {
+        return value ? FISHING_TRUE : FISHING_FALSE;
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/FishingFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/FishingFlag.java
@@ -28,7 +28,7 @@ public class FishingFlag extends BooleanFlag<FishingFlag> {
     public static final FishingFlag FISHING_FALSE = new FishingFlag(false);
 
     private FishingFlag(boolean value) {
-        super(value, TranslatableCaption.of("flags.flag_description_projectiles"));
+        super(value, TranslatableCaption.of("flags.flag_description_fishing"));
     }
 
     @Override

--- a/Core/src/main/resources/lang/messages_en.json
+++ b/Core/src/main/resources/lang/messages_en.json
@@ -559,6 +559,7 @@
   "flags.flag_description_drop_protection": "<gray>Set to `true` to prevent dropped items from being picked up by non-members of the plot.</gray>",
   "flags.flag_description_edit_sign": "<gray>Set to `true` to allow editing signs in the plot.</gray>",
   "flags.flag_description_feed": "<gray>Specify an interval in seconds and an optional amount by which the players will be fed (amount is 1 by default).</gray>",
+  "flags.flag_description_fishing": "<gray>Set to `true` to allow guests to use a rod in the plot.</gray>",
   "flags.flag_description_forcefield": "<gray>Set to `true` to enable member forcefield in the plot.</gray>",
   "flags.flag_description_grass_grow": "<gray>Set to `false` to prevent grass from growing within the plot.</gray>",
   "flags.flag_description_hanging_break": "<gray>Set to `true` to allow guests to break hanging objects in the plot.</gray>",

--- a/Core/src/main/resources/lang/messages_en.json
+++ b/Core/src/main/resources/lang/messages_en.json
@@ -559,7 +559,7 @@
   "flags.flag_description_drop_protection": "<gray>Set to `true` to prevent dropped items from being picked up by non-members of the plot.</gray>",
   "flags.flag_description_edit_sign": "<gray>Set to `true` to allow editing signs in the plot.</gray>",
   "flags.flag_description_feed": "<gray>Specify an interval in seconds and an optional amount by which the players will be fed (amount is 1 by default).</gray>",
-  "flags.flag_description_fishing": "<gray>Set to `true` to allow guests to use a rod in the plot.</gray>",
+  "flags.flag_description_fishing": "<gray>Set to `true` to allow guests to use a fishing rod in the plot.</gray>",
   "flags.flag_description_forcefield": "<gray>Set to `true` to enable member forcefield in the plot.</gray>",
   "flags.flag_description_grass_grow": "<gray>Set to `false` to prevent grass from growing within the plot.</gray>",
   "flags.flag_description_hanging_break": "<gray>Set to `true` to allow guests to break hanging objects in the plot.</gray>",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ log4j = "2.19.0"
 
 # Plugins
 worldedit = "7.2.18"
-fawe = "2.8.4"
+fawe = "2.9.0"
 placeholderapi = "2.11.5"
 luckperms = "5.4"
 essentialsx = "2.20.1"


### PR DESCRIPTION
Fixes #3455

## Description
Set to `true` to allow guests to use a rod in the plot. If set to `false` only added players and players with the permission `plots.admin.projectile.other` will be able to fish.