### PR TITLE
Add support for short world notation in placeholders

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/placeholder/PAPIPlaceholders.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/placeholder/PAPIPlaceholders.java
@@ -70,7 +70,7 @@ public class PAPIPlaceholders extends PlaceholderExpansion {
             if (identifier.isEmpty()) {
                 return "";
             }
-            
+
             if (identifier.equals("this")) {
                 identifier = pl.getLocation().getWorldName();
             }
@@ -85,11 +85,11 @@ public class PAPIPlaceholders extends PlaceholderExpansion {
             if (identifier.isEmpty()) {
                 return "";
             }
-            
+
             if (identifier.equals("this")) {
                 identifier = pl.getLocation().getWorldName();
             }
-            
+
             return String.valueOf(pl.getPlotCount(identifier));
         }
 
@@ -98,7 +98,7 @@ public class PAPIPlaceholders extends PlaceholderExpansion {
             if (identifier.isEmpty()) {
                 return "";
             }
-            
+
             if (identifier.equals("this")) {
                 identifier = pl.getLocation().getWorldName();
             }
@@ -108,6 +108,39 @@ public class PAPIPlaceholders extends PlaceholderExpansion {
                     .inWorld(identifier)
                     .whereBasePlot()
                     .thatPasses(plot -> !DoneFlag.isDone(plot))
+                    .count());
+        }
+
+        if (identifier.startsWith("server_plot_count_")) {
+            identifier = identifier.substring("server_plot_count_".length());
+            if (identifier.isEmpty()) {
+                return "";
+            }
+
+            if (identifier.equals("this")) {
+                identifier = pl.getLocation().getWorldName();
+            }
+
+            return String.valueOf(PlotQuery.newQuery()
+                    .allPlots()
+                    .inWorld(identifier)
+                    .count());
+        }
+
+        if (identifier.startsWith("server_base_plot_count_")) {
+            identifier = identifier.substring("server_base_plot_count_".length());
+            if (identifier.isEmpty()) {
+                return "";
+            }
+
+            if (identifier.equals("this")) {
+                identifier = pl.getLocation().getWorldName();
+            }
+
+            return String.valueOf(PlotQuery.newQuery()
+                    .allPlots()
+                    .inWorld(identifier)
+                    .whereBasePlot()
                     .count());
         }
 

--- a/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
+++ b/Core/src/main/java/com/plotsquared/core/util/placeholders/PlaceholderRegistry.java
@@ -225,6 +225,15 @@ public final class PlaceholderRegistry {
                 return Integer.toString(metaDataAccess.get().orElse(0));
             }
         });
+        this.createPlaceholder("server_plot_count", player -> Integer.toString(PlotQuery.newQuery()
+                .allPlots()
+                .count())
+        );
+        this.createPlaceholder("server_base_plot_count", player -> Integer.toString(PlotQuery.newQuery()
+                .allPlots()
+                .whereBasePlot()
+                .count())
+        );
     }
 
     /**


### PR DESCRIPTION
## Overview
This PR adds new placeholders and adds support for short world notation of exists PAPI placeholders.

## Description

### Improving of exists placeholders
Improving of placeholders with `this` as short term for `(worldname)` for the world in which the player currently is:

<img width="858" height="297" alt="grafik" src="https://github.com/user-attachments/assets/2555c609-4df1-41ad-92af-8dd959bf6338" />

- `%plotsquared_plotsquared_has_plot_this%` - Displays true or false whether the player has plot in _this_ world.
- `%plotsquared_plotsquared_plot_count_this%` - Amount of plots for a player in _this_ world.
- `%plotsquared_plotsquared_base_plot_count_this%` - Amount of plots for a player in _this_ world, counting merged plots as one.

### New placeholders:

- `%plotsquared_server_plot_count%` - Amount of all plots (of all players) on the entire server.
- `%plotsquared_server_base_plot_count%` - Amount of all plots (of all players) on the entire server, counting merged plots as one.
- `%plotsquared_server_plot_count_(world name or 'this')%` - Amount of all plots (of all players) in the target world.
- `%plotsquared_server_base_plot_count_(world name or 'this')%` - Amount of all plots (of all players) in the target world, counting merged plots as one.

### Further information

Tested with `/papi parse RedstoneFuture <placeholder>` on my test server.

I will write the placeholders into the [placeholder documentation](https://intellectualsites.gitbook.io/plotsquared/customization/placeholders) once everything has been approved.

**Note:** Placeholders _with_ `_(world)` or `_this` arguments are PAPI only placeholders. The Boolean string output depends on the PAPI configuration (`yes` and `no` by default). This was already the case previously.

### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
