### PR TITLE
perf: Avoid expensive Plot#getOwner calls in Plot#getOwners

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -643,35 +643,25 @@ public class Plot {
     }
 
     /**
-     * Gets a immutable set of owner UUIDs for a plot (supports multi-owner mega-plots).
+     * Gets an immutable set of owner UUIDs for a plot (supports multi-owner mega-plots).
      * <p>
      * This method cannot be used to add or remove owners from a plot.
      * </p>
      *
-     * @return Immutable view of plot owners
+     * @return Immutable set of plot owners
      */
     public @NonNull Set<UUID> getOwners() {
         if (this.getOwner() == null) {
             return ImmutableSet.of();
         }
-        if (isMerged()) {
-            Set<Plot> plots = getConnectedPlots();
-            Plot[] array = plots.toArray(new Plot[0]);
-            ImmutableSet.Builder<UUID> owners = ImmutableSet.builder();
-            UUID last = this.getOwner();
-            owners.add(this.getOwner());
-            for (final Plot current : array) {
-                if (current.getOwner() == null) {
-                    continue;
-                }
-                if (last == null || current.getOwner().getMostSignificantBits() != last.getMostSignificantBits()) {
-                    owners.add(current.getOwner());
-                    last = current.getOwner();
-                }
+        ImmutableSet.Builder<UUID> owners = ImmutableSet.builder();
+        for (Plot plot : getConnectedPlots()) {
+            UUID owner = plot.getOwner();
+            if (owner != null) {
+                owners.add(owner);
             }
-            return owners.build();
         }
-        return ImmutableSet.of(this.getOwner());
+        return owners.build();
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -651,9 +651,6 @@ public class Plot {
      * @return Immutable set of plot owners
      */
     public @NonNull Set<UUID> getOwners() {
-        if (this.getOwner() == null) {
-            return ImmutableSet.of();
-        }
         ImmutableSet.Builder<UUID> owners = ImmutableSet.builder();
         for (Plot plot : getConnectedPlots()) {
             UUID owner = plot.getOwner();


### PR DESCRIPTION
## Overview

## Description
Refactored Plot#getOwners and reduced the number of Plot#getOwner calls because
they go through a half dozen flag containers to check whether the plot is server-owned.

I'd like input on the first null check. The behavior is the same as the old implementation,
but it seems a little illogical. If there are 2 plots, one without an owner - getOwners would
return an empty set if called on the ownerless one, and 1 element on the other, creating
inconsistency.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
