### PR TITLE
fix: allow queues to not generate chunks

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/queue/BukkitQueueCoordinator.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/queue/BukkitQueueCoordinator.java
@@ -238,6 +238,7 @@ public class BukkitQueueCoordinator extends BasicQueueCoordinator {
                         .unloadAfter(isUnloadAfter())
                         .withProgressSubscribers(getProgressSubscribers())
                         .forceSync(isForceSync())
+                        .shouldGen(isShouldGen())
                         .build();
         return super.enqueue();
     }

--- a/Core/src/main/java/com/plotsquared/core/generator/HybridUtils.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridUtils.java
@@ -432,6 +432,7 @@ public class HybridUtils {
                 if (!UPDATE) {
                     Iterator<BlockVector2> iter = chunks.iterator();
                     QueueCoordinator queue = blockQueue.getNewQueue(worldUtil.getWeWorld(area.getWorldName()));
+                    queue.setShouldGen(false);
                     while (iter.hasNext()) {
                         BlockVector2 chunk = iter.next();
                         iter.remove();
@@ -474,6 +475,7 @@ public class HybridUtils {
                                     Iterator<BlockVector2> iterator = chunks.iterator();
                                     if (chunks.size() >= 32) {
                                         QueueCoordinator queue = blockQueue.getNewQueue(worldUtil.getWeWorld(area.getWorldName()));
+                                        queue.setShouldGen(false);
                                         for (int i = 0; i < 32; i++) {
                                             final BlockVector2 chunk = iterator.next();
                                             iterator.remove();
@@ -487,6 +489,7 @@ public class HybridUtils {
                                         return null;
                                     }
                                     QueueCoordinator queue = blockQueue.getNewQueue(worldUtil.getWeWorld(area.getWorldName()));
+                                    queue.setShouldGen(false);
                                     while (!chunks.isEmpty()) {
                                         final BlockVector2 chunk = iterator.next();
                                         iterator.remove();
@@ -502,7 +505,6 @@ public class HybridUtils {
                                 return;
                             }
                         } catch (Exception e) {
-                            e.printStackTrace();
                             Iterator<BlockVector2> iterator = HybridUtils.regions.iterator();
                             BlockVector2 loc = iterator.next();
                             iterator.remove();
@@ -510,7 +512,8 @@ public class HybridUtils {
                                     "Error! Could not update '{}/region/r.{}.{}.mca' (Corrupt chunk?)",
                                     area.getWorldHash(),
                                     loc.getX(),
-                                    loc.getZ()
+                                    loc.getZ(),
+                                    e
                             );
                         }
                         TaskManager.runTaskLater(task, TaskTime.seconds(1L));
@@ -558,7 +561,7 @@ public class HybridUtils {
                                 try {
                                     plotworld.setupSchematics();
                                 } catch (SchematicHandler.UnsupportedFormatException e) {
-                                    e.printStackTrace();
+                                    LOGGER.error(e);
                                 }
                             });
                 });

--- a/Core/src/main/java/com/plotsquared/core/inject/factory/ChunkCoordinatorFactory.java
+++ b/Core/src/main/java/com/plotsquared/core/inject/factory/ChunkCoordinatorFactory.java
@@ -40,7 +40,8 @@ public interface ChunkCoordinatorFactory {
             final @NonNull Consumer<Throwable> throwableConsumer,
             @Assisted("unloadAfter") final boolean unloadAfter,
             final @NonNull Collection<ProgressSubscriber> progressSubscribers,
-            @Assisted("forceSync") final boolean forceSync
+            @Assisted("forceSync") final boolean forceSync,
+            @Assisted("shouldGen") final boolean shouldGen
     );
 
 }

--- a/Core/src/main/java/com/plotsquared/core/queue/ChunkCoordinatorBuilder.java
+++ b/Core/src/main/java/com/plotsquared/core/queue/ChunkCoordinatorBuilder.java
@@ -52,6 +52,7 @@ public class ChunkCoordinatorBuilder {
     private int initialBatchSize = Settings.QUEUE.INITIAL_BATCH_SIZE;
     private boolean unloadAfter = true;
     private boolean forceSync = false;
+    private boolean shouldGen = true;
 
     @Inject
     public ChunkCoordinatorBuilder(@NonNull ChunkCoordinatorFactory chunkCoordinatorFactory) {
@@ -203,6 +204,19 @@ public class ChunkCoordinatorBuilder {
         return this;
     }
 
+    /**
+     * Set whether chunks should be generated as part of this operation. Default is true. Disabling this may not be supported
+     * depending on server implementation. (i.e. setting to false may not actually disable generation as part of this operation
+     * - this is just a catch-all in case of future differing server implementations; the option will work on Spigot/Paper).
+     *
+     * @param shouldGen should generate new chunks or not
+     * @since TODO
+     */
+    public @NonNull ChunkCoordinatorBuilder shouldGen(final boolean shouldGen) {
+        this.shouldGen = shouldGen;
+        return this;
+    }
+
     public @NonNull ChunkCoordinatorBuilder withProgressSubscriber(ProgressSubscriber progressSubscriber) {
         this.progressSubscribers.add(progressSubscriber);
         return this;
@@ -234,7 +248,8 @@ public class ChunkCoordinatorBuilder {
                         this.throwableConsumer,
                         this.unloadAfter,
                         this.progressSubscribers,
-                        this.forceSync
+                        this.forceSync,
+                        this.shouldGen
                 );
     }
 

--- a/Core/src/main/java/com/plotsquared/core/queue/DelegateQueueCoordinator.java
+++ b/Core/src/main/java/com/plotsquared/core/queue/DelegateQueueCoordinator.java
@@ -51,6 +51,7 @@ public class DelegateQueueCoordinator extends QueueCoordinator {
 
         if (parent != null) {
             this.setForceSync(parent.isForceSync());
+            this.setShouldGen(parent.isShouldGen());
         }
     }
 

--- a/Core/src/main/java/com/plotsquared/core/queue/QueueCoordinator.java
+++ b/Core/src/main/java/com/plotsquared/core/queue/QueueCoordinator.java
@@ -45,6 +45,7 @@ public abstract class QueueCoordinator {
 
     private final AtomicBoolean enqueued = new AtomicBoolean();
     private boolean forceSync = false;
+    private boolean shouldGen = true;
     @Nullable
     private Object chunkObject;
     @SuppressWarnings({"unused", "FieldCanBeLocal"})
@@ -108,6 +109,30 @@ public abstract class QueueCoordinator {
      */
     public void setForceSync(boolean forceSync) {
         this.forceSync = forceSync;
+    }
+
+
+    /**
+     * Get whether chunks should be generated as part of this operation. Default is true. Disabling this may not be supported
+     * depending on server implementation. (i.e. setting to false may not actually disable generation as part of this operation
+     * - this is just a catch-all in case of future differing server implementations; the option will work on Spigot/Paper).
+     *
+     * @since TODO
+     */
+    public boolean isShouldGen() {
+        return shouldGen;
+    }
+
+    /**
+     * Set whether chunks should be generated as part of this operation. Default is true. Disabling this may not be supported
+     * depending on server implementation. (i.e. setting to false may not actually disable generation as part of this operation
+     * - this is just a catch-all in case of future differing server implementations; the option will work on Spigot/Paper).
+     *
+     * @param shouldGen should generate new chunks or not
+     * @since TODO
+     */
+    public void setShouldGen(boolean shouldGen) {
+        this.shouldGen = shouldGen;
     }
 
     /**


### PR DESCRIPTION
 - initially apply to regenallroads
 - additionally add a 10s timeout for requesting a chunk before resubmitting it to the queue
 - fixes #4310