### PR TITLE
Add entity cap check of armor stands & end crystals into player interact listener

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
@@ -18,6 +18,7 @@
  */
 package com.plotsquared.bukkit.listener;
 
+import com.plotsquared.bukkit.util.BukkitEntityUtil;
 import com.plotsquared.bukkit.util.BukkitUtil;
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.Settings;
@@ -30,6 +31,7 @@ import org.bukkit.Chunk;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.EnderCrystal;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Item;
@@ -153,6 +155,12 @@ public class EntitySpawnListener implements Listener {
         }
         if (Settings.Done.RESTRICT_BUILDING && DoneFlag.isDone(plot)) {
             event.setCancelled(true);
+        }
+        if (entity instanceof EnderCrystal || type == EntityType.ARMOR_STAND) {
+            if (BukkitEntityUtil.checkEntity(entity, plot)) {
+                event.setCancelled(true);
+            }
+            return;
         }
         if (type == EntityType.SHULKER) {
             if (!entity.hasMetadata("shulkerPlot")) {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
@@ -18,7 +18,6 @@
  */
 package com.plotsquared.bukkit.listener;
 
-import com.plotsquared.bukkit.util.BukkitEntityUtil;
 import com.plotsquared.bukkit.util.BukkitUtil;
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.Settings;
@@ -31,7 +30,6 @@ import org.bukkit.Chunk;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.ArmorStand;
-import org.bukkit.entity.EnderCrystal;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Item;
@@ -155,12 +153,6 @@ public class EntitySpawnListener implements Listener {
         }
         if (Settings.Done.RESTRICT_BUILDING && DoneFlag.isDone(plot)) {
             event.setCancelled(true);
-        }
-        if (entity instanceof EnderCrystal || type == EntityType.ARMOR_STAND) {
-            if (BukkitEntityUtil.checkEntity(entity, plot)) {
-                event.setCancelled(true);
-            }
-            return;
         }
         if (type == EntityType.SHULKER) {
             if (!entity.hasMetadata("shulkerPlot")) {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -1298,11 +1298,12 @@ public class PlayerEventListener implements Listener {
                     //Allow all players to eat while also allowing the block place event to be fired
                     return;
                 }
-                // Process creature spawning of armor stands & end crystals here instead of EntitySpawnListener to be able to
-                // reset the player's in hand item if they need to be cancelled.
+                // Process creature spawning of armor stands & end crystals here if spawned by the player in order to be able to
+                // reset the player's hand item if spawning needs to be cancelled.
                 if (type == Material.ARMOR_STAND || type == Material.END_CRYSTAL) {
                     Plot plot = location.getOwnedPlotAbs();
-                    if (BukkitEntityUtil.checkEntity(type == Material.END_CRYSTAL ? EntityType.ENDER_CRYSTAL : EntityType.ARMOR_STAND, plot)) {
+                    if (BukkitEntityUtil.checkEntity(type == Material.ARMOR_STAND ? EntityType.ARMOR_STAND : EntityType.ENDER_CRYSTAL,
+                            plot)) {
                         event.setCancelled(true);
                         break;
                     }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -1298,6 +1298,16 @@ public class PlayerEventListener implements Listener {
                     //Allow all players to eat while also allowing the block place event to be fired
                     return;
                 }
+                // Process creature spawning of armor stands & end crystals here instead of EntitySpawnListener to be able to
+                // reset the player's in hand item if they need to be cancelled.
+                if (type == Material.ARMOR_STAND || type == Material.END_CRYSTAL) {
+                    Plot plot = location.getOwnedPlotAbs();
+                    if (BukkitEntityUtil.checkEntity(type == Material.END_CRYSTAL ? EntityType.ENDER_CRYSTAL : EntityType.ARMOR_STAND, plot)) {
+                        event.setCancelled(true);
+                        break;
+                    }
+                }
+                // Continue with normal place event checks
                 if (type == Material.ARMOR_STAND) {
                     location = BukkitUtil.adapt(block.getRelative(event.getBlockFace()).getLocation());
                     eventType = PlayerBlockEventType.PLACE_MISC;

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitEntityUtil.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitEntityUtil.java
@@ -354,13 +354,17 @@ public class BukkitEntityUtil {
     }
 
     public static boolean checkEntity(Entity entity, Plot plot) {
+        return checkEntity(entity.getType(), plot);
+    }
+
+    public static boolean checkEntity(EntityType type, Plot plot) {
         if (plot == null || !plot.hasOwner() || plot.getFlags().isEmpty() && plot.getArea()
                 .getFlagContainer().getFlagMap().isEmpty()) {
             return false;
         }
 
         final com.sk89q.worldedit.world.entity.EntityType entityType =
-                BukkitAdapter.adapt(entity.getType());
+                BukkitAdapter.adapt(type);
 
         if (EntityCategories.PLAYER.contains(entityType)) {
             return false;


### PR DESCRIPTION
## Overview
When cancelled in the creature spawn event and placed by a player, the player will lose the armor stand / end crystal item from their inventory. This PR aims to fix this by moving the verification whether the entity should be cancelled up to the spawn egg right click, this way the item is not touched.

I tried my best to verify this is not breaking anything; I'm not sure if the original code in EntitySpawnListener should be kept? Reviews appreciated.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
