### PR TITLE
fix-home-corner-teleport

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -1407,7 +1407,7 @@ public class Plot {
     @Deprecated
     public Location getHomeSynchronous() {
         BlockLoc home = this.getPosition();
-        if (home == null || home.getX() == 0 && home.getZ() == 0) {
+        if (home == null) {
             return this.getDefaultHomeSynchronous(true);
         } else {
             Location bottom = this.getBottomAbs();
@@ -1439,7 +1439,7 @@ public class Plot {
      */
     public void getHome(final Consumer<Location> result) {
         BlockLoc home = this.getPosition();
-        if (home == null || home.getX() == 0 && home.getZ() == 0) {
+        if (home == null) {
             this.getDefaultHome(result);
         } else {
             if (!isLoaded()) {


### PR DESCRIPTION
## Description
If a home was set in the corner, the x, y check ensured that one would be teleported to the default home instead of the corner that was set. It could be that the check was useful for something, but I didn't see the point at first glance.

```[tasklist]
### Submitter Checklist
- [ ] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [ ] Ensure that the pull request title represents the desired changelog entry.
- [ ] New public fields and methods are annotated with `@since TODO`.
- [ ] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
