### PR TITLE
Make builds reproducible

### DIFF
--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -113,5 +113,6 @@ tasks {
         opt.encoding("UTF-8")
         opt.keyWords()
         opt.addStringOption("-since", isRelease)
+        opt.noTimestamp()
     }
 }

--- a/Core/build.gradle.kts
+++ b/Core/build.gradle.kts
@@ -78,5 +78,6 @@ tasks {
         opt.encoding("UTF-8")
         opt.keyWords()
         opt.addStringOption("-since", isRelease)
+        opt.noTimestamp()
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -209,6 +209,11 @@ subprojects {
         test {
             useJUnitPlatform()
         }
+
+        withType<AbstractArchiveTask>().configureEach {
+            isPreserveFileTimestamps = false
+            isReproducibleFileOrder = true
+        }
     }
 }
 


### PR DESCRIPTION
[reproducible-builds.org](https://reproducible-builds.org/) explains the reasons why reproducible builds are desirable. As of gradle 3.4, we can make use of a [dedicated](https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives) task.

Additionally, the PR suppresses the hidden timestamp in javadocs' html code, ensuring this PR applies to -javadoc.jar's too.
Using diffoscope, the change proposed can be validated to produce identical jars.