### PR TITLE
Fix plot context being ignored if using `/set` command

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/SetCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/SetCommand.java
@@ -19,7 +19,6 @@
 package com.plotsquared.core.command;
 
 import com.plotsquared.core.configuration.caption.TranslatableCaption;
-import com.plotsquared.core.location.Location;
 import com.plotsquared.core.permissions.Permission;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;


### PR DESCRIPTION
## Overview

Fixes #4526

## Description
This fixes a problem, where if using the `/p 0;0 set (...)` command, it will ignore the plot coordinates you specified. This bug uses the generic `Player#getCurrentPlot` method, which takes the context into account, fixing this issue.

### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
