### PR TITLE
Update adventure-platform-bukkit to 4.4.1-SNAPSHOT

### DIFF
--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -15,6 +15,11 @@ repositories {
         name = "EssentialsX"
         url = uri("https://repo.essentialsx.net/releases/")
     }
+    maven("https://central.sonatype.com/repository/maven-snapshots/") {
+        content {
+            includeGroup("net.kyori")
+        }
+    }
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ gson = "2.10"
 guava = "31.1-jre"
 snakeyaml = "2.0"
 adventure = "4.23.0"
-adventure-bukkit = "4.4.0"
+adventure-bukkit = "4.4.1-SNAPSHOT"
 log4j = "2.19.0"
 
 # Plugins


### PR DESCRIPTION
Restore the ability to click on chat interaction and restore plot titles.

This is a fairly safe change to include, given the changeset covers adding support for new MC versions only: https://github.com/KyoriPowered/adventure-platform/compare/7ece7ac519f0c2dd00ad25205c28f50237d71a78...5867a1939ac34bfd2a1864ab41f67101fea45a7d