### PR TITLE
Preserve vanilla drop behavior when tile-drop flag is applied

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PaperListener.java
@@ -104,6 +104,10 @@ public class PaperListener implements Listener {
         }
         Plot plot = area.getPlot(location);
         if (plot != null) {
+            // Prevent dropping blocks which normally would not be dropped.
+            if (!event.willDrop()) {
+                return;
+            }
             event.setWillDrop(plot.getFlag(TileDropFlag.class));
         }
     }


### PR DESCRIPTION
## Description
Currently, the `tile-drop` flag does not respect the initial value of `BlockDestroyEvent#willDrop`, which is set by the server before the event is fired. As a result, some blocks that would not drop in a vanilla environment end up dropping.

You can reproduce that by doing the following:
1. Go to a plot which has `tile-drop` set to `true`
2. Spawn a sniffer egg using `/setblock ~ ~ ~ minecraft:sniffer_egg[hatch=2]`
3. Wait until the egg hatches

You will notice that the egg block is dropped.

This PR fixes the issue by adding a simple check to ensure PlotSquared only sets `willDrop` when it is already `true`, preserving vanilla behavior.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
