### PR TITLE
fix: correctly parse help messages with prefix

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/CommandCategory.java
+++ b/Core/src/main/java/com/plotsquared/core/command/CommandCategory.java
@@ -24,6 +24,7 @@ import com.plotsquared.core.configuration.caption.TranslatableCaption;
 import com.plotsquared.core.player.PlotPlayer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.NotNull;
 
@@ -95,6 +96,14 @@ public enum CommandCategory implements Caption {
 
     @Override
     public @NonNull Component toComponent(@NonNull final LocaleHolder localeHolder) {
+        return MiniMessage.miniMessage().deserialize(getComponent(localeHolder));
+    }
+
+    @Override
+    public @NonNull Component toComponent(
+            @NonNull final LocaleHolder localeHolder,
+            final @NonNull TagResolver @NonNull ... tagResolvers
+    ) {
         return MiniMessage.miniMessage().deserialize(getComponent(localeHolder));
     }
 

--- a/Core/src/main/java/com/plotsquared/core/command/Help.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Help.java
@@ -113,38 +113,34 @@ public class Help extends Command {
             }
             if (cat == null && page == 0) {
                 TextComponent.Builder builder = Component.text();
-                builder.append(MINI_MESSAGE.deserialize(TranslatableCaption.of("help.help_header").getComponent(player)));
+                builder.append(TranslatableCaption.of("help.help_header").toComponent(player));
                 for (CommandCategory c : CommandCategory.values()) {
                     if (!c.canAccess(player)) {
                         continue;
                     }
-                    builder.append(Component.newline()).append(MINI_MESSAGE
-                            .deserialize(
-                                    TranslatableCaption.of("help.help_info_item").getComponent(player),
-                                    TagResolver.builder()
-                                            .tag("command", Tag.inserting(Component.text("/plot help")))
-                                            .tag("category", Tag.inserting(Component.text(c.name().toLowerCase())))
-                                            .tag("category_desc", Tag.inserting(c.toComponent(player)))
-                                            .build()
-                            ));
+                    builder.append(Component.newline());
+                    builder.append(TranslatableCaption.of("help.help_info_item").toComponent(
+                            player, TagResolver.builder()
+                                    .tag("command", Tag.inserting(Component.text("/plot help")))
+                                    .tag("category", Tag.inserting(Component.text(c.name().toLowerCase())))
+                                    .tag("category_desc", Tag.inserting(c.toComponent(player)))
+                                    .build()
+                    ));
                 }
-                builder.append(Component.newline()).append(MINI_MESSAGE
-                        .deserialize(
-                                TranslatableCaption.of("help.help_info_item").getComponent(player),
-                                TagResolver.builder()
-                                        .tag("command", Tag.inserting(Component.text("/plot help")))
-                                        .tag("category", Tag.inserting(Component.text("all")))
-                                        .tag(
-                                                "category_desc",
-                                                Tag.inserting(TranslatableCaption
-                                                        .of("help.help_display_all_commands")
-                                                        .toComponent(player))
-                                        )
-                                        .build()
-                        ));
-                builder.append(Component.newline()).append(MINI_MESSAGE.deserialize(TranslatableCaption
-                        .of("help.help_footer")
-                        .getComponent(player)));
+                builder.append(Component.newline());
+                builder.append(TranslatableCaption.of("help.help_info_item").toComponent(
+                        player, TagResolver.builder()
+                                .tag("command", Tag.inserting(Component.text("/plot help")))
+                                .tag("category", Tag.inserting(Component.text("all")))
+                                .tag(
+                                        "category_desc", Tag.inserting(TranslatableCaption
+                                                .of("help.help_display_all_commands")
+                                                .toComponent(player))
+                                )
+                                .build()
+                ));
+                builder.append(Component.newline());
+                builder.append(TranslatableCaption.of("help.help_footer").toComponent(player));
                 player.sendMessage(StaticCaption.of(MINI_MESSAGE.serialize(builder.asComponent())));
                 return true;
             }

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/Caption.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/Caption.java
@@ -20,6 +20,7 @@ package com.plotsquared.core.configuration.caption;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -43,6 +44,16 @@ public interface Caption {
      * @since 7.0.0
      */
     @NonNull Component toComponent(@NonNull LocaleHolder localeHolder);
+
+    /**
+     * Get the Adventure {@link ComponentLike} for this caption while applying custom {@link TagResolver}
+     * (apart from the default {@code core.prefix})
+     * @param localeHolder Local holder
+     * @param tagResolvers custom tag resolvers to replace placeholders / parameters
+     * @return {@link ComponentLike}
+     * @since TODO
+     */
+    @NonNull Component toComponent(@NonNull LocaleHolder localeHolder, @NonNull TagResolver @NonNull... tagResolvers);
 
     @NonNull String toString();
 

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/StaticCaption.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/StaticCaption.java
@@ -21,6 +21,7 @@ package com.plotsquared.core.configuration.caption;
 import com.google.common.base.Preconditions;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public final class StaticCaption implements Caption {
@@ -49,6 +50,14 @@ public final class StaticCaption implements Caption {
     @Override
     public @NonNull Component toComponent(@NonNull final LocaleHolder localeHolder) {
         return MiniMessage.miniMessage().deserialize(this.value);
+    }
+
+    @Override
+    public @NonNull Component toComponent(
+            @NonNull final LocaleHolder localeHolder,
+            final @NonNull TagResolver @NonNull ... tagResolvers
+    ) {
+        return MiniMessage.miniMessage().deserialize(this.value, tagResolvers);
     }
 
     @Override

--- a/Core/src/main/java/com/plotsquared/core/configuration/caption/TranslatableCaption.java
+++ b/Core/src/main/java/com/plotsquared/core/configuration/caption/TranslatableCaption.java
@@ -27,6 +27,7 @@ import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
@@ -96,13 +97,23 @@ public final class TranslatableCaption implements NamespacedCaption {
 
     @Override
     public @NonNull Component toComponent(@NonNull final LocaleHolder localeHolder) {
+        return this.toComponent(localeHolder, new TagResolver[0]);
+    }
+
+    @Override
+    public @NonNull Component toComponent(
+            @NonNull final LocaleHolder localeHolder,
+            final @NonNull TagResolver @NonNull ... tagResolvers
+    ) {
         if (getKey().equals("core.prefix")) {
             return MiniMessage.miniMessage().deserialize(getComponent(localeHolder));
         }
-        return MiniMessage.miniMessage().deserialize(getComponent(localeHolder), TagResolver.resolver(
+        TagResolver[] finalResolvers = Arrays.copyOf(tagResolvers, tagResolvers.length + 1);
+        finalResolvers[finalResolvers.length - 1] = TagResolver.resolver(
                 "prefix",
                 Tag.inserting(TranslatableCaption.of("core.prefix").toComponent(localeHolder))
-        ));
+        );
+        return MiniMessage.miniMessage().deserialize(getComponent(localeHolder), finalResolvers);
     }
 
     @Override

--- a/Core/src/main/java/com/plotsquared/core/util/helpmenu/HelpObject.java
+++ b/Core/src/main/java/com/plotsquared/core/util/helpmenu/HelpObject.java
@@ -25,30 +25,24 @@ import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.util.StringMan;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.jetbrains.annotations.NotNull;
 
 public class HelpObject implements ComponentLike {
 
-    static final MiniMessage MINI_MESSAGE = MiniMessage.miniMessage();
-
     private final Component rendered;
 
     public HelpObject(final Command command, final String label, final PlotPlayer<?> audience) {
-        rendered = MINI_MESSAGE.deserialize(
-                TranslatableCaption.of("help.help_item").getComponent(audience),
-                TagResolver.builder()
-                        .tag("usage", Tag.inserting(Component.text(command.getUsage().replace("{label}", label))))
-                        .tag("alias", Tag.inserting(Component.text(
-                                command.getAliases().isEmpty() ? "" : StringMan.join(command.getAliases(), " | ")
-                        )))
-                        .tag("desc", Tag.inserting(command.getDescription().toComponent(audience)))
-                        .tag("arguments", Tag.inserting(Component.text(buildArgumentList(command.getRequiredArguments()))))
-                        .tag("label", Tag.inserting(Component.text(label)))
-                        .build()
-        );
+        this.rendered = TranslatableCaption.of("help.help_item").toComponent(audience, TagResolver.builder()
+                .tag("usage", Tag.inserting(Component.text(command.getUsage().replace("{label}", label))))
+                .tag("alias", Tag.inserting(Component.text(
+                        command.getAliases().isEmpty() ? "" : StringMan.join(command.getAliases(), " | ")
+                )))
+                .tag("desc", Tag.inserting(command.getDescription().toComponent(audience)))
+                .tag("arguments", Tag.inserting(Component.text(buildArgumentList(command.getRequiredArguments()))))
+                .tag("label", Tag.inserting(Component.text(label)))
+                .build());
     }
 
     private String buildArgumentList(final Argument<?>[] arguments) {


### PR DESCRIPTION
## Overview
Fixes #4595

## Description
help messages correctly display referenced prefix
![image](https://github.com/user-attachments/assets/d89ff681-3488-4392-8d23-e888ff21d1cf)
![image](https://github.com/user-attachments/assets/3b92644d-a405-4826-9b83-febb91cd81fa)


### Submitter Checklist
- [ ] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [ ] Ensure that the pull request title represents the desired changelog entry.
- [ ] New public fields and methods are annotated with `@since TODO`.
- [ ] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
