### PR TITLE
Ref: height limit check

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -60,7 +60,6 @@ import com.plotsquared.core.util.task.TaskTime;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.world.block.BlockType;
-import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.Bukkit;

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -1210,18 +1210,9 @@ public class BlockEventListener implements Listener {
             if (pp.hasPermission(Permission.PERMISSION_ADMIN_BUILD_HEIGHT_LIMIT)) {
                 continue;
             }
-            if (currentLocation.getY() >= area.getMaxBuildHeight() || currentLocation.getY() < area.getMinBuildHeight()) {
-                pp.sendMessage(
-                        TranslatableCaption.of("height.height_limit"),
-                        TagResolver.builder()
-                                .tag("minheight", Tag.inserting(Component.text(area.getMinBuildHeight())))
-                                .tag("maxheight", Tag.inserting(Component.text(area.getMaxBuildHeight())))
-                                .build()
-                );
-                if (area.notifyIfOutsideBuildArea(pp, currentLocation.getY())) {
-                    event.setCancelled(true);
-                    break;
-                }
+            if (area.notifyIfOutsideBuildArea(pp, currentLocation.getY())) {
+                event.setCancelled(true);
+                break;
             }
         }
 

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -164,13 +164,6 @@ public class BlockEventListener implements Listener {
         if (plot != null) {
             if (area.notifyIfOutsideBuildArea(pp, location.getY())) {
                 event.setCancelled(true);
-                pp.sendMessage(
-                        TranslatableCaption.of("height.height_limit"),
-                        TagResolver.builder()
-                                .tag("minheight", Tag.inserting(Component.text(area.getMinBuildHeight())))
-                                .tag("maxheight", Tag.inserting(Component.text(area.getMaxBuildHeight())))
-                                .build()
-                );
                 return;
             }
             if (!plot.hasOwner()) {
@@ -262,13 +255,6 @@ public class BlockEventListener implements Listener {
                 }
             } else if (area.notifyIfOutsideBuildArea(plotPlayer, location.getY())) {
                 event.setCancelled(true);
-                plotPlayer.sendMessage(
-                        TranslatableCaption.of("height.height_limit"),
-                        TagResolver.builder()
-                                .tag("minheight", Tag.inserting(Component.text(area.getMinBuildHeight())))
-                                .tag("maxheight", Tag.inserting(Component.text(area.getMaxBuildHeight())))
-                                .build()
-                );
                 return;
             }
             if (!plot.hasOwner()) {

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotArea.java
@@ -679,10 +679,8 @@ public abstract class PlotArea implements ComponentLike {
                     TranslatableCaption.of("height.height_limit"),
                     TagResolver.builder()
                             .tag("minheight", Tag.inserting(Component.text(minBuildHeight)))
-                            .tag(
-                                    "maxheight",
-                                    Tag.inserting(Component.text(maxBuildHeight))
-                            ).build()
+                            .tag("maxheight", Tag.inserting(Component.text(maxBuildHeight)))
+                            .build()
             );
             // Return true if "failed" as the method will always be inverted otherwise
             return true;


### PR DESCRIPTION
## Overview

- The `notifyIfOutsideBuildArea` method checks the limits and already includes sending the `height.height_limit` message. This does not need to be called again in the code.
- Small reformatting

## Description

In my test, the message was sent correctly even after the refactoring (`min_height: 1`; `max_height: 256`).

![grafik](https://github.com/IntellectualSites/PlotSquared/assets/4140635/325454af-ccd3-4b78-bf11-8f49c9074ec7)

```[tasklist]
### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
