### PR TITLE
feat-villager-cap-flag

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitEntityUtil.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitEntityUtil.java
@@ -39,6 +39,7 @@ import com.plotsquared.core.plot.flag.implementations.PveFlag;
 import com.plotsquared.core.plot.flag.implementations.PvpFlag;
 import com.plotsquared.core.plot.flag.implementations.TamedAttackFlag;
 import com.plotsquared.core.plot.flag.implementations.VehicleCapFlag;
+import com.plotsquared.core.plot.flag.implementations.VillagerCapFlag;
 import com.plotsquared.core.util.EntityUtil;
 import com.plotsquared.core.util.entity.EntityCategories;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
@@ -373,13 +374,20 @@ public class BukkitEntityUtil {
             );
         }
 
-        // Has to go go before vehicle as horses are both
+        // Has to go before vehicle as horses are both
         // animals and vehicles
-        if (EntityCategories.ANIMAL.contains(entityType) || EntityCategories.VILLAGER
-                .contains(entityType) || EntityCategories.TAMEABLE.contains(entityType)) {
+        if (EntityCategories.ANIMAL.contains(entityType)
+                || EntityCategories.TAMEABLE.contains(entityType)) {
             return EntityUtil
                     .checkEntity(plot, EntityCapFlag.ENTITY_CAP_UNLIMITED, MobCapFlag.MOB_CAP_UNLIMITED,
                             AnimalCapFlag.ANIMAL_CAP_UNLIMITED
+                    );
+        }
+
+        if(EntityCategories.VILLAGER.contains(entityType)) {
+            return EntityUtil
+                    .checkEntity(plot, EntityCapFlag.ENTITY_CAP_UNLIMITED, MobCapFlag.MOB_CAP_UNLIMITED,
+                            VillagerCapFlag.VILLAGER_CAP_UNLIMITED
                     );
         }
 

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitRegionManager.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitRegionManager.java
@@ -58,6 +58,7 @@ import java.util.Set;
 import static com.plotsquared.core.util.entity.EntityCategories.CAP_ANIMAL;
 import static com.plotsquared.core.util.entity.EntityCategories.CAP_ENTITY;
 import static com.plotsquared.core.util.entity.EntityCategories.CAP_MISC;
+import static com.plotsquared.core.util.entity.EntityCategories.CAP_VILLAGER;
 import static com.plotsquared.core.util.entity.EntityCategories.CAP_MOB;
 import static com.plotsquared.core.util.entity.EntityCategories.CAP_MONSTER;
 import static com.plotsquared.core.util.entity.EntityCategories.CAP_VEHICLE;
@@ -122,7 +123,7 @@ public class BukkitRegionManager extends RegionManager {
             }
         }
 
