### PR TITLE
fix: PlayerEnterPlotEvent (java doc) description

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/events/PlayerEnterPlotEvent.java
+++ b/Core/src/main/java/com/plotsquared/core/events/PlayerEnterPlotEvent.java
@@ -24,7 +24,7 @@ import com.plotsquared.core.plot.Plot;
 public class PlayerEnterPlotEvent extends PlotPlayerEvent {
 
     /**
-     * Called when a player leaves a plot.
+     * PlayerEnterPlotEvent: Called when a player enters a plot
      *
      * @param player Player that entered the plot
      * @param plot   Plot that was entered


### PR DESCRIPTION
## Overview
In this small Pull-Request the description of the `PlayerEnterPlotEvent` is fixed.

## Description

- The event should be triggered when the player "enters" the plot. And not when he "leaves" it.
- The wording now corresponds to the description of the [PlayerLeavePlotEvent](https://github.com/IntellectualSites/PlotSquared/blob/c8e8eb919f2cc76fc3ac4f3d1063c7c2847b237b/Core/src/main/java/com/plotsquared/core/events/PlayerLeavePlotEvent.java#L29-L37) event.

```[tasklist]
### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
