### PR TITLE
fix: don't break cow shearing if mob-spawning flag is set to false

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
@@ -160,7 +160,7 @@ public class EntityEventListener implements Listener {
                     return;
                 }
             }
-            case "REINFORCEMENTS", "NATURAL", "MOUNT", "PATROL", "RAID", "SHEARED", "SILVERFISH_BLOCK", "ENDER_PEARL",
+            case "REINFORCEMENTS", "NATURAL", "MOUNT", "PATROL", "RAID", "SILVERFISH_BLOCK", "ENDER_PEARL",
                  "TRAP", "VILLAGE_DEFENSE", "VILLAGE_INVASION", "BEEHIVE", "CHUNK_GEN", "NETHER_PORTAL",
                  "FROZEN", "SPELL", "DEFAULT" -> {
                 if (!area.isMobSpawning()) {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
@@ -202,7 +202,7 @@ public class PaperListener implements Listener {
                     return;
                 }
             }
-            case "REINFORCEMENTS", "NATURAL", "MOUNT", "PATROL", "RAID", "SHEARED", "SILVERFISH_BLOCK", "ENDER_PEARL", "TRAP", "VILLAGE_DEFENSE", "VILLAGE_INVASION", "BEEHIVE", "CHUNK_GEN" -> {
+            case "REINFORCEMENTS", "NATURAL", "MOUNT", "PATROL", "RAID", "SILVERFISH_BLOCK", "ENDER_PEARL", "TRAP", "VILLAGE_DEFENSE", "VILLAGE_INVASION", "BEEHIVE", "CHUNK_GEN" -> {
                 if (!area.isMobSpawning()) {
                     event.setShouldAbortSpawn(true);
                     event.setCancelled(true);


### PR DESCRIPTION
## Overview
Fixes cow shearing cancelled when mob-spawning is set to false. There are some other spawn reasons which I believe should also be removed (e.g. BEEHIVE) but this one is present on our server and shouldn't case any regressions.

## Description
Same as above, pinging @PierreSchwang as requested.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
