### PR TITLE
Replace `isPluginEnabled` check with null check. Fixes vault economy interactions.

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/inject/BukkitModule.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/inject/BukkitModule.java
@@ -133,7 +133,7 @@ public class BukkitModule extends AbstractModule {
     @Provides
     @Singleton
     @NonNull EconHandler provideEconHandler() {
-        if (!Settings.Enabled_Components.ECONOMY || !Bukkit.getPluginManager().isPluginEnabled("Vault")) {
+        if (!Settings.Enabled_Components.ECONOMY || Bukkit.getPluginManager().getPlugin("Vault") == null) {
             return EconHandler.nullEconHandler();
         }
         // Guice eagerly initializes singletons, so we need to bring the laziness ourselves


### PR DESCRIPTION
## Overview
In some cases, the `isPluginEnabled` check will cause the NullEconHandler to be used - Even though everything will work out.

## Description
I noticed that PlotSquared will use the `NullEconHandler` in some scenarios.
One of them is when the plugin providing the Economy is depending on Vault and PlotSquared.

I fixed this by replacing the Vault `isPluginEnabled` check with a null check.

The VaultPermissionHandler is also affected, although I don't know what's causing the issue here.
I did not replace the `isPluginEnabled` this time, as it breaks permissions otherwise (See previous pull request).

Note that I kept the Vault `isPluginEnabled`  check in the `ServerListener`, since Vault is going to be enabled at this point.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
