### PR TITLE
Improve teleport behavior for home command

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
@@ -262,6 +262,11 @@ public class BukkitUtil extends WorldUtil {
     }
 
     @Override
+    public boolean isSmallBlock(Location location) {
+        return adapt(location).getBlock().getBoundingBox().getHeight() < 0.25;
+    }
+
+    @Override
     @NonNegative
     public int getHighestBlockSynchronous(final @NonNull String world, final int x, final int z) {
         final World bukkitWorld = Objects.requireNonNull(getWorld(world));

--- a/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
@@ -577,6 +577,8 @@ public class Settings extends Config {
         public static boolean PER_WORLD_VISIT = false;
         @Comment("Search merged plots for having multiple owners when using the visit command")
         public static boolean VISIT_MERGED_OWNERS = true;
+        @Comment("Allows to teleport based on block size instead to spawn on the highest block at the home command")
+        public static boolean SIZED_BASED = true;
 
     }
 

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -1420,6 +1420,9 @@ public class Plot {
                 );
             }
             Location location = toHomeLocation(bottom, home);
+            if (Settings.Teleport.SIZED_BASED && this.worldUtil.isSmallBlock(location) && this.worldUtil.isSmallBlock(location.add(0,1,0))) {
+                return location;
+            }
             if (!this.worldUtil.getBlockSynchronous(location).getBlockType().getMaterial().isAir()) {
                 location = location.withY(
                         Math.max(1 + this.worldUtil.getHighestBlockSynchronous(
@@ -1453,15 +1456,21 @@ public class Plot {
             }
             Location bottom = this.getBottomAbs();
             Location location = toHomeLocation(bottom, home);
-            this.worldUtil.getBlock(location, block -> {
-                if (!block.getBlockType().getMaterial().isAir()) {
-                    this.worldUtil.getHighestBlock(this.getWorldName(), location.getX(), location.getZ(),
-                            y -> result.accept(location.withY(Math.max(1 + y, bottom.getY())))
-                    );
-                } else {
-                    result.accept(location);
-                }
-            });
+            if (Settings.Teleport.SIZED_BASED && this.worldUtil.isSmallBlock(location) && this.worldUtil.isSmallBlock(location.add(0,1,0))) {
+                result.accept(location);
+            } else {
+                this.worldUtil.getBlock(location, block -> {
+
+                    if (!block.getBlockType().getMaterial().isAir()) {
+                        this.worldUtil.getHighestBlock(this.getWorldName(), location.getX(), location.getZ(),
+                                y -> result.accept(location.withY(Math.max(1 + y, bottom.getY())))
+                        );
+                    } else {
+                        result.accept(location);
+                    }
+                });
+            }
+
         }
     }
 

--- a/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
@@ -169,6 +169,13 @@ public abstract class WorldUtil {
     public abstract void getBlock(@NonNull Location location, @NonNull Consumer<BlockState> result);
 
     /**
+     * Checks if the block smaller as a slab
+     * @param location Block location
+     * @return true if it smaller as a slab
+     */
+    public abstract boolean isSmallBlock(@NonNull Location location);
+
+    /**
      * Get the block at a given location (synchronously)
      *
      * @param location Block location


### PR DESCRIPTION
## Overview
Fixes #4351

## Description
This PR adds another setting called `sized-based` in the teleport section. This setting activates an additional check at the home command in which the block size is queried. If this is smaller than a slab, the player will be teleported in between instead of on top of it.

```[tasklist]
### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```


### Additonal informations
Thanks to @Tamikaschu for the base idea and the initial pr of #4352
