### PR TITLE
fix: allow admin override when setting plot context in command

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/MainCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/MainCommand.java
@@ -296,7 +296,7 @@ public class MainCommand extends Command {
         final boolean isDenied = newPlot.isDenied(player.getUUID());
         if (!isAdmin) {
             if (isDenied) {
-                return CompletableFuture.completedFuture(Optional.of(data));
+                throw new CommandException(TranslatableCaption.of("deny.cannot_interact"));
             }
             if (area != null && area.equals(newPlot.getArea()) && !player.hasPermission(Permission.PERMISSION_ADMIN_AREA_SUDO)) {
                 return CompletableFuture.completedFuture(Optional.of(data));

--- a/Core/src/main/resources/lang/messages_en.json
+++ b/Core/src/main/resources/lang/messages_en.json
@@ -414,6 +414,7 @@
   "deny.denied_added": "<prefix><dark_aqua>You successfully denied the player from this plot.</dark_aqua>",
   "deny.no_enter": "<prefix><red>You are denied from the plot <red><gold><plot></gold><red> and therefore not allowed to enter.</red>",
   "deny.you_got_denied": "<prefix><red>You are denied from the plot you were previously on, and got teleported to spawn.</red>",
+  "deny.cannot_interact": "<prefix><red>You are denied from the plot <red><gold><plot></gold><red> and therefore cannot interact with it.</red>",
   "deny.cant_remove_owner": "<prefix><red>You can't remove the plot owner.</red>",
   "kick.player_not_in_plot": "<prefix><red>The player <gray><player></gray> is not on this plot.</red>",
   "kick.cannot_kick_player": "<prefix><red>You cannot kick the player <gray><player></gray>.</red>",


### PR DESCRIPTION
 - when admins (plots.admin or console) attempted to use /plot x;z to set context on a plot they are denied on, it would not work
 - fixes #4696
