### PR TITLE
 Introduce tile-drop flag

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
@@ -43,7 +43,7 @@ import com.plotsquared.core.plot.flag.implementations.BeaconEffectsFlag;
 import com.plotsquared.core.plot.flag.implementations.DoneFlag;
 import com.plotsquared.core.plot.flag.implementations.FishingFlag;
 import com.plotsquared.core.plot.flag.implementations.ProjectilesFlag;
-import com.plotsquared.core.plot.flag.implementations.TileDropsFlag;
+import com.plotsquared.core.plot.flag.implementations.TileDropFlag;
 import com.plotsquared.core.plot.flag.types.BooleanFlag;
 import com.plotsquared.core.plot.world.PlotAreaManager;
 import com.plotsquared.core.util.PlotFlagUtil;
@@ -88,9 +88,9 @@ public class PaperListener implements Listener {
     }
 
     /**
-     * @Since TODO
+     * @since TODO
      */
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
     public void onBlockBreak(final BlockBreakEvent event) {
         Location location = BukkitUtil.adapt(event.getBlock().getLocation());
         PlotArea area = location.getPlotArea();
@@ -99,14 +99,14 @@ public class PaperListener implements Listener {
         }
         Plot plot = area.getPlot(location);
         if (plot != null) {
-            event.setDropItems(!plot.getFlag(TileDropsFlag.class));
+            event.setDropItems(plot.getFlag(TileDropFlag.class));
         }
     }
 
     /**
-     * @Since TODO
+     * @since TODO
      */
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
     public void onBlockDestroy(final BlockDestroyEvent event) {
         Location location = BukkitUtil.adapt(event.getBlock().getLocation());
         PlotArea area = location.getPlotArea();
@@ -115,7 +115,7 @@ public class PaperListener implements Listener {
         }
         Plot plot = area.getPlot(location);
         if (plot != null) {
-            event.setWillDrop(!plot.getFlag(TileDropsFlag.class));
+            event.setWillDrop(plot.getFlag(TileDropFlag.class));
         }
     }
 

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
@@ -19,6 +19,7 @@
 package com.plotsquared.bukkit.listener;
 
 import com.destroystokyo.paper.event.block.BeaconEffectEvent;
+import com.destroystokyo.paper.event.block.BlockDestroyEvent;
 import com.destroystokyo.paper.event.entity.EntityPathfindEvent;
 import com.destroystokyo.paper.event.entity.PlayerNaturallySpawnCreaturesEvent;
 import com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent;
@@ -42,6 +43,7 @@ import com.plotsquared.core.plot.flag.implementations.BeaconEffectsFlag;
 import com.plotsquared.core.plot.flag.implementations.DoneFlag;
 import com.plotsquared.core.plot.flag.implementations.FishingFlag;
 import com.plotsquared.core.plot.flag.implementations.ProjectilesFlag;
+import com.plotsquared.core.plot.flag.implementations.TileDropsFlag;
 import com.plotsquared.core.plot.flag.types.BooleanFlag;
 import com.plotsquared.core.plot.world.PlotAreaManager;
 import com.plotsquared.core.util.PlotFlagUtil;
