### PR TITLE
fix: cancel structure locate in classic plot worlds

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
@@ -29,6 +29,7 @@ import com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent;
 import com.destroystokyo.paper.event.server.AsyncTabCompleteEvent;
 import com.google.inject.Inject;
 import com.plotsquared.bukkit.util.BukkitUtil;
+import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.command.Command;
 import com.plotsquared.core.command.MainCommand;
 import com.plotsquared.core.configuration.Settings;
@@ -38,6 +39,7 @@ import com.plotsquared.core.permissions.Permission;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
+import com.plotsquared.core.plot.PlotAreaType;
 import com.plotsquared.core.plot.flag.FlagContainer;
 import com.plotsquared.core.plot.flag.implementations.BeaconEffectsFlag;
 import com.plotsquared.core.plot.flag.implementations.DoneFlag;
@@ -48,6 +50,7 @@ import com.plotsquared.core.plot.flag.types.BooleanFlag;
 import com.plotsquared.core.plot.world.PlotAreaManager;
 import com.plotsquared.core.util.PlotFlagUtil;
 import io.papermc.paper.event.entity.EntityMoveEvent;
+import io.papermc.paper.event.world.StructuresLocateEvent;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
@@ -454,6 +457,21 @@ public class PaperListener implements Listener {
         }
 
         if (!plotBeaconEffects || Settings.Enabled_Components.DISABLE_BEACON_EFFECT_OVERFLOW) {
+            event.setCancelled(true);
+        }
+    }
+
+    /**
+     * Don't let the server die when populating cartographers (villager offering maps) in classic plot worlds
+     * (as those don't generate POIs)
+     */
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
+    public void onStructuresLocate(StructuresLocateEvent event) {
+        if (!PlotSquared.get().getPlotAreaManager().hasPlotArea(event.getWorld().getName())) {
+            return;
+        }
+        final PlotArea area = PlotSquared.get().getPlotAreaManager().getPlotAreaByString(event.getWorld().getName());
+        if (area != null && area.getType() == PlotAreaType.NORMAL) {
             event.setCancelled(true);
         }
     }


### PR DESCRIPTION
## Overview

cancels the StructuresLocateEvent in classic plot worlds, as those don't generate POIs and could potentially crash when searching for them.

When summoning villagers in a classic plot world, they simply don't sell maps. in single plot areas in the normal `world` they still sell maps.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
