### PR TITLE
Don't heal dead players

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
+++ b/Core/src/main/java/com/plotsquared/core/listener/PlotListener.java
@@ -106,6 +106,10 @@ public class PlotListener {
                             iterator.remove();
                             continue;
                         }
+                        // Don't attempt to heal dead players - they will get stuck in the abyss (#4406)
+                        if (PlotSquared.platform().worldUtil().getHealth(player) <= 0) {
+                            continue;
+                        }
                         double level = PlotSquared.platform().worldUtil().getHealth(player);
                         if (level != value.max) {
                             PlotSquared.platform().worldUtil().setHealth(player, Math.min(level + value.amount, value.max));


### PR DESCRIPTION
## Overview
Skips dead players (health < 0.1) from the healing scheduling task

Fixes #4406

## Description
As of now, dead players are healed by the heal-flag even when they are dead (open respawn screen). The healthbar fills, while in the respawn screen - and it seems the server does not like that behavior at all. In my case, I could not click on respawn (button stay's dark gray / in pressed state). When clicking on "Back to Title Screen" and then "Respawn" it just put's me back into the world as if I did not die at all.

Just ignoring dead players seem to fix that behavior.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