@@ -59,6 +61,7 @@ import org.bukkit.entity.Slime;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.projectiles.ProjectileSource;
@@ -82,6 +85,32 @@ public class PaperListener implements Listener {
     @Inject
     public PaperListener(final @NonNull PlotAreaManager plotAreaManager) {
         this.plotAreaManager = plotAreaManager;
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onBlockBreak(final BlockBreakEvent event) {
+        Location location = BukkitUtil.adapt(event.getBlock().getLocation());
+        PlotArea area = location.getPlotArea();
+        if (area == null) {
+            return;
+        }
+        Plot plot = area.getPlot(location);
+        if (plot != null) {
+            event.setDropItems(!plot.getFlag(TileDropsFlag.class));
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onBlockDestroy(final BlockDestroyEvent event) {
+        Location location = BukkitUtil.adapt(event.getBlock().getLocation());
+        PlotArea area = location.getPlotArea();
+        if (area == null) {
+            return;
+        }
+        Plot plot = area.getPlot(location);
+        if (plot != null) {
+            event.setWillDrop(!plot.getFlag(TileDropsFlag.class));
+        }
     }
 
     @EventHandler

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
@@ -61,7 +61,6 @@ import org.bukkit.entity.Slime;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.projectiles.ProjectileSource;
@@ -87,25 +86,6 @@ public class PaperListener implements Listener {
         this.plotAreaManager = plotAreaManager;
     }
 
-    /**
-     * @since TODO
-     */
-    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
-    public void onBlockBreak(final BlockBreakEvent event) {
-        Location location = BukkitUtil.adapt(event.getBlock().getLocation());
-        PlotArea area = location.getPlotArea();
-        if (area == null) {
-            return;
-        }
-        Plot plot = area.getPlot(location);
-        if (plot != null) {
-            event.setDropItems(plot.getFlag(TileDropFlag.class));
-        }
-    }
-
-    /**
-     * @since TODO
-     */
     @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
     public void onBlockDestroy(final BlockDestroyEvent event) {
         Location location = BukkitUtil.adapt(event.getBlock().getLocation());

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
@@ -87,6 +87,9 @@ public class PaperListener implements Listener {
         this.plotAreaManager = plotAreaManager;
     }
 
+    /**
+     * @Since TODO
+     */
     @EventHandler(ignoreCancelled = true)
     public void onBlockBreak(final BlockBreakEvent event) {
         Location location = BukkitUtil.adapt(event.getBlock().getLocation());
@@ -100,6 +103,9 @@ public class PaperListener implements Listener {
         }
     }
 
+    /**
+     * @Since TODO
+     */
     @EventHandler(ignoreCancelled = true)
     public void onBlockDestroy(final BlockDestroyEvent event) {
         Location location = BukkitUtil.adapt(event.getBlock().getLocation());

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -61,6 +61,7 @@ import com.plotsquared.core.plot.flag.implementations.MiscInteractFlag;
 import com.plotsquared.core.plot.flag.implementations.PlayerInteractFlag;
 import com.plotsquared.core.plot.flag.implementations.PreventCreativeCopyFlag;
 import com.plotsquared.core.plot.flag.implementations.TamedInteractFlag;
+import com.plotsquared.core.plot.flag.implementations.TileDropFlag;
 import com.plotsquared.core.plot.flag.implementations.UntrustedVisitFlag;
 import com.plotsquared.core.plot.flag.implementations.VehicleBreakFlag;
 import com.plotsquared.core.plot.flag.implementations.VehicleUseFlag;
@@ -107,6 +108,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.EntityPlaceEvent;
 import org.bukkit.event.entity.EntityPotionEffectEvent;
@@ -234,6 +236,19 @@ public class PlayerEventListener implements Listener {
         this.worldEdit = worldEdit;
         this.plotAreaManager = plotAreaManager;
         this.plotListener = plotListener;
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
+    public void onBlockBreak(final BlockBreakEvent event) {
+        Location location = BukkitUtil.adapt(event.getBlock().getLocation());
+        PlotArea area = location.getPlotArea();
+        if (area == null) {
+            return;
+        }
+        Plot plot = area.getPlot(location);
+        if (plot != null) {
+            event.setDropItems(plot.getFlag(TileDropFlag.class));
+        }
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/GlobalFlagContainer.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/GlobalFlagContainer.java
@@ -102,7 +102,7 @@ import com.plotsquared.core.plot.flag.implementations.SnowMeltFlag;
 import com.plotsquared.core.plot.flag.implementations.SoilDryFlag;
 import com.plotsquared.core.plot.flag.implementations.TamedAttackFlag;
 import com.plotsquared.core.plot.flag.implementations.TamedInteractFlag;
-import com.plotsquared.core.plot.flag.implementations.TileDropsFlag;
+import com.plotsquared.core.plot.flag.implementations.TileDropFlag;
 import com.plotsquared.core.plot.flag.implementations.TimeFlag;
 import com.plotsquared.core.plot.flag.implementations.TitlesFlag;
 import com.plotsquared.core.plot.flag.implementations.UntrustedVisitFlag;
@@ -199,7 +199,7 @@ public final class GlobalFlagContainer extends FlagContainer {
         this.addFlag(SoilDryFlag.SOIL_DRY_FALSE);
         this.addFlag(TamedAttackFlag.TAMED_ATTACK_FALSE);
         this.addFlag(TamedInteractFlag.TAMED_INTERACT_FALSE);
-        this.addFlag(TileDropsFlag.TILE_DROP_FALSE);
+        this.addFlag(TileDropFlag.TILE_DROP_TRUE);
         this.addFlag(UntrustedVisitFlag.UNTRUSTED_VISIT_FLAG_TRUE);
         this.addFlag(VehicleBreakFlag.VEHICLE_BREAK_FALSE);
         this.addFlag(VehiclePlaceFlag.VEHICLE_PLACE_FALSE);

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/GlobalFlagContainer.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/GlobalFlagContainer.java
@@ -102,6 +102,7 @@ import com.plotsquared.core.plot.flag.implementations.SnowMeltFlag;
 import com.plotsquared.core.plot.flag.implementations.SoilDryFlag;
 import com.plotsquared.core.plot.flag.implementations.TamedAttackFlag;
 import com.plotsquared.core.plot.flag.implementations.TamedInteractFlag;
+import com.plotsquared.core.plot.flag.implementations.TileDropsFlag;
 import com.plotsquared.core.plot.flag.implementations.TimeFlag;
 import com.plotsquared.core.plot.flag.implementations.TitlesFlag;
 import com.plotsquared.core.plot.flag.implementations.UntrustedVisitFlag;
@@ -198,6 +199,7 @@ public final class GlobalFlagContainer extends FlagContainer {
         this.addFlag(SoilDryFlag.SOIL_DRY_FALSE);
         this.addFlag(TamedAttackFlag.TAMED_ATTACK_FALSE);
         this.addFlag(TamedInteractFlag.TAMED_INTERACT_FALSE);
+        this.addFlag(TileDropsFlag.TILE_DROP_FALSE);
         this.addFlag(UntrustedVisitFlag.UNTRUSTED_VISIT_FLAG_TRUE);
         this.addFlag(VehicleBreakFlag.VEHICLE_BREAK_FALSE);
         this.addFlag(VehiclePlaceFlag.VEHICLE_PLACE_FALSE);

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/TileDropFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/TileDropFlag.java
@@ -23,20 +23,20 @@ import com.plotsquared.core.plot.flag.types.BooleanFlag;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
- * @Since TODO
+ * @since TODO
  */
 
-public class TileDropsFlag extends BooleanFlag<TileDropsFlag> {
+public class TileDropFlag extends BooleanFlag<TileDropFlag> {
 
-    public static final TileDropsFlag TILE_DROP_TRUE = new TileDropsFlag(true);
-    public static final TileDropsFlag TILE_DROP_FALSE = new TileDropsFlag(false);
+    public static final TileDropFlag TILE_DROP_TRUE = new TileDropFlag(true);
+    public static final TileDropFlag TILE_DROP_FALSE = new TileDropFlag(false);
 
-    private TileDropsFlag(boolean value) {
-        super(value, TranslatableCaption.of("flags.flag_description_tile_drops"));
+    private TileDropFlag(boolean value) {
+        super(value, TranslatableCaption.of("flags.flag_description_tile_drop"));
     }
 
     @Override
-    protected TileDropsFlag flagOf(@NonNull Boolean value) {
+    protected TileDropFlag flagOf(@NonNull Boolean value) {
         return value ? TILE_DROP_TRUE : TILE_DROP_FALSE;
     }
 

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/TileDropsFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/TileDropsFlag.java
@@ -1,0 +1,39 @@
+/*
+ * PlotSquared, a land and world management plugin for Minecraft.
+ * Copyright (C) IntellectualSites <https://intellectualsites.com>
+ * Copyright (C) IntellectualSites team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.plot.flag.implementations;
+
+import com.plotsquared.core.configuration.caption.TranslatableCaption;
+import com.plotsquared.core.plot.flag.types.BooleanFlag;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public class TileDropsFlag extends BooleanFlag<TileDropsFlag> {
+
+    public static final TileDropsFlag TILE_DROP_TRUE = new TileDropsFlag(true);
+    public static final TileDropsFlag TILE_DROP_FALSE = new TileDropsFlag(false);
+
+    private TileDropsFlag(boolean value) {
+        super(value, TranslatableCaption.of("flags.flag_description_tile_drops"));
+    }
+
+    @Override
+    protected TileDropsFlag flagOf(@NonNull Boolean value) {
+        return value ? TILE_DROP_TRUE : TILE_DROP_FALSE;
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/TileDropsFlag.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/flag/implementations/TileDropsFlag.java
@@ -22,6 +22,10 @@ import com.plotsquared.core.configuration.caption.TranslatableCaption;
 import com.plotsquared.core.plot.flag.types.BooleanFlag;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+/**
+ * @Since TODO
+ */
+
 public class TileDropsFlag extends BooleanFlag<TileDropsFlag> {
 
     public static final TileDropsFlag TILE_DROP_TRUE = new TileDropsFlag(true);

--- a/Core/src/main/resources/lang/messages_en.json
+++ b/Core/src/main/resources/lang/messages_en.json
@@ -606,7 +606,7 @@
   "flags.flag_description_tamed_attack": "<gray>Set to `true` to allow guests to attack tamed animals in the plot.</gray>",
   "flags.flag_description_tamed_interact": "<gray>Set to `true` to allow guests to interact with tamed animals in the plot.</gray>",
   "flags.flag_description_time": "<gray>Set the time in the plot to a fixed value.</gray>",
-  "flags.flag_description_tile_drop": "<gray>Set whether blocks should have drops (Equivalent to 'doTileDrops' game rule).</gray>",
+  "flags.flag_description_tile_drop": "<gray>Set to `false` to prevent blocks from dropping items in the plot.</gray>",
   "flags.flag_description_titles": "<gray>Set to `false` to disable plot titles. Can be set to: `none` (to inherit world settings), `true`, or `false`</gray>",
   "flags.flag_description_title": "<gray>Set the pop-up title's title and subtitle. Format: /plot flag set title \"A title\" \"The subtitle\"</gray>",
   "flags.flag_description_use": "<gray>Define a list of materials players should be able to interact with in the plot.</gray>",

--- a/Core/src/main/resources/lang/messages_en.json
+++ b/Core/src/main/resources/lang/messages_en.json
@@ -606,6 +606,7 @@
   "flags.flag_description_tamed_attack": "<gray>Set to `true` to allow guests to attack tamed animals in the plot.</gray>",
   "flags.flag_description_tamed_interact": "<gray>Set to `true` to allow guests to interact with tamed animals in the plot.</gray>",
   "flags.flag_description_time": "<gray>Set the time in the plot to a fixed value.</gray>",
+  "flags.flag_description_tile_drops": "<gray>Set whether blocks should have drops (Equivalent to 'doTileDrops' game rule).</gray>",
   "flags.flag_description_titles": "<gray>Set to `false` to disable plot titles. Can be set to: `none` (to inherit world settings), `true`, or `false`</gray>",
   "flags.flag_description_title": "<gray>Set the pop-up title's title and subtitle. Format: /plot flag set title \"A title\" \"The subtitle\"</gray>",
   "flags.flag_description_use": "<gray>Define a list of materials players should be able to interact with in the plot.</gray>",

--- a/Core/src/main/resources/lang/messages_en.json
+++ b/Core/src/main/resources/lang/messages_en.json
@@ -606,7 +606,7 @@
   "flags.flag_description_tamed_attack": "<gray>Set to `true` to allow guests to attack tamed animals in the plot.</gray>",
   "flags.flag_description_tamed_interact": "<gray>Set to `true` to allow guests to interact with tamed animals in the plot.</gray>",
   "flags.flag_description_time": "<gray>Set the time in the plot to a fixed value.</gray>",
-  "flags.flag_description_tile_drops": "<gray>Set whether blocks should have drops (Equivalent to 'doTileDrops' game rule).</gray>",
+  "flags.flag_description_tile_drop": "<gray>Set whether blocks should have drops (Equivalent to 'doTileDrops' game rule).</gray>",
   "flags.flag_description_titles": "<gray>Set to `false` to disable plot titles. Can be set to: `none` (to inherit world settings), `true`, or `false`</gray>",
   "flags.flag_description_title": "<gray>Set the pop-up title's title and subtitle. Format: /plot flag set title \"A title\" \"The subtitle\"</gray>",
   "flags.flag_description_use": "<gray>Define a list of materials players should be able to interact with in the plot.</gray>",


### PR DESCRIPTION
## Description
Introduces a flag equivalent to the `doTileDrops` game rule. This flag, when set to false, prevents blocks from dropping items, even if they are not broken by a player, so the game rule can now be set per plot.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
