### PR TITLE
Ignore already cancelled block breaks to improve plugin compatibility

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener.java
@@ -219,7 +219,7 @@ public class BlockEventListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void blockDestroy(BlockBreakEvent event) {
         Player player = event.getPlayer();
         Location location = BukkitUtil.adapt(event.getBlock().getLocation());


### PR DESCRIPTION
## Overview
Currently, PlotSquared always processes BlockBreakEvent even if another plugin has already cancelled it. This can result in unwanted "no permission" messages and complicates integration with plugins that need to handle certain blocks when broken regardless of plot protection.

## Description
This change ensures that if a block break event is already cancelled by another plugin, PlotSquared will ignore it.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
