### PR TITLE
Replace isEnabled check with null check to fix vault interactions

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/inject/BukkitModule.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/inject/BukkitModule.java
@@ -133,7 +133,7 @@ public class BukkitModule extends AbstractModule {
     @Provides
     @Singleton
     @NonNull EconHandler provideEconHandler() {
-        if (!Settings.Enabled_Components.ECONOMY || !Bukkit.getPluginManager().isPluginEnabled("Vault")) {
+        if (!Settings.Enabled_Components.ECONOMY || Bukkit.getPluginManager().getPlugin("Vault") == null) {
             return EconHandler.nullEconHandler();
         }
         // Guice eagerly initializes singletons, so we need to bring the laziness ourselves

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/inject/PermissionModule.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/inject/PermissionModule.java
@@ -32,7 +32,7 @@ public class PermissionModule extends AbstractModule {
     @Singleton
     PermissionHandler providePermissionHandler() {
         try {
-            if (Bukkit.getPluginManager().isPluginEnabled("Vault")) {
+            if (Bukkit.getPluginManager().getPlugin("Vault") != null) {
                 return new VaultPermissionHandler();
             }
         } catch (final Exception ignored) {


### PR DESCRIPTION
## Overview
In some cases, the `isEnabled` check will cause the NullEconHandler to be used - Even though everything will work out.

## Description
I noticed that PlotSquared will use the NullEconHandler in some scenarios.
One of them is when the plugin providing the Economy is depending on Vault and PlotSquared.

I fixed this by replacing the Vault `isEnabled` check with a null check.

The VaultPermissionHandler was also affected, so I also replaced the `isEnabled` check with a null check.

Note that I kept the Vault `isEnabled` check in the `ServerListener`, since Vault is going to be enabled at this point.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
(At least I think I did it correctly?)
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
(There are no new public fields and methods)
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
