### PR TITLE
fix plot music volume to span full plot

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/player/BukkitPlayer.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/player/BukkitPlayer.java
@@ -326,7 +326,7 @@ public class BukkitPlayer extends PlotPlayer<Player> {
             return;
         }
         this.player.playSound(BukkitUtil.adapt(location), Sound.valueOf(BukkitAdapter.adapt(id).name()),
-                SoundCategory.MUSIC, 1f, 1f
+                SoundCategory.MUSIC, Float.MAX_VALUE, 1f
         );
     }
 


### PR DESCRIPTION
## Overview
Fixes #4316

## Description
I missed a Float.MAX_VALUE in https://github.com/IntellectualSites/PlotSquared/pull/4302 - which this PR is a follow-up to and addresses the mistake.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
