### PR TITLE
Add option to prevent entities from being moved from plot

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/configuration/Config.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Config.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -372,6 +373,7 @@ public class Config {
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ElementType.FIELD, ElementType.TYPE})
+    @Documented
     public @interface Comment {
 
         String[] value();

--- a/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/Settings.java
@@ -651,6 +651,8 @@ public class Settings extends Config {
         public static boolean PAPER_LISTENERS = true;
         @Comment("Prevent entities from leaving plots")
         public static boolean ENTITY_PATHING = true;
+        @Comment("Prevent entities from leaving plots, even by pushing or pulling")
+        public static boolean ENTITY_MOVEMENT = false;
         @Comment(
                 "Cancel entity spawns when the chunk is loaded if the PlotArea's mob spawning is off")
         public static boolean CANCEL_CHUNK_SPAWN = true;


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

We already have an option to prevent entities from wandering off plots themselves due to pathfinding, but they can still be pushed outside (or pulled with a leash). Using Paper's `EntityMoveEvent`, we can also prevent such actions.
The feature is disabled by default to not affect behavior of existing setups.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
