### PR TITLE
fix: rename minecart EntityType enum constants

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -821,12 +821,18 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
                         case "ARMOR_STAND":
                             // Temporarily classify as vehicle
                         case "MINECART":
+                        case "MINECART_CHEST":
                         case "CHEST_MINECART":
+                        case "MINECART_COMMAND":
                         case "COMMAND_BLOCK_MINECART":
+                        case "MINECART_FURNACE":
                         case "FURNACE_MINECART":
+                        case "MINECART_HOPPER":
                         case "HOPPER_MINECART":
+                        case "MINECART_MOB_SPAWNER":
                         case "SPAWNER_MINECART":
                         case "ENDER_CRYSTAL":
+                        case "MINECART_TNT":
                         case "TNT_MINECART":
                         case "CHEST_BOAT":
                         case "BOAT":

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -821,13 +821,13 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
                         case "ARMOR_STAND":
                             // Temporarily classify as vehicle
                         case "MINECART":
-                        case "MINECART_CHEST":
-                        case "MINECART_COMMAND":
-                        case "MINECART_FURNACE":
-                        case "MINECART_HOPPER":
-                        case "MINECART_MOB_SPAWNER":
+                        case "CHEST_MINECART":
+                        case "COMMAND_BLOCK_MINECART":
+                        case "FURNACE_MINECART":
+                        case "HOPPER_MINECART":
+                        case "SPAWNER_MINECART":
                         case "ENDER_CRYSTAL":
-                        case "MINECART_TNT":
+                        case "TNT_MINECART":
                         case "CHEST_BOAT":
                         case "BOAT":
                             if (Settings.Enabled_Components.KILL_ROAD_VEHICLES) {


### PR DESCRIPTION
## Overview
Fixes #4462

## Description
Adjusted the enum constant names to the new naming. Only working 1.20 onwards - though backwards compatibility doesn't seem to exist for a while now https://github.com/IntellectualSites/PlotSquared/blob/895cf0da664cf4983aa186971a690c5c4701458a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java#L168-L175

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