-        int[] count = new int[6];
+        int[] count = new int[7];
         if (doWhole) {
             for (Entity entity : entities) {
                 org.bukkit.Location location = entity.getLocation();
@@ -330,7 +331,10 @@ public class BukkitRegionManager extends RegionManager {
         } else if (EntityCategories.PROJECTILE.contains(entityType) || EntityCategories.OTHER.contains(entityType) || EntityCategories.HANGING
                 .contains(entityType)) {
             count[CAP_MISC]++;
-        } else if (EntityCategories.ANIMAL.contains(entityType) || EntityCategories.VILLAGER.contains(entityType) || EntityCategories.TAMEABLE
+        } else if (EntityCategories.VILLAGER.contains(entityType)) {
+            count[CAP_MOB]++;
+            count[CAP_VILLAGER]++;
+        } else if (EntityCategories.ANIMAL.contains(entityType) || EntityCategories.TAMEABLE
                 .contains(entityType)) {
             count[CAP_MOB]++;
             count[CAP_ANIMAL]++;

--- a/Core/src/main/java/com/plotsquared/core/command/Caps.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Caps.java
@@ -29,6 +29,7 @@ import com.plotsquared.core.plot.flag.implementations.HostileCapFlag;
 import com.plotsquared.core.plot.flag.implementations.MiscCapFlag;
 import com.plotsquared.core.plot.flag.implementations.MobCapFlag;
 import com.plotsquared.core.plot.flag.implementations.VehicleCapFlag;
+import com.plotsquared.core.plot.flag.implementations.VillagerCapFlag;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.minimessage.tag.Tag;
@@ -40,6 +41,7 @@ import static com.plotsquared.core.util.entity.EntityCategories.CAP_MISC;
 import static com.plotsquared.core.util.entity.EntityCategories.CAP_MOB;
 import static com.plotsquared.core.util.entity.EntityCategories.CAP_MONSTER;
 import static com.plotsquared.core.util.entity.EntityCategories.CAP_VEHICLE;
+import static com.plotsquared.core.util.entity.EntityCategories.CAP_VILLAGER;
 
 @CommandDeclaration(command = "caps",
         category = CommandCategory.INFO,
@@ -71,6 +73,7 @@ public class Caps extends SubCommand {
         sendFormatted(plot, player, AnimalCapFlag.class, countedEntities, "animals", CAP_ANIMAL);
         sendFormatted(plot, player, VehicleCapFlag.class, countedEntities, "vehicle", CAP_VEHICLE);
         sendFormatted(plot, player, MiscCapFlag.class, countedEntities, "misc", CAP_MISC);
+        sendFormatted(plot, player, VillagerCapFlag.class, countedEntities, "villagers", CAP_VILLAGER);
         sendFormatted(plot, player, EntityCapFlag.class, countedEntities, "entities", CAP_ENTITY);
         return true;
     }

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -106,6 +106,7 @@ import static com.plotsquared.core.util.entity.EntityCategories.CAP_MISC;
 import static com.plotsquared.core.util.entity.EntityCategories.CAP_MOB;
 import static com.plotsquared.core.util.entity.EntityCategories.CAP_MONSTER;
 import static com.plotsquared.core.util.entity.EntityCategories.CAP_VEHICLE;
+import static com.plotsquared.core.util.entity.EntityCategories.CAP_VILLAGER;
 
 /**
  * The plot class<br>
@@ -1219,7 +1220,7 @@ public class Plot {
      * @see RegionManager#countEntities(Plot)
      */
     public int[] countEntities() {
-        int[] count = new int[6];
+        int[] count = new int[7];
         for (Plot current : this.getConnectedPlots()) {
             int[] result = this.regionManager.countEntities(current);
             count[CAP_ENTITY] += result[CAP_ENTITY];
@@ -1228,6 +1229,7 @@ public class Plot {
             count[CAP_MOB] += result[CAP_MOB];
             count[CAP_VEHICLE] += result[CAP_VEHICLE];
             count[CAP_MISC] += result[CAP_MISC];
+            count[CAP_VILLAGER] += result[CAP_VILLAGER];
         }
         return count;
     }

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/GlobalFlagContainer.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/GlobalFlagContainer.java
@@ -109,6 +109,7 @@ import com.plotsquared.core.plot.flag.implementations.VehicleBreakFlag;
 import com.plotsquared.core.plot.flag.implementations.VehicleCapFlag;
 import com.plotsquared.core.plot.flag.implementations.VehiclePlaceFlag;
 import com.plotsquared.core.plot.flag.implementations.VehicleUseFlag;
+import com.plotsquared.core.plot.flag.implementations.VillagerCapFlag;
 import com.plotsquared.core.plot.flag.implementations.VillagerInteractFlag;
 import com.plotsquared.core.plot.flag.implementations.VineGrowFlag;
 import com.plotsquared.core.plot.flag.implementations.WeatherFlag;
@@ -223,6 +224,7 @@ public final class GlobalFlagContainer extends FlagContainer {
         this.addFlag(EntityCapFlag.ENTITY_CAP_UNLIMITED);
         this.addFlag(HostileCapFlag.HOSTILE_CAP_UNLIMITED);
         this.addFlag(MiscCapFlag.MISC_CAP_UNLIMITED);
+        this.addFlag(VillagerCapFlag.VILLAGER_CAP_UNLIMITED);
         this.addFlag(MobCapFlag.MOB_CAP_UNLIMITED);
         this.addFlag(TimeFlag.TIME_DISABLED);
         this.addFlag(VehicleCapFlag.VEHICLE_CAP_UNLIMITED);

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/VillagerCapFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/VillagerCapFlag.java
@@ -1,0 +1,38 @@
+/*
+ * PlotSquared, a land and world management plugin for Minecraft.
+ * Copyright (C) IntellectualSites <https://intellectualsites.com>
+ * Copyright (C) IntellectualSites team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.plot.flag.implementations;
+
+import com.plotsquared.core.configuration.caption.TranslatableCaption;
+import com.plotsquared.core.plot.flag.types.NonNegativeIntegerFlag;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public class VillagerCapFlag extends NonNegativeIntegerFlag<VillagerCapFlag> {
+
+    public static final VillagerCapFlag VILLAGER_CAP_UNLIMITED = new VillagerCapFlag(Integer.MAX_VALUE);
+
+    protected VillagerCapFlag(int value) {
+        super(value, TranslatableCaption.of("flags.flag_description_villager_cap"));
+    }
+
+    @Override
+    protected VillagerCapFlag flagOf(@NonNull Integer value) {
+        return new VillagerCapFlag(value);
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/util/EntityUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/EntityUtil.java
@@ -30,6 +30,7 @@ import static com.plotsquared.core.util.entity.EntityCategories.CAP_MISC;
 import static com.plotsquared.core.util.entity.EntityCategories.CAP_MOB;
 import static com.plotsquared.core.util.entity.EntityCategories.CAP_MONSTER;
 import static com.plotsquared.core.util.entity.EntityCategories.CAP_VEHICLE;
+import static com.plotsquared.core.util.entity.EntityCategories.CAP_VILLAGER;
 
 /**
  * Entity related general utility methods
@@ -48,6 +49,7 @@ public class EntityUtil {
             case "animal-cap" -> CAP_ANIMAL;
             case "vehicle-cap" -> CAP_VEHICLE;
             case "misc-cap" -> CAP_MISC;
+            case "villager-cap" -> CAP_VILLAGER;
             default -> CAP_ENTITY;
         };
     }

--- a/Core/src/main/java/com/plotsquared/core/util/entity/EntityCategories.java
+++ b/Core/src/main/java/com/plotsquared/core/util/entity/EntityCategories.java
@@ -31,6 +31,7 @@ public class EntityCategories {
     public static final int CAP_MOB = 3;
     public static final int CAP_VEHICLE = 4;
     public static final int CAP_MISC = 5;
+    public static final int CAP_VILLAGER = 6;
 
     public static final EntityCategory ANIMAL = register("animal");
     public static final EntityCategory TAMEABLE = register("tameable");

--- a/Core/src/main/resources/lang/messages_en.json
+++ b/Core/src/main/resources/lang/messages_en.json
@@ -578,6 +578,7 @@
   "flags.flag_description_misc_break": "<gray>Set to `true` to allow guests to break miscellaneous items.</gray>",
   "flags.flag_description_misc_cap": "<gray>Set to an integer value to limit the amount of miscellaneous entities on the plot.</gray>",
   "flags.flag_description_misc_interact": "<gray>Set to `true` to allow guests to interact with miscellaneous items.</gray>",
+  "flags.flag_description_villager_cap": "<gray>Set to an integer value to limit the amount of villagers on the plot.</gray>",
   "flags.flag_description_sculk_sensor_interact": "<gray>Set to `true` to allow guests to interact with sculk sensors.</gray>",
   "flags.flag_description_misc_place": "<gray>Set to `true` to allow guests to place miscellaneous items.</gray>",
   "flags.flag_description_mob_break": "<gray>Set to `true` to allow mobs to break blocks within the plot.</gray>",


### PR DESCRIPTION
Fixes #4269

## Description
With this feature we can limit villagers, useful for some servers that only want to control villagers, which is the case in most cbs servers.