### PR TITLE
fix(WorldGen): Schematics chest inventory contents aren't pasted correctly on plots 

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/schematic/StateWrapper.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/schematic/StateWrapper.java
@@ -212,7 +212,10 @@ public class StateWrapper {
                     if (type == null) {
                         continue;
                     }
-                    int count = itemComp.getByte("Count");
+                    // At some point they used lowercase "count" as IntTag; older format uses "Count" as ByteTag
+                    int count = itemComp.getValue().containsKey("count")
+                            ? itemComp.getInt("count")
+                            : itemComp.getByte("Count");
                     int slot = itemComp.getByte("Slot");
                     CompoundTag tag = (CompoundTag) itemComp.getValue().get("tag");
                     BaseItemStack baseItemStack = new BaseItemStack(type, tag, count);


### PR DESCRIPTION

## Overview

Fixes #4708 (again?)


## Description

**Cause** At some point of time the schematic has changed to `count`: int instead of `Count`
<img width="501" height="385" alt="image" src="https://github.com/user-attachments/assets/e6bc00cb-f6b4-41e1-8f73-44053bf7a4ec" />

By simply checking for hasTag("Count") ? read `Count` : read `count`, backward compatibility with older item formats should be given.

### Verify
Tested using a my modified Fork which places random schematics on top of a plot on `1.21.11` with `FAWE`

1. In theory a road schematic which has chests with contents  should be generated empty using the latest Release
2. Switching the jar with this version, chest content should be generated too.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
