### PR TITLE
perf: make PlayerManager and WorldManager access faster

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -24,7 +24,6 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Singleton;
 import com.google.inject.Stage;
-import com.google.inject.TypeLiteral;
 import com.plotsquared.bukkit.generator.BukkitPlotGenerator;
 import com.plotsquared.bukkit.inject.BackupModule;
 import com.plotsquared.bukkit.inject.BukkitModule;
@@ -45,7 +44,6 @@ import com.plotsquared.bukkit.listener.SpigotListener;
 import com.plotsquared.bukkit.listener.WorldEvents;
 import com.plotsquared.bukkit.placeholder.PAPIPlaceholders;
 import com.plotsquared.bukkit.placeholder.PlaceholderFormatter;
-import com.plotsquared.bukkit.player.BukkitPlayer;
 import com.plotsquared.bukkit.player.BukkitPlayerManager;
 import com.plotsquared.bukkit.util.BukkitUtil;
 import com.plotsquared.bukkit.util.BukkitWorld;
@@ -1271,15 +1269,13 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
 
     @Override
     public @NonNull PlatformWorldManager<?> worldManager() {
-        return injector().getInstance(Key.get(new TypeLiteral<PlatformWorldManager<World>>() {
-        }));
+        return worldManager;
     }
 
     @Override
     @NonNull
-    @SuppressWarnings("unchecked")
     public PlayerManager<? extends PlotPlayer<Player>, ? extends Player> playerManager() {
-        return (PlayerManager<BukkitPlayer, Player>) injector().getInstance(PlayerManager.class);
+        return playerManager;
     }
 
     @Override

--- a/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/PlayerManager.java
@@ -331,12 +331,7 @@ public abstract class PlayerManager<P extends PlotPlayer<? extends T>, T> {
      */
     public @NonNull P getPlayer(final @NonNull UUID uuid) {
         synchronized (playerLock) {
-            P player = this.playerMap.get(uuid);
-            if (player == null) {
-                player = createPlayer(uuid);
-                this.playerMap.put(uuid, player);
-            }
-            return player;
+            return this.playerMap.computeIfAbsent(uuid, this::createPlayer);
         }
     }
 


### PR DESCRIPTION
## Overview
Replaced expensive injector access with already present fields.
Also, avoided a possible extra map access by using computeIfAbsent.

## Description
<!-- Please describe what this pull request does. -->

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
