### PR TITLE
fix: correct height that FAWE ends up using for schematics

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/generator/ClassicPlotWorld.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/ClassicPlotWorld.java
@@ -164,6 +164,9 @@ public abstract class ClassicPlotWorld extends SquarePlotWorld {
                 : getMinBuildHeight();
     }
 
+    /**
+     * Get the lowest height of plot, road, and wall. Accounts for {@link Settings.Schematics#USE_WALL_IN_ROAD_SCHEM_HEIGHT}
+     */
     int schematicStartHeight() {
         int plotRoadMin = Math.min(PLOT_HEIGHT, ROAD_HEIGHT);
         if (!Settings.Schematics.USE_WALL_IN_ROAD_SCHEM_HEIGHT) {

--- a/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
@@ -276,7 +276,7 @@ public class HybridPlotWorld extends ClassicPlotWorld {
                 SCHEM_Y = getMinGenHeight();
                 plotY = 0;
             } else if (!Settings.Schematics.PASTE_ON_TOP) {
-                SCHEM_Y = getMinGenHeight();
+                SCHEM_Y = getMinBuildHeight();
                 plotY = 0;
             }
         }

--- a/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridPlotWorld.java
@@ -276,6 +276,7 @@ public class HybridPlotWorld extends ClassicPlotWorld {
                 SCHEM_Y = getMinGenHeight();
                 plotY = 0;
             } else if (!Settings.Schematics.PASTE_ON_TOP) {
+                // Schematics should generate/be pasted from build height
                 SCHEM_Y = getMinBuildHeight();
                 plotY = 0;
             }
@@ -293,18 +294,14 @@ public class HybridPlotWorld extends ClassicPlotWorld {
                 roadY = 0; // Road is the lowest schematic
                 if (schematic3 != null && schematic3.getClipboard().getDimensions().getY() != worldGenHeight) {
                     // Road is the lowest schematic. Normalize plotY to it.
-                    if (Settings.Schematics.PASTE_ON_TOP) {
-                        plotY = PLOT_HEIGHT - getMinGenHeight();
-                    }
+                    plotY = (Settings.Schematics.PASTE_ON_TOP ? PLOT_HEIGHT : getMinBuildHeight()) - SCHEM_Y;
                 }
             } else if (!Settings.Schematics.PASTE_ROAD_ON_TOP) {
                 roadY = 0;
                 SCHEM_Y = getMinGenHeight();
-                if (schematic3 != null) {
-                    if (Settings.Schematics.PASTE_ON_TOP) {
-                        // Road is the lowest schematic. Normalize plotY to it.
-                        plotY = PLOT_HEIGHT - SCHEM_Y;
-                    }
+                if (schematic3 != null && schematic3.getClipboard().getDimensions().getY() != worldGenHeight) {
+                    // Road is the lowest schematic. Normalize plotY to it.
+                    plotY = (Settings.Schematics.PASTE_ON_TOP ? PLOT_HEIGHT : getMinBuildHeight()) - SCHEM_Y;
                 }
             } else {
                 roadY = minRoadWall - SCHEM_Y;

--- a/Core/src/main/java/com/plotsquared/core/generator/HybridUtils.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridUtils.java
@@ -68,6 +68,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -529,7 +530,7 @@ public class HybridUtils {
         final QueueCoordinator queue = blockQueue.getNewQueue(worldUtil.getWeWorld(world));
         Location bot = plot.getBottomAbs().subtract(1, 0, 1);
         Location top = plot.getTopAbs();
-        final HybridPlotWorld plotworld = (HybridPlotWorld) plot.getArea();
+        final HybridPlotWorld plotworld = Objects.requireNonNull((HybridPlotWorld) plot.getArea());
         // Do not use plotworld#schematicStartHeight() here as we want to restore the pre 6.1.4 way of doing it if
         //  USE_WALL_IN_ROAD_SCHEM_HEIGHT is false
         int schemY = Settings.Schematics.USE_WALL_IN_ROAD_SCHEM_HEIGHT ?


### PR DESCRIPTION
 - this did not end up having an impact on P2 code as it always used getMinBuildHeight when PASTE_ON_TOP was false anyway
 - there should not be any side effects to this as any uses this specific SCHEM_Y value are effectively normalised against it
 - fixes #4404