### PR TITLE
Remove unused SNOW field which triggers legacy mode

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -106,9 +106,6 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.bukkit.Tag.CORALS;
 import static org.bukkit.Tag.CORAL_BLOCKS;
@@ -116,12 +113,6 @@ import static org.bukkit.Tag.WALL_CORALS;
 
 @SuppressWarnings("unused")
 public class BlockEventListener implements Listener {
-
-    private static final Set<Material> SNOW = Stream.of(Material.values()) // needed as Tag.SNOW isn't present in 1.16.5
-            .filter(material -> material.name().contains("SNOW"))
-            .filter(Material::isBlock)
-            .collect(Collectors.toUnmodifiableSet());
-
     private final PlotAreaManager plotAreaManager;
     private final WorldEdit worldEdit;
 


### PR DESCRIPTION
## Description
There is a `SNOW` field in `BlockEventListener` which seems to be a remnant of handling the introduction of powdered snow in 1.17. I can find no uses of this field, and snow-related code in this file uses `Tag.SNOW` directly.

The material iteration for setting this field is also unnecessarily triggering the legacy material system, so it is best removed.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
