### PR TITLE
renewed fix: update error message of `/p remove <player>` if player does not need to be removed

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Remove.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Remove.java
@@ -117,8 +117,8 @@ public class Remove extends SubCommand {
             }
             if (count == 0) {
                 player.sendMessage(
-                        TranslatableCaption.of("errors.invalid_player"),
-                        TagResolver.resolver("value", Tag.inserting(Component.text(args[0])))
+                        TranslatableCaption.of("member.player_not_removed"),
+                        TagResolver.resolver("player", Tag.inserting(Component.text(args[0])))
                 );
             } else {
                 player.sendMessage(


### PR DESCRIPTION
## Overview
This pull request update an error message that was already included in pull request [#3734](https://github.com/IntellectualSites/PlotSquared/pull/3734) in PlotSquared v6.
Unfortunately, the change from back then was not adopted in v7, hence the request to reintegrate this change now.

Notice PR #3734 : The placeholder `“member.player_not_removed”` already exists.
In v7, only the reference to this placeholder is missing in the Remove.java command.

## Description
Update/Changes the message if you try to remove a player from a plot, which is not added, trusted or denied from the plot to make it more clear, why the command failed.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
