### PR TITLE
fix: binary incompatibility on 1.21.1

### DIFF
--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -17,6 +17,19 @@ repositories {
     }
 }
 
+// Make sure we control the exact version of paper being included, while dropping spigot + bukkit
+configurations.all {
+    exclude("org.bukkit")
+    exclude("org.spigotmc")
+
+    resolutionStrategy.eachDependency {
+        if (requested.group == "io.papermc.paper" && requested.name == "paper-api") {
+            useVersion(checkNotNull(libs.paper.orNull?.version))
+            because("specific paper version is required to prevent binary incompatibilities on older versions")
+        }
+    }
+}
+
 dependencies {
     api(projects.plotsquaredCore)
 
@@ -28,20 +41,13 @@ dependencies {
     implementation(libs.paperlib)
 
     // Plugins
-    compileOnly(libs.worldeditBukkit) {
-        exclude(group = "org.bukkit")
-        exclude(group = "org.spigotmc")
-    }
+    compileOnly(libs.worldeditBukkit)
     compileOnly(libs.faweBukkit) { isTransitive = false }
     testImplementation(libs.faweBukkit) { isTransitive = false }
-    compileOnly(libs.vault) {
-        exclude(group = "org.bukkit")
-    }
+    compileOnly(libs.vault)
     compileOnly(libs.placeholderapi)
     compileOnly(libs.luckperms)
-    compileOnly(libs.essentialsx) {
-        exclude(group = "org.spigotmc")
-    }
+    compileOnly(libs.essentialsx)
     compileOnly(libs.mvdwapi) { isTransitive = false }
 
     // Other libraries


### PR DESCRIPTION
## Overview
EssentialsX pulled in paper as a dependency , which resulted in paper 1.21.8 being on the classpath. Gradle / Java compiled against that version, which resulted in PlotSquared not running on older versions anymore (like 1.21.1, etc). Reason being the change of the Biome enum to an interface, which results in different instructions in the bytecode, which makes PS not compatible with the enum versions anymore.

Strictly set the paper version globally and drop bukkit and spigot globally. That should prevent that happening in the future as well.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
