### PR TITLE
fix: correct tab completion for `/plot flag set <flag> <value>`

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/FlagCommand.java
@@ -316,7 +316,7 @@ public final class FlagCommand extends Command {
             } catch (final Exception ignored) {
             }
         }
-        return tabOf(player, args, space);
+        return Collections.emptyList();
     }
 
     @CommandDeclaration(command = "set",


### PR DESCRIPTION
## Overview
Fixes #3028 

## Description
This PR fixes the incorrect tab completion behavior for the command `/plot flag set <flag> <value>`

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
