### PR TITLE
fix: load single plot areas on creation

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/PlotSquared.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotSquared.java
@@ -795,9 +795,8 @@ public class PlotSquared {
         if (world.equals("CheckingPlotSquaredGenerator")) {
             return;
         }
-        if (!this.getPlotAreaManager().addWorld(world)) {
-            return;
-        }
+        // Don't check the return result -> breaks runtime loading of single plot areas on creation
+        this.getPlotAreaManager().addWorld(world);
         Set<String> worlds;
         if (this.worldConfiguration.contains("worlds")) {
             worlds = this.worldConfiguration.getConfigurationSection("worlds").getKeys(false);

--- a/Core/src/main/java/com/plotsquared/core/command/Area.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Area.java
@@ -184,6 +184,7 @@ public class Area extends SubCommand {
                         CuboidRegion.makeCuboid(playerSelectedRegion)
                 ).length != 0) {
                     player.sendMessage(TranslatableCaption.of("single.single_area_overlapping"));
+                    return false;
                 }
                 // Alter the region
                 final BlockVector3 playerSelectionMin = playerSelectedRegion.getMinimumPoint();


### PR DESCRIPTION
## Overview
Fixes #4467

## Description
That change was made quite often in the last couple of years. `adWorld` returns false if the world is already registered in PS - which it is when creating a single area in an existing world.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
