### PR TITLE
Fix misleading grants.added message to indicate single plot grant

### DIFF
--- a/Core/src/main/resources/lang/messages_en.json
+++ b/Core/src/main/resources/lang/messages_en.json
@@ -456,7 +456,7 @@
   "category.command_category_debug": "<gray>Debug</gray>",
   "category.command_category_administration": "<gray>Admin</gray>",
   "grants.granted_plots": "<prefix><gold>Result: <gray><amount> </gray>grants left.</gold>",
-  "grants.added": "<prefix><gold><grants></gold> <gray>grant(s) have been added.</gray>",
+  "grants.added": "<prefix><gold>1</gold> <gray>grant has been added.</gray>",
   "events.event_denied": "<prefix><gold><value> </gold><gray>Cancelled by external plugin.</gray>",
   "backups.backup_impossible": "<prefix><red>Backups are not enabled for this plot: <plot>.</red>",
   "backups.backup_save_success": "<prefix><gold>The backup was created successfully.</gold>",


### PR DESCRIPTION
## Overview

Fixes  #4384 

## Description
This pull request updates the `grants.added` message in `messages_en.json` to match the actual behavior of `/plot grant add <player>`, which always grants **a single plot** and does not support multiple grants.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
