### PR TITLE
fix: Don't use list to proof block is copper. Instead check with name

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener117.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener117.java
@@ -48,25 +48,6 @@ import java.util.UUID;
 @SuppressWarnings("unused")
 public class BlockEventListener117 implements Listener {
 
-    private static final Set<Material> COPPER_OXIDIZING = Set.of(
-            Material.COPPER_BLOCK,
-            Material.EXPOSED_COPPER,
-            Material.WEATHERED_COPPER,
-            Material.OXIDIZED_COPPER,
-            Material.CUT_COPPER,
-            Material.EXPOSED_CUT_COPPER,
-            Material.WEATHERED_CUT_COPPER,
-            Material.OXIDIZED_CUT_COPPER,
-            Material.CUT_COPPER_STAIRS,
-            Material.EXPOSED_CUT_COPPER_STAIRS,
-            Material.WEATHERED_CUT_COPPER_STAIRS,
-            Material.OXIDIZED_CUT_COPPER_STAIRS,
-            Material.CUT_COPPER_SLAB,
-            Material.EXPOSED_CUT_COPPER_SLAB,
-            Material.WEATHERED_CUT_COPPER_SLAB,
-            Material.OXIDIZED_CUT_COPPER_SLAB
-    );
-
     @Inject
     public BlockEventListener117() {
     }
@@ -184,7 +165,7 @@ public class BlockEventListener117 implements Listener {
         if (plot == null) {
             return;
         }
-        if (COPPER_OXIDIZING.contains(event.getNewState().getType())) {
+        if (event.getNewState().getType().name().contains("COPPER")) {
             if (!plot.getFlag(CopperOxideFlag.class)) {
                 plot.debug("Copper could not oxide because copper-oxide = false");
                 event.setCancelled(true);

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener117.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener117.java
@@ -28,7 +28,6 @@ import com.plotsquared.core.plot.flag.implementations.CopperOxideFlag;
 import com.plotsquared.core.plot.flag.implementations.MiscInteractFlag;
 import com.plotsquared.core.plot.flag.implementations.SculkSensorInteractFlag;
 import com.plotsquared.core.util.PlotFlagUtil;
-import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
@@ -42,7 +41,6 @@ import org.bukkit.event.block.BlockReceiveGameEvent;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.UUID;
 
 @SuppressWarnings("unused")


### PR DESCRIPTION
## Overview
Fixes #4627

## Description
This fixes the issue, that not all copper-blocks are ignored in BlockFormEvent if flag is set.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
