### PR TITLE
Adding "entity-change-block" flag check for roads

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
@@ -401,7 +401,13 @@ public class EntityEventListener implements Listener {
         }
 
         Plot plot = area.getOwnedPlot(location);
-        if (plot != null && !plot.getFlag(EntityChangeBlockFlag.class)) {
+        if (plot == null) {
+            if (PlotFlagUtil.isAreaRoadFlagsAndFlagEquals(area, EntityChangeBlockFlag.class, false)) {
+                event.setCancelled(true);
+            }
+            return;
+        }
+        if (!plot.getFlag(EntityChangeBlockFlag.class)) {
             plot.debug(e.getType() + " could not change block because entity-change-block = false");
             event.setCancelled(true);
         }


### PR DESCRIPTION
## Overview

This PR adds the check and restriction for wall/roads in case of `EntityChangeBlock` events. The used PS flag is still `entity-change-block`.

Fixes #4524

## Description
I don't understand why the road flag is not observed at this point. It is necessary so that the default value “false” of the flag or the configured flag setting is taken into account.

The road flags should actually be validated and completed for all events, but here is the fix for the linked issue.

```[tasklist]
### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
