### PR TITLE
Add server brand to debugpaste

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -253,6 +253,11 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
     }
 
     @Override
+    public @NonNull String serverBrand() {
+        return Bukkit.getName();
+    }
+
+    @Override
     @SuppressWarnings("deprecation") // Paper deprecation
     public void onEnable() {
         this.pluginName = getDescription().getName();

--- a/Core/src/main/java/com/plotsquared/core/PlotPlatform.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotPlatform.java
@@ -121,6 +121,14 @@ public interface PlotPlatform<P> extends LocaleHolder {
     @NonNull String serverImplementation();
 
     /**
+     * Gets the server brand name
+     *
+     * @return server brand
+     * @since TODO
+     */
+    @NonNull String serverBrand();
+
+    /**
      * Gets the native server code package prefix.
      *
      * @return The package prefix

--- a/Core/src/main/java/com/plotsquared/core/command/DebugPaste.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DebugPaste.java
@@ -86,7 +86,8 @@ public class DebugPaste extends SubCommand {
                 b.append("# WorldEdit implementation:\n");
                 b.append(PlotSquared.platform().worldEditImplementations()).append("\n\n");
                 b.append("# Server Information\n");
-                b.append("Server Version: ").append(PlotSquared.platform().serverImplementation())
+                b.append("Server Version: ").append(PlotSquared.platform().serverBrand()).append(": ")
+                        .append(PlotSquared.platform().serverImplementation()).append("\n")
                         .append("\n");
                 b.append("online_mode: ").append(!Settings.UUID.OFFLINE).append(';')
                         .append(!Settings.UUID.OFFLINE).append('\n');


### PR DESCRIPTION
Before:
```
# Server Information
Server Version: 1.21.4-226-a838a88 (MC: 1.21.4)
```

After:
```
# Server Information
Server Version: Paper: 1.21.4-226-a838a88 (MC: 1.21.4)
```

Apparently something changed, that `Bukkit#getVersion()` does no longer return the server brand.