### PR TITLE
feat: Added missing music_discs from 1.21.6 & 1.21.7

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Music.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Music.java
@@ -57,7 +57,7 @@ public class Music extends SubCommand {
                     "music_disc_far", "music_disc_mall", "music_disc_mellohi", "music_disc_stal",
                     "music_disc_strad", "music_disc_ward", "music_disc_11", "music_disc_wait", "music_disc_otherside",
                     "music_disc_pigstep", "music_disc_5", "music_disc_relic", "music_disc_creator",
-                    "music_disc_creator_music_box", "music_disc_precipice"
+                    "music_disc_creator_music_box", "music_disc_precipice", "music_disc_tears", "music_disc_lava_chicken"
             );
 
     // make sure all discs and the bedrock ("cancel") fit into the inventory


### PR DESCRIPTION
## Overview
Partially fixes #4687

## Description
I realized that two music discs introduced in recent Minecraft updates were missing in the plot jukebox. This pull request adds those two missing discs.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
