### PR TITLE
Force-enable NETWORK side effect to ensure blocks are instantly visible

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/queue/BukkitQueueCoordinator.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/queue/BukkitQueueCoordinator.java
@@ -62,19 +62,28 @@ public class BukkitQueueCoordinator extends BasicQueueCoordinator {
     private static final SideEffectSet EDGE_LIGHTING_SIDE_EFFECT_SET;
 
     static {
-        NO_SIDE_EFFECT_SET = SideEffectSet.none().with(SideEffect.LIGHTING, SideEffect.State.OFF).with(
-                SideEffect.NEIGHBORS,
-                SideEffect.State.OFF
-        );
-        EDGE_SIDE_EFFECT_SET = SideEffectSet.none().with(SideEffect.UPDATE, SideEffect.State.ON).with(
-                SideEffect.NEIGHBORS,
-                SideEffect.State.ON
-        );
-        LIGHTING_SIDE_EFFECT_SET = SideEffectSet.none().with(SideEffect.NEIGHBORS, SideEffect.State.OFF);
-        EDGE_LIGHTING_SIDE_EFFECT_SET = SideEffectSet.none().with(SideEffect.UPDATE, SideEffect.State.ON).with(
-                SideEffect.NEIGHBORS,
-                SideEffect.State.ON
-        );
+        NO_SIDE_EFFECT_SET = enableNetworkIfNeeded()
+                .with(SideEffect.LIGHTING, SideEffect.State.OFF)
+                .with(SideEffect.NEIGHBORS, SideEffect.State.OFF);
+        EDGE_SIDE_EFFECT_SET = NO_SIDE_EFFECT_SET
+                .with(SideEffect.UPDATE, SideEffect.State.ON)
+                .with(SideEffect.NEIGHBORS, SideEffect.State.ON);
+        LIGHTING_SIDE_EFFECT_SET = NO_SIDE_EFFECT_SET
+                .with(SideEffect.NEIGHBORS, SideEffect.State.OFF);
+        EDGE_LIGHTING_SIDE_EFFECT_SET = NO_SIDE_EFFECT_SET
+                .with(SideEffect.UPDATE, SideEffect.State.ON)
+                .with(SideEffect.NEIGHBORS, SideEffect.State.ON);
+    }
+
+    // make sure block changes are sent
+    private static SideEffectSet enableNetworkIfNeeded() {
+        SideEffect network;
+        try {
+            network = SideEffect.valueOf("NETWORK");
+        } catch (IllegalArgumentException ignored) {
+            return SideEffectSet.none();
+        }
+        return SideEffectSet.none().with(network, SideEffect.State.ON);
     }
 
     private org.bukkit.World bukkitWorld;


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

Fixes an issue where block changes depending on WNA weren't visible. This is initially caused by FAWE as it changes the NETWORK default to OFF. By just re-enabling it, we can restore the previous behavior.
As the NETWORK side effect is WE 7.3+, we fall back to ignoring it if not present.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
