### PR TITLE
Fix IndexOutOfBoundsException on BlockFertilizeEvent

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener117.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener117.java
@@ -134,7 +134,7 @@ public class BlockEventListener117 implements Listener {
     public void onBlockFertilize(BlockFertilizeEvent event) {
         Block block = event.getBlock();
         List<org.bukkit.block.BlockState> blocks = event.getBlocks();
-        Location location = BukkitUtil.adapt(blocks.get(0).getLocation());
+        Location location = BukkitUtil.adapt(block.getLocation());
 
         PlotArea area = location.getPlotArea();
         if (area == null) {


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #4608

## Description
<!-- Please describe what this pull request does. -->

On an empty list, the code threw an exception. Taking a closer look, the initial position to check should be the one the fertilizer was applied to, especially since the block list doesn't have any specified order.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
