### PR TITLE
fix: skip valid location check for world plots

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -2574,7 +2574,7 @@ public class Plot {
      */
     public void teleportPlayer(final PlotPlayer<?> player, TeleportCause cause, Consumer<Boolean> resultConsumer) {
         Plot plot = this.getBasePlot(false);
-        if (!WorldUtil.isValidLocation(plot.getBottomAbs())) {
+        if ((getArea() == null || !(getArea() instanceof SinglePlotArea)) && !WorldUtil.isValidLocation(plot.getBottomAbs())) {
             // prevent from teleporting into unsafe regions
             player.sendMessage(TranslatableCaption.of("border.denied"));
             resultConsumer.accept(false);

--- a/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlotManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlotManager.java
@@ -37,7 +37,7 @@ import java.util.List;
 
 public class SinglePlotManager extends PlotManager {
 
-    private static final int MAX_COORDINATE = 30000000;
+    private static final int MAX_COORDINATE = 20000000;
 
     public SinglePlotManager(final @NonNull PlotArea plotArea) {
         super(plotArea);


### PR DESCRIPTION
 - Checking location on teleport to a single plot means the bukkit world is attempted to be accessed before it is loaded
 - we can just skip this check because we know the player will teleport to a reasonable location