### PR TITLE
fix: `/plot grant add` doesn't send success message reliably

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Grant.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Grant.java
@@ -101,6 +101,10 @@ public class Grant extends Command {
                                     );
                                 } else {
                                     access.set(access.get().orElse(0) + 1);
+                                    player.sendMessage(
+                                            TranslatableCaption.of("grants.added"),
+                                            TagResolver.resolver("grants", Tag.inserting(Component.text(access.get().orElse(0))))
+                                    );
                                 }
                             }
                         } else {
@@ -130,10 +134,6 @@ public class Grant extends Command {
                                         String key = "grantedPlots";
                                         byte[] rawData = Ints.toByteArray(amount);
                                         DBFunc.addPersistentMeta(uuid, key, rawData, replace);
-                                        player.sendMessage(
-                                                TranslatableCaption.of("grants.added"),
-                                                TagResolver.resolver("grants", Tag.inserting(Component.text(amount)))
-                                        );
                                     }
                                 }
                             });


### PR DESCRIPTION
## Overview

Fixes #4383 

## Description
Moves the `grants.added` success message in the `Grant.java` command handler so that it is reliably sent **after** the plot has been successfully granted.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
