### PR TITLE
Prevent vanished players from being in plot kick autocompletion

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Kick.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Kick.java
@@ -153,7 +153,7 @@ public class Kick extends SubCommand {
         if (plot == null) {
             return Collections.emptyList();
         }
-        return TabCompletions.completePlayersInPlot(plot, String.join(",", args).trim(),
+        return TabCompletions.completePlayersInPlot(player, plot, String.join(",", args).trim(),
                 Collections.singletonList(player.getName())
         );
     }

--- a/Core/src/main/java/com/plotsquared/core/util/TabCompletions.java
+++ b/Core/src/main/java/com/plotsquared/core/util/TabCompletions.java
@@ -107,6 +107,7 @@ public final class TabCompletions {
     }
 
     public static @NonNull List<Command> completePlayersInPlot(
+            final @NonNull PlotPlayer<?> issuer,
             final @NonNull Plot plot,
             final @NonNull String input, final @NonNull List<String> existing
     ) {
@@ -115,7 +116,9 @@ public final class TabCompletions {
             final List<PlotPlayer<?>> inPlot = plot.getPlayersInPlot();
             players = new ArrayList<>(inPlot.size());
             for (PlotPlayer<?> player : inPlot) {
-                players.add(player.getName());
+                if (issuer.canSee(player)) {
+                    players.add(player.getName());
+                }
             }
             cachedCompletionValues.put("inPlot" + plot, players);
         }


### PR DESCRIPTION
## Overview
Fixes #4484 

## Description
I added the parameter `PlotPlayer<?> issuer` to the method `TabCompletions#completePlayersInPlot` to be able to call the PlotPlayer#canSee method. Moreover, it makes sense to me that a player should be supplied to this method to have its "personalized" completions.
I didn't add null check in my if block as the parameter is already annotated with `@NonNull`.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
