### PR TITLE
Introduce 'skip.signing' property

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,7 +118,7 @@ subprojects {
     }
 
     signing {
-        if (!version.toString().endsWith("-SNAPSHOT")) {
+        if (!project.hasProperty("skip.signing") && !version.toString().endsWith("-SNAPSHOT")) {
             val signingKey: String? by project
             val signingPassword: String? by project
             useInMemoryPgpKeys(signingKey, signingPassword)


### PR DESCRIPTION
Working towards https://github.com/IntellectualSites/PlotSquared/pull/4395, by introducing a property to skip signing, for example, when calling `publishToMavenLocal` to skip the signing step but generate a local publishing bundle when comparing data.