### PR TITLE
Fix: (build) Defer shadowJar output access to fix exclusive lock issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -216,8 +216,6 @@ tasks.getByName<Jar>("jar") {
     enabled = false
 }
 
-val plotSquaredShadowJarProviders = project(":plotsquared-bukkit").tasks.named<Jar>("shadowJar").map { it.archiveFile }
-
 val supportedVersions = listOf("1.19.4", "1.20.6", "1.21.1", "1.21.3", "1.21.4", "1.21.5", "1.21.6", "1.21.7", "1.21.8")
 tasks {
     register("cacheLatestFaweArtifact") {
@@ -233,8 +231,10 @@ tasks {
         register<RunServer>("runServer-$it") {
             dependsOn(getByName("cacheLatestFaweArtifact"))
             minecraftVersion(it)
-            // Defer the access to the execution phase.
-            pluginJars(project.files(plotSquaredShadowJarProviders))
+            pluginJars(project.files(
+                project(":plotsquared-bukkit").tasks.named<Jar>("shadowJar")
+                .map { it.archiveFile }
+            ))
             jvmArgs("-DPaper.IgnoreJavaVersion=true", "-Dcom.mojang.eula.agree=true")
             downloadPlugins {
                 url("https://ci.athion.net/job/FastAsyncWorldEdit/lastSuccessfulBuild/artifact/artifacts/${project.ext["faweArtifact"]}")


### PR DESCRIPTION
## Overview
```gradle
[error] FAILURE: Build failed with an exception.

* What went wrong:
Resolution of the configuration ':plotsquared-bukkit:annotationProcessor' was attempted without an exclusive lock. This is unsafe and not allowed.
```

## Description
This issue is only present when running the project with `org.gradle.parallel=true`

The previous implementation accessed the `.archiveFile` property directly during the configuration phase. This is not allowed.

This eager access forces Gradle to resolve dependent configs inmmediately, potentially leading to this error when running in parallel or with Configuration Cache.

* Resolves exclusive lock error by deferring Jar output access
* Avoids eager task output resolution for runServer tasks.
* Uses Provider API for shadowJar output in runServer tasks.

This ensures that the output file path is only resolved during the Execution Phase, where Gradle holds the necessary locks, thereby eliminating the unsafe access and improving build stability ;)

[Gradle Docs](https://docs.gradle.org/9.2.1/userguide/viewing_debugging_dependencies.html#sub:resolving-unsafe-configuration-resolution-errors)

### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
