### PR TITLE
fix: test case for adventure update

### DIFF
--- a/Core/src/test/java/com/plotsquared/core/configuration/caption/ClickStripTransformTest.java
+++ b/Core/src/test/java/com/plotsquared/core/configuration/caption/ClickStripTransformTest.java
@@ -37,12 +37,7 @@ class ClickStripTransformTest {
     void removeClickEvent() {
         var commonAction = ClickEvent.Action.OPEN_FILE;
         var transform = new ClickStripTransform(EnumSet.of(commonAction));
-        var component = Component.text("Hello")
-                .clickEvent(ClickEvent.clickEvent(
-                                commonAction,
-                                "World"
-                        )
-                );
+        var component = Component.text("Hello").clickEvent(ClickEvent.openFile("World"));
         var transformedComponent = transform.transform(component);
         Assertions.assertNull(transformedComponent.clickEvent());
     }
@@ -52,10 +47,7 @@ class ClickStripTransformTest {
     void ignoreClickEvent() {
         var actionToRemove = ClickEvent.Action.SUGGEST_COMMAND;
         var transform = new ClickStripTransform(EnumSet.of(actionToRemove));
-        var originalClickEvent = ClickEvent.clickEvent(
-                ClickEvent.Action.CHANGE_PAGE,
-                "World"
-        );
+        var originalClickEvent = ClickEvent.changePage(1337);
         var component = Component.text("Hello")
                 .clickEvent(originalClickEvent);
         var transformedComponent = transform.transform(component);
@@ -76,12 +68,12 @@ class ClickStripTransformTest {
                 .insertion("DEF");
         var component = Component.text("Hello ")
                 .append(
-                        inner.clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://example.org"))
+                        inner.clickEvent(ClickEvent.openUrl("https://example.org"))
                 );
         var transformedComponent = transform.transform(component);
         Assertions.assertFalse(transformedComponent.children().isEmpty()); // child still exists
-        Assertions.assertEquals(inner, transformedComponent.children().get(0)); // only the click event has changed
-        Assertions.assertNull(transformedComponent.children().get(0).clickEvent());
+        Assertions.assertEquals(inner, transformedComponent.children().getFirst()); // only the click event has changed
+        Assertions.assertNull(transformedComponent.children().getFirst().clickEvent());
     }
 
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ checkerqual = "3.49.5"
 gson = "2.10"
 guava = "31.1-jre"
 snakeyaml = "2.0"
-adventure = "4.21.0"
+adventure = "4.23.0"
 adventure-bukkit = "4.4.0"
 log4j = "2.19.0"
 


### PR DESCRIPTION
## Overview

Supersedes #4674 

## Description
Strings shouldn't be passed to the open_page click event. adventure no parses the value to an int and fails with the previous test case.

Replaced deprecated methods with new accessors (and cleaned up general deprecations).

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
