### PR TITLE
fix: missing fallback if current plot is not explicitly overridden

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/command/DebugRoadRegen.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DebugRoadRegen.java
@@ -90,7 +90,7 @@ public class DebugRoadRegen extends SubCommand {
     }
 
     public boolean regenPlot(PlotPlayer<?> player) {
-        PlotArea area = player.getCurrentPlot().getArea();
+        PlotArea area = player.getContextualPlotArea();
         if (area == null) {
             player.sendMessage(TranslatableCaption.of("errors.not_in_plot_world"));
             return false;
@@ -145,9 +145,10 @@ public class DebugRoadRegen extends SubCommand {
             return false;
         }
 
-        PlotArea area = player.getCurrentPlot().getArea();
+        PlotArea area = player.getContextualPlotArea();
         if (area == null) {
             player.sendMessage(TranslatableCaption.of("errors.not_in_plot_world"));
+            return false;
         }
         Plot plot = player.getCurrentPlot();
         PlotManager manager = area.getPlotManager();

--- a/Core/src/main/java/com/plotsquared/core/command/ListCmd.java
+++ b/Core/src/main/java/com/plotsquared/core/command/ListCmd.java
@@ -150,8 +150,8 @@ public class ListCmd extends SubCommand {
             page = 0;
         }
 
-        String world = player.getCurrentPlot().getWorldName();
-        PlotArea area = player.getCurrentPlot().getArea();
+        PlotArea area = player.getContextualPlotArea();
+        String world = area != null ? area.getWorldName() : "";
         String arg = args[0].toLowerCase();
         final boolean[] sort = new boolean[]{true};
 

--- a/Core/src/main/java/com/plotsquared/core/command/Load.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Load.java
@@ -68,11 +68,6 @@ public class Load extends SubCommand {
 
     @Override
     public boolean onCommand(final PlotPlayer<?> player, final String[] args) {
-        final String world = player.getCurrentPlot().getWorldName();
-        if (!this.plotAreaManager.hasPlotArea(world)) {
-            player.sendMessage(TranslatableCaption.of("errors.not_in_plot_world"));
-            return false;
-        }
         final Plot plot = player.getCurrentPlot();
         if (plot == null) {
             player.sendMessage(TranslatableCaption.of("errors.not_in_plot"));

--- a/Core/src/main/java/com/plotsquared/core/command/Set.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Set.java
@@ -78,7 +78,7 @@ public class Set extends SubCommand {
 
             @Override
             public boolean set(PlotPlayer<?> player, final Plot plot, String value) {
-                final PlotArea plotArea = player.getCurrentPlot().getArea();
+                final PlotArea plotArea = player.getContextualPlotArea();
                 if (plotArea == null) {
                     return false;
                 }

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -541,7 +541,7 @@ public class Plot {
      *
      * @return World name
      */
-    public @Nullable String getWorldName() {
+    public @NonNull String getWorldName() {
         return area.getWorldName();
     }
 

--- a/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlot.java
@@ -58,7 +58,7 @@ public class SinglePlot extends Plot {
     }
 
     @Override
-    public String getWorldName() {
+    public @NonNull String getWorldName() {
         return getId().toUnderscoreSeparatedString();
     }
 


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #4756
Fixes #4772

## Description
<!-- Please describe what this pull request does. -->

`PlotPlayer#getCurrentPlot()` considers the override in commands, e.g., `/plot 1;1 info`. However, if the current plot is not overridden and the player is not on a plot, we need properly fall back to still return the plot area or the world name the player is in. This PR addresses such situation.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
