### PR TITLE
fix: tab completion for /plot grant add/check <name> commands

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/Grant.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Grant.java
@@ -177,8 +177,14 @@ public class Grant extends Command {
                 commands.addAll(TabCompletions.completePlayers(player, args[0], Collections.emptyList()));
             }
             return commands;
+        } else if (args.length == 2) {
+            final String subcommand = args[0].toLowerCase();
+            if ((subcommand.equals("add") && player.hasPermission(Permission.PERMISSION_GRANT_ADD)) ||
+                (subcommand.equals("check") && player.hasPermission(Permission.PERMISSION_GRANT_CHECK))) {
+                return TabCompletions.completePlayers(player, args[1], Collections.emptyList());
+            }
         }
-        return TabCompletions.completePlayers(player, String.join(",", args).trim(), Collections.emptyList());
+        return Collections.emptyList();
     }
 
 }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #4382

## Description
<!-- Please describe what this pull request does. -->

Fixed tab completion for `/plot grant add/check <name>` commands where player name suggestions were not appearing correctly.

**Problem:**
The tab completion logic was attempting to complete player names using all arguments joined together, which meant typing `/plot grant add <TAB>` would try to complete players using "add," as the search term instead of providing player suggestions for the name parameter.

**Solution:**
Updated the `tab()` method in `Grant.java` to properly handle completion for the second argument:
- `/plot grant <TAB>` → shows "add", "check" subcommands  
- `/plot grant add <TAB>` → shows player list
- `/plot grant check <TAB>` → shows player list

The fix ensures that player completions are provided specifically when the user is typing the player name parameter after a valid subcommand.

### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).