### PR TITLE
fix: support new world / dimension directory structure and fix per-world plots

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -145,6 +145,7 @@ import org.incendo.serverlib.ServerLib;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -778,6 +779,24 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
     @Override
     public @NonNull File worldContainer() {
         return Bukkit.getWorldContainer();
+    }
+
+    @Override
+    public @NonNull Path getWorldContainer(final String namespace) {
+        Path root = Bukkit.getWorldContainer().toPath();
+        if (MinecraftVersion.current().isOlderOrEqualThan(MinecraftVersion.TINY_TAKEOVER)) {
+            return root.resolve("world").resolve("dimensions").resolve(namespace);
+        }
+        return root;
+    }
+
+    @Override
+    public @NonNull Path getWorldPath(final String namespace, final String world) {
+        Path root = Bukkit.getWorldContainer().toPath();
+        if (MinecraftVersion.current().isOlderOrEqualThan(MinecraftVersion.TINY_TAKEOVER)) {
+            return root.resolve("world").resolve("dimensions").resolve(namespace).resolve(world);
+        }
+        return root.resolve(world);
     }
 
     @SuppressWarnings("deprecation")

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -145,7 +145,6 @@ import org.incendo.serverlib.ServerLib;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -779,24 +778,6 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
     @Override
     public @NonNull File worldContainer() {
         return Bukkit.getWorldContainer();
-    }
-
-    @Override
-    public @NonNull Path getWorldContainer(final String namespace) {
-        Path root = Bukkit.getWorldContainer().toPath();
-        if (MinecraftVersion.current().isOlderOrEqualThan(MinecraftVersion.TINY_TAKEOVER)) {
-            return root.resolve("world").resolve("dimensions").resolve(namespace);
-        }
-        return root;
-    }
-
-    @Override
-    public @NonNull Path getWorldPath(final String namespace, final String world) {
-        Path root = Bukkit.getWorldContainer().toPath();
-        if (MinecraftVersion.current().isOlderOrEqualThan(MinecraftVersion.TINY_TAKEOVER)) {
-            return root.resolve("world").resolve("dimensions").resolve(namespace).resolve(world);
-        }
-        return root.resolve(world);
     }
 
     @SuppressWarnings("deprecation")

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/SingleWorldListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/SingleWorldListener.java
@@ -22,8 +22,6 @@ import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.plot.world.PlotAreaManager;
 import com.plotsquared.core.plot.world.SinglePlotArea;
 import com.plotsquared.core.plot.world.SinglePlotAreaManager;
-import com.plotsquared.core.util.MinecraftVersion;
-import com.plotsquared.core.util.ReflectionUtils;
 import org.bukkit.Chunk;
 import org.bukkit.World;
 import org.bukkit.event.EventHandler;
@@ -32,18 +30,14 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.world.ChunkEvent;
 import org.bukkit.event.world.ChunkLoadEvent;
 
-import java.lang.reflect.Method;
-
-import static com.plotsquared.core.util.ReflectionUtils.getRefClass;
-
 public class SingleWorldListener implements Listener {
 
-    private final Method methodSetUnsaved;
-    private Method methodGetHandleChunk;
-    private Object objChunkStatusFull = null;
+    //private final Method methodSetUnsaved;
+    //private Method methodGetHandleChunk;
+    //private Object objChunkStatusFull = null;
 
     public SingleWorldListener() throws Exception {
-        ReflectionUtils.RefClass classCraftChunk = getRefClass("{cb}.CraftChunk");
+        /* ReflectionUtils.RefClass classCraftChunk = getRefClass("{cb}.CraftChunk");
         ReflectionUtils.RefClass classChunkAccess = getRefClass("net.minecraft.world.level.chunk.IChunkAccess");
         this.methodSetUnsaved = classChunkAccess.getMethod("a", boolean.class).getRealMethod();
         try {
@@ -61,18 +55,18 @@ public class SingleWorldListener implements Listener {
             } catch (NoSuchMethodException ex) {
                 throw new RuntimeException(ex);
             }
-        }
+        } */
     }
 
     public void markChunkAsClean(Chunk chunk) {
-        try {
+        /* try {
             Object nmsChunk = objChunkStatusFull != null
                     ? this.methodGetHandleChunk.invoke(chunk, objChunkStatusFull)
                     : this.methodGetHandleChunk.invoke(chunk);
             methodSetUnsaved.invoke(nmsChunk, false);
         } catch (Throwable e) {
             e.printStackTrace();
-        }
+        } */
     }
 
     private void handle(ChunkEvent event) {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
@@ -562,10 +562,11 @@ public class BukkitUtil extends WorldUtil {
     }
 
     @Override
-    public Set<BlockVector2> getChunkChunks(String world) {
+    public Set<BlockVector2> getChunkChunks(com.plotsquared.core.location.World<?> world) {
         Set<BlockVector2> chunks = super.getChunkChunks(world);
+        World bukkitWorld = ((com.plotsquared.bukkit.util.BukkitWorld) world).getPlatformWorld();
         if (Bukkit.isPrimaryThread()) {
-            for (Chunk chunk : Objects.requireNonNull(Bukkit.getWorld(world)).getLoadedChunks()) {
+            for (Chunk chunk : bukkitWorld.getLoadedChunks()) {
                 BlockVector2 loc = BlockVector2.at(chunk.getX() >> 5, chunk.getZ() >> 5);
                 chunks.add(loc);
             }
@@ -574,7 +575,7 @@ public class BukkitUtil extends WorldUtil {
             try {
                 semaphore.acquire();
                 Bukkit.getScheduler().runTask(BukkitPlatform.getPlugin(BukkitPlatform.class), () -> {
-                    for (Chunk chunk : Objects.requireNonNull(Bukkit.getWorld(world)).getLoadedChunks()) {
+                    for (Chunk chunk : bukkitWorld.getLoadedChunks()) {
                         BlockVector2 loc = BlockVector2.at(chunk.getX() >> 5, chunk.getZ() >> 5);
                         chunks.add(loc);
                     }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitWorld.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitWorld.java
@@ -20,11 +20,15 @@ package com.plotsquared.bukkit.util;
 
 import com.google.common.collect.Maps;
 import com.plotsquared.core.location.World;
+import net.kyori.adventure.key.Key;
 import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
+import java.nio.file.Path;
 import java.util.Map;
 
 public class BukkitWorld implements World<org.bukkit.World> {
@@ -47,6 +51,7 @@ public class BukkitWorld implements World<org.bukkit.World> {
 
     // We want to allow GC to remove bukkit worlds, but not too eagerly
     private final SoftReference<org.bukkit.World> world;
+    private Key key = null;
 
     private BukkitWorld(final org.bukkit.World world) {
         this.world = new SoftReference<>(world);
@@ -102,7 +107,7 @@ public class BukkitWorld implements World<org.bukkit.World> {
     }
 
     @Override
-    public org.bukkit.World getPlatformWorld() {
+    public org.bukkit.@NonNull World getPlatformWorld() {
         org.bukkit.World world = this.world.get();
         if (world == null) {
             throw new IllegalStateException("Bukkit platform world was unloaded from memory");
@@ -123,6 +128,21 @@ public class BukkitWorld implements World<org.bukkit.World> {
     @Override
     public int getMaxHeight() {
         return getMaxWorldHeight(getPlatformWorld()) - 1;
+    }
+
+    @Override
+    public @NonNull Path getWorldFolder() {
+        return getPlatformWorld().getWorldFolder().toPath();
+    }
+
+    @Override
+    @SuppressWarnings("PatternValidation") // kyori pattern validation...
+    public @NotNull Key key() {
+        if (this.key == null) {
+            NamespacedKey bukkitKey = getPlatformWorld().getKey();
+            this.key = Key.key(bukkitKey.getNamespace(), bukkitKey.getKey());
+        }
+        return this.key;
     }
 
     @Override

--- a/Core/src/main/java/com/plotsquared/core/PlotPlatform.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotPlatform.java
@@ -50,6 +50,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.File;
+import java.nio.file.Path;
 
 /**
  * PlotSquared main utility class
@@ -67,10 +68,44 @@ public interface PlotPlatform<P> extends LocaleHolder {
 
     /**
      * Gets the folder where all world data is stored.
+     * For legacy versions this is the server root, for 26.1+ this is {@code ./world}
      *
      * @return the world folder
      */
-    @NonNull File worldContainer();
+    @NonNull
+    File worldContainer();
+
+    /**
+     * Gets the path to the dimension directory for the given namespace, e.g. {@code ./world/dimension/<namespace>}.
+     * <p>
+     * Legacy versions ignore the namespace and return the default path (by default the server root).
+     *
+     * @param namespace the dimension namespace
+     * @return a path to the dimension directory. may not exist.
+     */
+    @NonNull
+    Path getWorldContainer(String namespace);
+
+    /**
+     * See {@link #getWorldPath(String, String)}. Uses the default {@code minecraft} namespace.
+     *
+     */
+    @NonNull
+    default Path getWorldPath(String world) {
+        return getWorldPath("minecraft", world);
+    }
+
+    /**
+     * Gets the path to the world directory for the given namespace, e.g. {@code ./world/dimension/<namespace>/<world>}.
+     * <p>
+     * Legacy versions ignore the namespace (by default {@code ./<world>})
+     *
+     * @param namespace the dimension namespace
+     * @param world     the name of the world in the given dimension
+     * @return a path to the world directory. may not exist.
+     */
+    @NonNull
+    Path getWorldPath(String namespace, String world);
 
     /**
      * Completely shuts down the plugin.

--- a/Core/src/main/java/com/plotsquared/core/PlotPlatform.java
+++ b/Core/src/main/java/com/plotsquared/core/PlotPlatform.java
@@ -50,7 +50,6 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.File;
-import java.nio.file.Path;
 
 /**
  * PlotSquared main utility class
@@ -68,44 +67,12 @@ public interface PlotPlatform<P> extends LocaleHolder {
 
     /**
      * Gets the folder where all world data is stored.
-     * For legacy versions this is the server root, for 26.1+ this is {@code ./world}
+     * For legacy versions this is the server root, for 26.1+ this is the universe folder (by default {@code ./world})
      *
      * @return the world folder
      */
     @NonNull
     File worldContainer();
-
-    /**
-     * Gets the path to the dimension directory for the given namespace, e.g. {@code ./world/dimension/<namespace>}.
-     * <p>
-     * Legacy versions ignore the namespace and return the default path (by default the server root).
-     *
-     * @param namespace the dimension namespace
-     * @return a path to the dimension directory. may not exist.
-     */
-    @NonNull
-    Path getWorldContainer(String namespace);
-
-    /**
-     * See {@link #getWorldPath(String, String)}. Uses the default {@code minecraft} namespace.
-     *
-     */
-    @NonNull
-    default Path getWorldPath(String world) {
-        return getWorldPath("minecraft", world);
-    }
-
-    /**
-     * Gets the path to the world directory for the given namespace, e.g. {@code ./world/dimension/<namespace>/<world>}.
-     * <p>
-     * Legacy versions ignore the namespace (by default {@code ./<world>})
-     *
-     * @param namespace the dimension namespace
-     * @param world     the name of the world in the given dimension
-     * @return a path to the world directory. may not exist.
-     */
-    @NonNull
-    Path getWorldPath(String namespace, String world);
 
     /**
      * Completely shuts down the plugin.
@@ -266,7 +233,7 @@ public interface PlotPlatform<P> extends LocaleHolder {
      * @param worldName World name
      * @return Platform world wrapper
      */
-    @Nullable World<?> getPlatformWorld(@NonNull String worldName);
+    @NonNull World<?> getPlatformWorld(@NonNull String worldName);
 
     /**
      * Get the {@link com.google.inject.Injector} instance used by PlotSquared

--- a/Core/src/main/java/com/plotsquared/core/command/DatabaseCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DatabaseCommand.java
@@ -43,9 +43,14 @@ import com.plotsquared.core.util.task.TaskManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,6 +65,8 @@ import java.util.Map.Entry;
         requiredType = RequiredType.CONSOLE,
         usage = "/plot database [area] <sqlite | mysql | import>")
 public class DatabaseCommand extends SubCommand {
+
+    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + DatabaseCommand.class.getSimpleName());
 
     private final PlotAreaManager plotAreaManager;
     private final EventDispatcher eventDispatcher;
@@ -93,7 +100,7 @@ public class DatabaseCommand extends SubCommand {
                 });
             } catch (Exception e) {
                 player.sendMessage(TranslatableCaption.of("database.conversion_failed"));
-                e.printStackTrace();
+                LOGGER.error("Database conversion failed", e);
             }
         });
     }
@@ -171,18 +178,14 @@ public class DatabaseCommand extends SubCommand {
                                         if (newPlot != null) {
                                             PlotId newId = newPlot.getId();
                                             PlotId id = plot.getId();
-                                            File worldFile =
-                                                    new File(
-                                                            PlotSquared.platform().worldContainer(),
-                                                            id.toCommaSeparatedString()
-                                                    );
-                                            if (worldFile.exists()) {
-                                                File newFile =
-                                                        new File(
-                                                                PlotSquared.platform().worldContainer(),
-                                                                newId.toCommaSeparatedString()
-                                                        );
-                                                worldFile.renameTo(newFile);
+                                            Path worldPath = PlotSquared.platform().getWorldPath(id.toCommaSeparatedString());
+                                            if (Files.exists(worldPath)) {
+                                                Path newPath = PlotSquared.platform().getWorldPath(newId.toCommaSeparatedString());
+                                                try {
+                                                    Files.move(worldPath, newPath);
+                                                } catch (IOException e) {
+                                                    LOGGER.error("Failed to rename world entry", e);
+                                                }
                                             }
                                             plot.setId(newId);
                                             plot.setArea(pa);
@@ -257,7 +260,7 @@ public class DatabaseCommand extends SubCommand {
             } catch (ClassNotFoundException | SQLException e) {
                 player.sendMessage(TranslatableCaption.of("database.failed_to_save_plots"));
                 player.sendMessage(TranslatableCaption.of("errors.stacktrace_begin"));
-                e.printStackTrace();
+                LOGGER.error("Inserting plots failed", e);
                 player.sendMessage(TranslatableCaption.of("errors.stacktrace_end"));
                 player.sendMessage(TranslatableCaption.of("database.invalid_args"));
                 return false;
@@ -265,7 +268,7 @@ public class DatabaseCommand extends SubCommand {
         } catch (ClassNotFoundException | SQLException e) {
             player.sendMessage(TranslatableCaption.of("database.failed_to_open"));
             player.sendMessage(TranslatableCaption.of("errors.stacktrace_begin"));
-            e.printStackTrace();
+            LOGGER.error("Opening database connection failed", e);
             player.sendMessage(TranslatableCaption.of("errors.stacktrace_end"));
             player.sendMessage(TranslatableCaption.of("database.invalid_args"));
             return false;

--- a/Core/src/main/java/com/plotsquared/core/command/DatabaseCommand.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DatabaseCommand.java
@@ -38,6 +38,7 @@ import com.plotsquared.core.plot.world.PlotAreaManager;
 import com.plotsquared.core.plot.world.SinglePlotArea;
 import com.plotsquared.core.util.EventDispatcher;
 import com.plotsquared.core.util.FileUtils;
+import com.plotsquared.core.util.WorldUtil;
 import com.plotsquared.core.util.query.PlotQuery;
 import com.plotsquared.core.util.task.TaskManager;
 import net.kyori.adventure.text.Component;
@@ -165,6 +166,7 @@ public class DatabaseCommand extends SubCommand {
                             this.eventDispatcher, this.plotListener, this.worldConfiguration
                     );
                     HashMap<String, HashMap<PlotId, Plot>> map = manager.getPlots();
+                    Path worldContainer = PlotSquared.platform().worldContainer().toPath();
                     plots = new ArrayList<>();
                     for (Entry<String, HashMap<PlotId, Plot>> entry : map.entrySet()) {
                         String areaName = entry.getKey();
@@ -178,9 +180,15 @@ public class DatabaseCommand extends SubCommand {
                                         if (newPlot != null) {
                                             PlotId newId = newPlot.getId();
                                             PlotId id = plot.getId();
-                                            Path worldPath = PlotSquared.platform().getWorldPath(id.toCommaSeparatedString());
+                                            Path worldPath = (WorldUtil.isModernServerLevelStructure() ?
+                                                    worldContainer.resolve("dimensions").resolve("minecraft") :
+                                                    worldContainer
+                                            ).resolve(id.toCommaSeparatedString());
                                             if (Files.exists(worldPath)) {
-                                                Path newPath = PlotSquared.platform().getWorldPath(newId.toCommaSeparatedString());
+                                                Path newPath = (WorldUtil.isModernServerLevelStructure() ?
+                                                        worldContainer.resolve("dimensions").resolve("minecraft") :
+                                                        worldContainer
+                                                ).resolve(newId.toCommaSeparatedString());
                                                 try {
                                                     Files.move(worldPath, newPath);
                                                 } catch (IOException e) {

--- a/Core/src/main/java/com/plotsquared/core/command/DebugImportWorlds.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DebugImportWorlds.java
@@ -127,13 +127,14 @@ public class DebugImportWorlds extends Command {
                 uuid = UUID.nameUUIDFromBytes(("OfflinePlayer:" + p.name()).getBytes(Charsets.UTF_8));
             }
             Path target;
-            if (Files.exists(target = this.container.resolve(this.id.toCommaSeparatedString()))) {
+            while (Files.exists(target = this.container.resolve(this.id.toCommaSeparatedString()))) {
                 this.id = this.id.getNextId();
             }
             try {
                 Files.move(p.path(), target);
                 Objects.requireNonNull(this.area.getPlot(this.id)).setOwner(uuid);
-            } catch (IOException ignored) {
+            } catch (IOException e) {
+                LOGGER.error("Failed to import world: Failed to move world", e);
             }
         }
 

--- a/Core/src/main/java/com/plotsquared/core/command/DebugImportWorlds.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DebugImportWorlds.java
@@ -84,7 +84,8 @@ public class DebugImportWorlds extends Command {
             return CompletableFuture.completedFuture(false);
         }
         try (Stream<Path> stream = Files.walk(container, 1)) {
-            stream.map(path -> new PathWithName(path, path.getFileName().toString()))
+            stream.skip(1) // skip container / root
+                    .map(path -> new PathWithName(path, path.getFileName().toString()))
                     .filter(p -> !this.worldUtil.isWorld(p.name()))
                     .filter(p -> PlotId.fromStringOrNull(p.name()) == null)
                     .forEach(new ImportAction(player, area, container));

--- a/Core/src/main/java/com/plotsquared/core/command/DebugImportWorlds.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DebugImportWorlds.java
@@ -43,6 +43,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 @CommandDeclaration(command = "debugimportworlds",
@@ -84,7 +85,7 @@ public class DebugImportWorlds extends Command {
             return CompletableFuture.completedFuture(false);
         }
         try (Stream<Path> stream = Files.walk(container, 1)) {
-            stream.skip(1) // skip container / root
+            stream.filter(Predicate.not(p -> p.equals(container))) // skip container / root
                     .map(path -> new PathWithName(path, path.getFileName().toString()))
                     .filter(p -> !this.worldUtil.isWorld(p.name()))
                     .filter(p -> PlotId.fromStringOrNull(p.name()) == null)

--- a/Core/src/main/java/com/plotsquared/core/command/DebugImportWorlds.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DebugImportWorlds.java
@@ -21,8 +21,10 @@ package com.plotsquared.core.command;
 import com.google.common.base.Charsets;
 import com.google.inject.Inject;
 import com.plotsquared.core.PlotSquared;
+import com.plotsquared.core.configuration.caption.StaticCaption;
 import com.plotsquared.core.configuration.caption.TranslatableCaption;
 import com.plotsquared.core.player.PlotPlayer;
+import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.plot.PlotId;
 import com.plotsquared.core.plot.world.PlotAreaManager;
 import com.plotsquared.core.plot.world.SinglePlotArea;
@@ -30,17 +32,26 @@ import com.plotsquared.core.plot.world.SinglePlotAreaManager;
 import com.plotsquared.core.util.WorldUtil;
 import com.plotsquared.core.util.task.RunnableVal2;
 import com.plotsquared.core.util.task.RunnableVal3;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 @CommandDeclaration(command = "debugimportworlds",
         permission = "plots.admin",
         requiredType = RequiredType.CONSOLE,
         category = CommandCategory.TELEPORT)
 public class DebugImportWorlds extends Command {
+
+    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + DebugImportWorlds.class.getSimpleName());
 
     private final PlotAreaManager plotAreaManager;
     private final WorldUtil worldUtil;
@@ -67,37 +78,65 @@ public class DebugImportWorlds extends Command {
             return CompletableFuture.completedFuture(false);
         }
         SinglePlotArea area = ((SinglePlotAreaManager) this.plotAreaManager).getArea();
-        PlotId id = PlotId.of(0, 0);
-        File container = PlotSquared.platform().worldContainer();
-        if (container.equals(new File("."))) {
+        Path container = PlotSquared.platform().getWorldContainer("minecraft");
+        if (container.equals(Path.of("."))) {
             player.sendMessage(TranslatableCaption.of("debugimportworlds.world_container"));
             return CompletableFuture.completedFuture(false);
         }
-        for (File folder : container.listFiles()) {
-            String name = folder.getName();
-            if (!this.worldUtil.isWorld(name) && PlotId.fromStringOrNull(name) == null) {
-                UUID uuid;
-                if (name.length() > 16) {
-                    uuid = UUID.fromString(name);
-                } else {
-                    player.sendMessage(TranslatableCaption.of("players.fetching_player"));
-                    uuid = PlotSquared.get().getImpromptuUUIDPipeline().getSingle(name, 60000L);
-                }
-                if (uuid == null) {
-                    uuid =
-                            UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(Charsets.UTF_8));
-                }
-                while (new File(container, id.toCommaSeparatedString()).exists()) {
-                    id = id.getNextId();
-                }
-                File newDir = new File(container, id.toCommaSeparatedString());
-                if (folder.renameTo(newDir)) {
-                    area.getPlot(id).setOwner(uuid);
-                }
-            }
+        try (Stream<Path> stream = Files.walk(container, 1)) {
+            stream.map(path -> new PathWithName(path, path.getFileName().toString()))
+                    .filter(p -> !this.worldUtil.isWorld(p.name()))
+                    .filter(p -> PlotId.fromStringOrNull(p.name()) == null)
+                    .forEach(new ImportAction(player, area, container));
+        } catch (IOException e) {
+            LOGGER.error("Failed to import world", e);
+            throw new CommandException(StaticCaption.of("<red>World import failed. Check console.</red>"));
         }
         player.sendMessage(TranslatableCaption.of("players.done"));
         return CompletableFuture.completedFuture(true);
+    }
+
+    private record PathWithName(Path path, String name) {
+
+    }
+
+    private static class ImportAction implements Consumer<PathWithName> {
+
+        private final PlotPlayer<?> player;
+        private final PlotArea area;
+        private final Path container;
+
+        private PlotId id = PlotId.of(0, 0);
+
+        private ImportAction(final PlotPlayer<?> player, final PlotArea area, final Path container) {
+            this.player = player;
+            this.area = area;
+            this.container = container;
+        }
+
+        @Override
+        public void accept(final PathWithName p) {
+            UUID uuid;
+            if (p.name().length() > 16) {
+                uuid = UUID.fromString(p.name());
+            } else {
+                this.player.sendMessage(TranslatableCaption.of("players.fetching_player"));
+                uuid = PlotSquared.get().getImpromptuUUIDPipeline().getSingle(p.name(), 60000L);
+            }
+            if (uuid == null) {
+                uuid = UUID.nameUUIDFromBytes(("OfflinePlayer:" + p.name()).getBytes(Charsets.UTF_8));
+            }
+            Path target;
+            if (Files.exists(target = this.container.resolve(this.id.toCommaSeparatedString()))) {
+                this.id = this.id.getNextId();
+            }
+            try {
+                Files.move(p.path(), target);
+                Objects.requireNonNull(this.area.getPlot(this.id)).setOwner(uuid);
+            } catch (IOException ignored) {
+            }
+        }
+
     }
 
 }

--- a/Core/src/main/java/com/plotsquared/core/command/DebugImportWorlds.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DebugImportWorlds.java
@@ -79,17 +79,21 @@ public class DebugImportWorlds extends Command {
             return CompletableFuture.completedFuture(false);
         }
         SinglePlotArea area = ((SinglePlotAreaManager) this.plotAreaManager).getArea();
-        Path container = PlotSquared.platform().getWorldContainer("minecraft");
+        Path container = PlotSquared.platform().worldContainer().toPath();
+        if (WorldUtil.isModernServerLevelStructure()) {
+            container = container.resolve("dimensions").resolve("minecraft");
+        }
         if (container.equals(Path.of("."))) {
             player.sendMessage(TranslatableCaption.of("debugimportworlds.world_container"));
             return CompletableFuture.completedFuture(false);
         }
-        try (Stream<Path> stream = Files.walk(container, 1)) {
-            stream.filter(Predicate.not(p -> p.equals(container))) // skip container / root
+        final Path finalContainer = container;
+        try (Stream<Path> stream = Files.walk(finalContainer, 1)) {
+            stream.filter(Predicate.not(p -> p.equals(finalContainer))) // skip container / root
                     .map(path -> new PathWithName(path, path.getFileName().toString()))
                     .filter(p -> !this.worldUtil.isWorld(p.name()))
                     .filter(p -> PlotId.fromStringOrNull(p.name()) == null)
-                    .forEach(new ImportAction(player, area, container));
+                    .forEach(new ImportAction(player, area, finalContainer));
         } catch (IOException e) {
             LOGGER.error("Failed to import world", e);
             throw new CommandException(StaticCaption.of("<red>World import failed. Check console.</red>"));

--- a/Core/src/main/java/com/plotsquared/core/command/DebugImportWorlds.java
+++ b/Core/src/main/java/com/plotsquared/core/command/DebugImportWorlds.java
@@ -102,6 +102,9 @@ public class DebugImportWorlds extends Command {
         return CompletableFuture.completedFuture(true);
     }
 
+    /**
+     * A directory path paired with its file name, used while filtering candidate world folders for import.
+     */
     private record PathWithName(Path path, String name) {
 
     }

--- a/Core/src/main/java/com/plotsquared/core/command/Trim.java
+++ b/Core/src/main/java/com/plotsquared/core/command/Trim.java
@@ -23,6 +23,7 @@ import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.caption.StaticCaption;
 import com.plotsquared.core.configuration.caption.TranslatableCaption;
 import com.plotsquared.core.location.Location;
+import com.plotsquared.core.location.World;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.world.PlotAreaManager;
@@ -78,22 +79,23 @@ public class Trim extends SubCommand {
     /**
      * Runs the result task with the parameters (viable, nonViable).
      *
-     * @param world  The world
+     * @param worldName  The world name
      * @param result (viable = .mcr to trim, nonViable = .mcr keep)
      * @return success or not
      */
     public static boolean getTrimRegions(
-            String world,
+            String worldName,
             final RunnableVal2<Set<BlockVector2>, Set<BlockVector2>> result
     ) {
         if (result == null) {
             return false;
         }
         TranslatableCaption.of("trim.trim_starting");
-        final List<Plot> plots = PlotQuery.newQuery().inWorld(world).asList();
+        final List<Plot> plots = PlotQuery.newQuery().inWorld(worldName).asList();
         if (PlotSquared.platform().expireManager() != null) {
             plots.removeAll(PlotSquared.platform().expireManager().getPendingExpired());
         }
+        World<?> world = PlotSquared.platform().getPlatformWorld(worldName);
         result.value1 = new HashSet<>(PlotSquared.platform().worldUtil().getChunkChunks(world));
         result.value2 = new HashSet<>();
         StaticCaption.of(" - MCA #: " + result.value1.size());
@@ -117,8 +119,7 @@ public class Trim extends SubCommand {
                     }
                 }
             }
-        }).thenAccept(ignore ->
-                TaskManager.getPlatformImplementation().taskLater(result, TaskTime.ticks(1L)));
+        }).thenRun(() -> TaskManager.getPlatformImplementation().taskLater(result, TaskTime.ticks(1L)));
         return true;
     }
 

--- a/Core/src/main/java/com/plotsquared/core/generator/HybridUtils.java
+++ b/Core/src/main/java/com/plotsquared/core/generator/HybridUtils.java
@@ -19,6 +19,7 @@
 package com.plotsquared.core.generator;
 
 import com.google.inject.Inject;
+import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.events.PlotFlagAddEvent;
 import com.plotsquared.core.events.Result;
@@ -400,7 +401,7 @@ public class HybridUtils {
             return false;
         }
         HybridUtils.UPDATE = true;
-        Set<BlockVector2> regions = this.worldUtil.getChunkChunks(area.getWorldName());
+        Set<BlockVector2> regions = this.worldUtil.getChunkChunks(PlotSquared.platform().getPlatformWorld(area.getWorldName()));
         return scheduleRoadUpdate(area, regions, extend, new LinkedHashSet<>());
     }
 

--- a/Core/src/main/java/com/plotsquared/core/location/World.java
+++ b/Core/src/main/java/com/plotsquared/core/location/World.java
@@ -72,7 +72,8 @@ public interface World<T> extends Keyed {
     int getMaxHeight();
 
     /**
-     * Get the path to this worlds' folder (the folder containing the {@code level.dat} file).
+     * Get the path to this worlds' folder (for legacy versions the folder containing the {@code level.dat} file, for newer
+     * versions the namespaced dimension folder).
      *
      * @return the path
      * @since TODO

--- a/Core/src/main/java/com/plotsquared/core/location/World.java
+++ b/Core/src/main/java/com/plotsquared/core/location/World.java
@@ -18,14 +18,19 @@
  */
 package com.plotsquared.core.location;
 
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.Keyed;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
 
 /**
  * PlotSquared representation of a platform world
  *
  * @param <T> Platform world type
  */
-public interface World<T> {
+public interface World<T> extends Keyed {
 
     /**
      * Get a {@link NullWorld} implementation
@@ -66,6 +71,14 @@ public interface World<T> {
      */
     int getMaxHeight();
 
+    /**
+     * Get the path to this worlds' folder (the folder containing the {@code level.dat} file).
+     *
+     * @return the path
+     * @since TODO
+     */
+    @NonNull Path getWorldFolder();
+
     class NullWorld<T> implements World<T> {
 
         private NullWorld() {
@@ -90,6 +103,16 @@ public interface World<T> {
         @Override
         public int getMaxHeight() {
             return 0;
+        }
+
+        @Override
+        public @NonNull Path getWorldFolder() {
+            throw new UnsupportedOperationException("Cannot get world folder from NullWorld");
+        }
+
+        @Override
+        public @NotNull Key key() {
+            throw new UnsupportedOperationException("Cannot get key from NullWorld");
         }
 
         @Override

--- a/Core/src/main/java/com/plotsquared/core/plot/Plot.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/Plot.java
@@ -2257,7 +2257,8 @@ public class Plot {
      * @return if the given player can claim the plot
      */
     public boolean canClaim(@NonNull PlotPlayer<?> player) {
-        if (!WorldUtil.isValidLocation(getBottomAbs())) {
+        // only check bounds if the plot is not part of a single plot area (the world does not exist before claiming)
+        if (!(area instanceof SinglePlotArea) && !WorldUtil.isValidLocation(getBottomAbs())) {
             return false;
         }
         PlotCluster cluster = this.getCluster();

--- a/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/PlotModificationManager.java
@@ -37,6 +37,7 @@ import com.plotsquared.core.location.Direction;
 import com.plotsquared.core.location.Location;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.flag.PlotFlag;
+import com.plotsquared.core.plot.world.SinglePlotManager;
 import com.plotsquared.core.queue.QueueCoordinator;
 import com.plotsquared.core.util.task.TaskManager;
 import com.plotsquared.core.util.task.TaskTime;
@@ -227,7 +228,8 @@ public final class PlotModificationManager {
             @Override
             public void run() {
                 if (queue.isEmpty()) {
-                    Runnable run = () -> {
+                    // don't touch world for single plot areas on deletion (un-fuck this in the future)
+                    Runnable run = isDelete && manager instanceof SinglePlotManager ? whenDone : () -> {
                         for (CuboidRegion region : regions) {
                             Location[] corners = Plot.getCorners(plot.getWorldName(), region);
                             PlotSquared.platform().regionManager().clearAllEntities(corners[0], corners[1]);
@@ -250,7 +252,9 @@ public final class PlotModificationManager {
                         queue.enqueue();
                         return;
                     }
-                    run.run();
+                    if (run != null) {
+                        run.run();
+                    }
                     return;
                 }
                 Plot current = queue.poll();

--- a/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlotArea.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlotArea.java
@@ -44,9 +44,12 @@ import com.plotsquared.core.util.task.TaskManager;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 
 public class SinglePlotArea extends GridPlotWorld {
 
@@ -135,45 +138,40 @@ public class SinglePlotArea extends GridPlotWorld {
                 .settingsNodesWrapper(new SettingsNodesWrapper(new ConfigurationNode[0], null))
                 .worldName(worldName);
 
-        File container = PlotSquared.platform().worldContainer();
-        File destination = new File(container, worldName);
+        Path destination = PlotSquared.platform().getWorldPath(worldName);
 
         {// convert old
-            File oldFile = new File(container, id.toCommaSeparatedString());
-            if (oldFile.exists()) {
-                oldFile.renameTo(destination);
-            } else {
-                oldFile = new File(container, id.toSeparatedString("."));
-                if (oldFile.exists()) {
-                    oldFile.renameTo(destination);
+            Path old = PlotSquared.platform().getWorldPath(id.toCommaSeparatedString());
+            if (!Files.exists(old)) {
+                old = PlotSquared.platform().getWorldPath(id.toSeparatedString("."));
+            }
+            if (Files.exists(old)) {
+                try {
+                    Files.move(old, destination);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
                 }
             }
         }
         // Duplicate 0;0
         if (builder.plotAreaType() != PlotAreaType.NORMAL) {
-            if (!destination.exists()) {
-                File src = new File(container, "0_0");
-                if (src.exists()) {
-                    if (!destination.exists()) {
-                        destination.mkdirs();
+            if (!Files.exists(destination)) {
+                Path src = PlotSquared.platform().getWorldPath("0_0");
+                if (Files.exists(src)) {
+                    try {
+                        Files.createDirectories(destination);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
                     }
-                    File levelDat = new File(src, "level.dat");
-                    if (levelDat.exists()) {
+                    Path levelDat = src.resolve("level.dat");
+                    if (Files.exists(levelDat)) {
                         try {
-                            Files.copy(
-                                    levelDat.toPath(),
-                                    new File(destination, levelDat.getName()).toPath()
-                            );
-                            File data = new File(src, "data");
-                            if (data.exists()) {
-                                File dataDest = new File(destination, "data");
-                                dataDest.mkdirs();
-                                for (File file : data.listFiles()) {
-                                    Files.copy(
-                                            file.toPath(),
-                                            new File(dataDest, file.getName()).toPath()
-                                    );
-                                }
+                            Files.copy(levelDat, destination.resolve(levelDat.getFileName()));
+                            Path data = src.resolve("data");
+                            if (Files.exists(data)) {
+                                Path dataDest = destination.resolve("data");
+                                Files.createDirectories(dataDest);
+                                Files.walkFileTree(data, new RecursiveDirectoryCopyVisitor(dataDest));
                             }
                         } catch (IOException exception) {
                             exception.printStackTrace();
@@ -207,6 +205,37 @@ public class SinglePlotArea extends GridPlotWorld {
         //        return AsyncWorld.create(wc);
     }
 
+    private static final class RecursiveDirectoryCopyVisitor extends SimpleFileVisitor<Path> {
+
+        private final Path target;
+        private Path base;
+
+        public RecursiveDirectoryCopyVisitor(Path target) {
+            this.target = target;
+        }
+
+        @Override
+        public @NonNull FileVisitResult preVisitDirectory(
+                @NonNull final Path dir,
+                @NonNull final BasicFileAttributes attrs
+        ) throws IOException {
+            if (this.base == null) {
+                // first iteration, root
+                this.base = dir;
+            } else {
+                Files.createDirectories(this.target.resolve(this.base.relativize(dir)));
+            }
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public @NonNull FileVisitResult visitFile(@NonNull final Path file, @NonNull final BasicFileAttributes attrs) throws
+                IOException {
+            Files.copy(file, this.target.resolve(this.base.relativize(file)));
+            return FileVisitResult.CONTINUE;
+        }
+
+    }
 
     @Override
     public ConfigurationNode[] getSettingNodes() {

--- a/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlotArea.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlotArea.java
@@ -36,7 +36,9 @@ import com.plotsquared.core.plot.PlotId;
 import com.plotsquared.core.plot.PlotManager;
 import com.plotsquared.core.plot.PlotSettings;
 import com.plotsquared.core.plot.flag.FlagContainer;
+import com.plotsquared.core.queue.DelegateQueueCoordinator;
 import com.plotsquared.core.queue.GlobalBlockQueue;
+import com.plotsquared.core.queue.QueueCoordinator;
 import com.plotsquared.core.setup.PlotAreaBuilder;
 import com.plotsquared.core.setup.SettingsNodesWrapper;
 import com.plotsquared.core.util.EventDispatcher;
@@ -114,6 +116,22 @@ public class SinglePlotArea extends GridPlotWorld {
     @Override
     protected PlotManager createManager() {
         return new SinglePlotManager(this);
+    }
+
+    /**
+     * Single Plot Areas must provide a different QueueCoordinator than other plot areas, otherwise plot deletion fails.
+     * When deleting plots, the PlotModificationManager retrieves a QueueCoordinator from the associated PlotArea, which
+     * accesses the plots world. For SinglePlotAreas this world is null at this point, as the whole world is deleted (and the
+     * areas world name being `*`).
+     * <br>
+     * The queue doesn't know <i>when</i> it's used, so this always provides a QueueCoordinator that doesn't do anything and
+     * doesn't contain any tasks. This isn't really bad, as SinglePlotAreas don't utilize the Queue as of now.
+     *
+     * @return a QueueCoordinator for SinglePlotAreas
+     */
+    @Override
+    public QueueCoordinator getQueue() {
+        return new DelegateQueueCoordinator(null);
     }
 
     @Override

--- a/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlotArea.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlotArea.java
@@ -40,6 +40,7 @@ import com.plotsquared.core.queue.GlobalBlockQueue;
 import com.plotsquared.core.setup.PlotAreaBuilder;
 import com.plotsquared.core.setup.SettingsNodesWrapper;
 import com.plotsquared.core.util.EventDispatcher;
+import com.plotsquared.core.util.WorldUtil;
 import com.plotsquared.core.util.task.TaskManager;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -138,12 +139,16 @@ public class SinglePlotArea extends GridPlotWorld {
                 .settingsNodesWrapper(new SettingsNodesWrapper(new ConfigurationNode[0], null))
                 .worldName(worldName);
 
-        Path destination = PlotSquared.platform().getWorldPath(worldName);
+        Path dimensionRoot = PlotSquared.platform().worldContainer().toPath();
+        if (WorldUtil.isModernServerLevelStructure()) {
+            dimensionRoot = dimensionRoot.resolve("dimensions").resolve("minecraft");
+        }
+        Path destination = dimensionRoot.resolve(worldName);
 
         {// convert old
-            Path old = PlotSquared.platform().getWorldPath(id.toCommaSeparatedString());
+            Path old = dimensionRoot.resolve(id.toCommaSeparatedString());
             if (!Files.exists(old)) {
-                old = PlotSquared.platform().getWorldPath(id.toSeparatedString("."));
+                old = dimensionRoot.resolve(id.toSeparatedString("."));
             }
             if (Files.exists(old)) {
                 try {
@@ -156,7 +161,7 @@ public class SinglePlotArea extends GridPlotWorld {
         // Duplicate 0;0
         if (builder.plotAreaType() != PlotAreaType.NORMAL) {
             if (!Files.exists(destination)) {
-                Path src = PlotSquared.platform().getWorldPath("0_0");
+                Path src = dimensionRoot.resolve("0_0");
                 if (Files.exists(src)) {
                     try {
                         Files.createDirectories(destination);

--- a/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlotManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlotManager.java
@@ -26,13 +26,14 @@ import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.plot.PlotId;
 import com.plotsquared.core.plot.PlotManager;
 import com.plotsquared.core.queue.QueueCoordinator;
-import com.plotsquared.core.util.FileUtils;
 import com.plotsquared.core.util.task.TaskManager;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 public class SinglePlotManager extends PlotManager {
@@ -71,9 +72,13 @@ public class SinglePlotManager extends PlotManager {
             @Nullable QueueCoordinator queue
     ) {
         PlotSquared.platform().setupUtils().unload(plot.getWorldName(), false);
-        final File worldFolder = new File(PlotSquared.platform().worldContainer(), plot.getWorldName());
+        Path path = PlotSquared.platform().getWorldPath(plot.getWorldName());
         TaskManager.getPlatformImplementation().taskAsync(() -> {
-            FileUtils.deleteDirectory(worldFolder);
+            try {
+                Files.deleteIfExists(path);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to delete directory", e);
+            }
             if (whenDone != null) {
                 whenDone.run();
             }

--- a/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlotManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlotManager.java
@@ -26,8 +26,11 @@ import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.plot.PlotId;
 import com.plotsquared.core.plot.PlotManager;
 import com.plotsquared.core.queue.QueueCoordinator;
+import com.plotsquared.core.util.RecursiveDirectoryRemovalWalker;
 import com.plotsquared.core.util.task.TaskManager;
 import com.sk89q.worldedit.function.pattern.Pattern;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -39,6 +42,7 @@ import java.util.List;
 public class SinglePlotManager extends PlotManager {
 
     private static final int MAX_COORDINATE = 20000000;
+    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + SinglePlotManager.class.getSimpleName());
 
     public SinglePlotManager(final @NonNull PlotArea plotArea) {
         super(plotArea);
@@ -75,9 +79,9 @@ public class SinglePlotManager extends PlotManager {
         Path path = PlotSquared.platform().getWorldPath(plot.getWorldName());
         TaskManager.getPlatformImplementation().taskAsync(() -> {
             try {
-                Files.deleteIfExists(path);
+                Files.walkFileTree(path, RecursiveDirectoryRemovalWalker.INSTANCE);
             } catch (IOException e) {
-                throw new RuntimeException("Failed to delete directory", e);
+                LOGGER.error("Failed to delete plot world for single plot area", e);
             }
             if (whenDone != null) {
                 whenDone.run();

--- a/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlotManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlotManager.java
@@ -20,7 +20,6 @@ package com.plotsquared.core.plot.world;
 
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.location.Location;
-import com.plotsquared.core.location.World;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
@@ -28,10 +27,8 @@ import com.plotsquared.core.plot.PlotId;
 import com.plotsquared.core.plot.PlotManager;
 import com.plotsquared.core.queue.QueueCoordinator;
 import com.plotsquared.core.util.RecursiveDirectoryRemovalWalker;
-import com.plotsquared.core.util.WorldUtil;
 import com.plotsquared.core.util.task.TaskManager;
 import com.sk89q.worldedit.function.pattern.Pattern;
-import net.kyori.adventure.key.Key;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -78,17 +75,11 @@ public class SinglePlotManager extends PlotManager {
             @Nullable PlotPlayer<?> actor,
             @Nullable QueueCoordinator queue
     ) {
-        World<?> world = PlotSquared.platform().getPlatformWorld(plot.getWorldName());
-        Path path = world.getWorldFolder();
-        Key key = world.key();
+        Path path = PlotSquared.platform().getPlatformWorld(plot.getWorldName()).getWorldFolder();
         PlotSquared.platform().setupUtils().unload(plot.getWorldName(), false);
-        if (WorldUtil.isModernServerLevelStructure()) {
-            path = path.resolve("dimensions").resolve(key.namespace()).resolve(key.value());
-        }
-        final Path finalPath = path;
         TaskManager.getPlatformImplementation().taskAsync(() -> {
             try {
-                Files.walkFileTree(finalPath, RecursiveDirectoryRemovalWalker.INSTANCE);
+                Files.walkFileTree(path, RecursiveDirectoryRemovalWalker.INSTANCE);
             } catch (IOException e) {
                 LOGGER.error("Failed to delete plot world for single plot area", e);
             }

--- a/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlotManager.java
+++ b/Core/src/main/java/com/plotsquared/core/plot/world/SinglePlotManager.java
@@ -20,6 +20,7 @@ package com.plotsquared.core.plot.world;
 
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.location.Location;
+import com.plotsquared.core.location.World;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
@@ -27,8 +28,10 @@ import com.plotsquared.core.plot.PlotId;
 import com.plotsquared.core.plot.PlotManager;
 import com.plotsquared.core.queue.QueueCoordinator;
 import com.plotsquared.core.util.RecursiveDirectoryRemovalWalker;
+import com.plotsquared.core.util.WorldUtil;
 import com.plotsquared.core.util.task.TaskManager;
 import com.sk89q.worldedit.function.pattern.Pattern;
+import net.kyori.adventure.key.Key;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -75,11 +78,17 @@ public class SinglePlotManager extends PlotManager {
             @Nullable PlotPlayer<?> actor,
             @Nullable QueueCoordinator queue
     ) {
+        World<?> world = PlotSquared.platform().getPlatformWorld(plot.getWorldName());
+        Path path = world.getWorldFolder();
+        Key key = world.key();
         PlotSquared.platform().setupUtils().unload(plot.getWorldName(), false);
-        Path path = PlotSquared.platform().getWorldPath(plot.getWorldName());
+        if (WorldUtil.isModernServerLevelStructure()) {
+            path = path.resolve("dimensions").resolve(key.namespace()).resolve(key.value());
+        }
+        final Path finalPath = path;
         TaskManager.getPlatformImplementation().taskAsync(() -> {
             try {
-                Files.walkFileTree(path, RecursiveDirectoryRemovalWalker.INSTANCE);
+                Files.walkFileTree(finalPath, RecursiveDirectoryRemovalWalker.INSTANCE);
             } catch (IOException e) {
                 LOGGER.error("Failed to delete plot world for single plot area", e);
             }

--- a/Core/src/main/java/com/plotsquared/core/util/CloseShieldOutputStream.java
+++ b/Core/src/main/java/com/plotsquared/core/util/CloseShieldOutputStream.java
@@ -1,0 +1,36 @@
+/*
+ * PlotSquared, a land and world management plugin for Minecraft.
+ * Copyright (C) IntellectualSites <https://intellectualsites.com>
+ * Copyright (C) IntellectualSites team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.util;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public final class CloseShieldOutputStream extends FilterOutputStream {
+
+    public CloseShieldOutputStream(final OutputStream out) {
+        super(out);
+    }
+
+    @Override
+    public void close() throws IOException {
+        // NOOP
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/util/CloseShieldOutputStream.java
+++ b/Core/src/main/java/com/plotsquared/core/util/CloseShieldOutputStream.java
@@ -22,6 +22,11 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
+/**
+ * A {@link FilterOutputStream} that shields the underlying stream from
+ * being closed. Useful when passing a stream to code that may call
+ * {@link #close()}, but the stream needs to remain open for further writing.
+ */
 public final class CloseShieldOutputStream extends FilterOutputStream {
 
     public CloseShieldOutputStream(final OutputStream out) {

--- a/Core/src/main/java/com/plotsquared/core/util/RecursiveDirectoryRemovalWalker.java
+++ b/Core/src/main/java/com/plotsquared/core/util/RecursiveDirectoryRemovalWalker.java
@@ -1,3 +1,21 @@
+/*
+ * PlotSquared, a land and world management plugin for Minecraft.
+ * Copyright (C) IntellectualSites <https://intellectualsites.com>
+ * Copyright (C) IntellectualSites team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.plotsquared.core.util;
 
 import org.jetbrains.annotations.NotNull;

--- a/Core/src/main/java/com/plotsquared/core/util/RecursiveDirectoryRemovalWalker.java
+++ b/Core/src/main/java/com/plotsquared/core/util/RecursiveDirectoryRemovalWalker.java
@@ -1,0 +1,34 @@
+package com.plotsquared.core.util;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+public class RecursiveDirectoryRemovalWalker extends SimpleFileVisitor<Path> {
+
+    public static final RecursiveDirectoryRemovalWalker INSTANCE = new RecursiveDirectoryRemovalWalker();
+
+    private RecursiveDirectoryRemovalWalker() {
+    }
+
+    @Override
+    public @NotNull FileVisitResult postVisitDirectory(@NotNull final Path dir, @Nullable final IOException exc) throws
+            IOException {
+        Files.delete(dir);
+        return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public @NotNull FileVisitResult visitFile(@NotNull final Path file, @NotNull final BasicFileAttributes attrs) throws
+            IOException {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+    }
+
+}

--- a/Core/src/main/java/com/plotsquared/core/util/RecursiveDirectoryRemovalWalker.java
+++ b/Core/src/main/java/com/plotsquared/core/util/RecursiveDirectoryRemovalWalker.java
@@ -28,6 +28,9 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 
+/**
+ * A {@link SimpleFileVisitor} that recursively deletes a directory tree.
+ */
 public class RecursiveDirectoryRemovalWalker extends SimpleFileVisitor<Path> {
 
     public static final RecursiveDirectoryRemovalWalker INSTANCE = new RecursiveDirectoryRemovalWalker();

--- a/Core/src/main/java/com/plotsquared/core/util/RegionManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/RegionManager.java
@@ -99,7 +99,7 @@ public abstract class RegionManager {
                 try {
                     Files.deleteIfExists(path);
                 } catch (IOException e) {
-                    throw new RuntimeException("Failed to delete region file", e);
+                    LOGGER.error("Failed to delete region file", e);
                 }
             }
             TaskManager.runTask(whenDone);

--- a/Core/src/main/java/com/plotsquared/core/util/RegionManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/RegionManager.java
@@ -45,7 +45,9 @@ import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Set;
 
@@ -89,13 +91,15 @@ public abstract class RegionManager {
     public abstract int[] countEntities(Plot plot);
 
     public void deleteRegionFiles(final String world, final Collection<BlockVector2> chunks, final Runnable whenDone) {
+        Path regionRoot = PlotSquared.platform().getWorldPath(world).resolve("region");
         TaskManager.runTaskAsync(() -> {
             for (BlockVector2 loc : chunks) {
-                String directory = world + File.separator + "region" + File.separator + "r." + loc.getX() + "." + loc.getZ() + ".mca";
-                File file = new File(PlotSquared.platform().worldContainer(), directory);
-                LOGGER.info("- Deleting file: {} (max 1024 chunks)", file.getName());
-                if (file.exists()) {
-                    file.delete();
+                Path path = regionRoot.resolve(String.format("r.%s.%s.mca", loc.getX(), loc.getZ()));
+                LOGGER.info("- Deleting file: {} (max 1024 chunks)", path.getFileName());
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to delete region file", e);
                 }
             }
             TaskManager.runTask(whenDone);

--- a/Core/src/main/java/com/plotsquared/core/util/RegionManager.java
+++ b/Core/src/main/java/com/plotsquared/core/util/RegionManager.java
@@ -90,8 +90,9 @@ public abstract class RegionManager {
      */
     public abstract int[] countEntities(Plot plot);
 
-    public void deleteRegionFiles(final String world, final Collection<BlockVector2> chunks, final Runnable whenDone) {
-        Path regionRoot = PlotSquared.platform().getWorldPath(world).resolve("region");
+    public void deleteRegionFiles(final String worldName, final Collection<BlockVector2> chunks, final Runnable whenDone) {
+        com.plotsquared.core.location.World<?> world = PlotSquared.platform().getPlatformWorld(worldName);
+        Path regionRoot = world.getWorldFolder().resolve("region");
         TaskManager.runTaskAsync(() -> {
             for (BlockVector2 loc : chunks) {
                 Path path = regionRoot.resolve(String.format("r.%s.%s.mca", loc.getX(), loc.getZ()));

--- a/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
@@ -58,6 +58,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
@@ -370,7 +371,8 @@ public abstract class WorldUtil {
             throw new RuntimeException("Could not find regions folder: " + regionRoot + " ? (no read access?)");
         }
         try (Stream<Path> stream = Files.find(regionRoot, 1, WorldUtil::isMcaRegionFile)) {
-            return stream.map(Path::getFileName)
+            return stream.filter(Predicate.not(p -> p.equals(regionRoot))) // skip root
+                    .map(Path::getFileName)
                     .map(this::fromMcaFileName)
                     .filter(Objects::nonNull)
                     .collect(Collectors.toSet());
@@ -382,6 +384,7 @@ public abstract class WorldUtil {
 
     /**
      * checks if the given file, by its path and BasicFileAttributes, is a mca region file
+     *
      * @param path full path to file
      * @param bfa attributes of the given file
      * @return {@code true} if the given file is a seemingly valid mca region file. {@code false} otherwise
@@ -396,6 +399,7 @@ public abstract class WorldUtil {
 
     /**
      * Retrieves the coordinates from a region mca file
+     *
      * @param filename the filename part of the full path ({@link Path#getFileName()})
      * @return A BV2 containg the coordinates, or {@code null} if the filename does not match the expected format
      */

--- a/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
@@ -25,7 +25,7 @@ import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.util.task.RunnableVal;
 import com.sk89q.jnbt.CompoundTag;
-import com.sk89q.jnbt.IntTag;
+import com.sk89q.jnbt.CompoundTagBuilder;
 import com.sk89q.jnbt.NBTInputStream;
 import com.sk89q.jnbt.NBTOutputStream;
 import com.sk89q.jnbt.Tag;
@@ -37,30 +37,37 @@ import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.entity.EntityType;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 public abstract class WorldUtil {
+
+    private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + WorldUtil.class.getSimpleName());
 
     /**
      * {@return whether the given location is valid in the world}
@@ -257,40 +264,27 @@ public abstract class WorldUtil {
             final @Nullable String file,
             final @NonNull RunnableVal<URL> whenDone
     ) {
+        boolean modern = MinecraftVersion.current().isNewerOrEqualThan(MinecraftVersion.TINY_TAKEOVER);
+        String relativeMcaRoot = modern ? "dimensions/minecraft/overworld/region" : "region";
         plot.getHome(home -> SchematicHandler.upload(uuid, file, "zip", new RunnableVal<>() {
             @Override
             public void run(OutputStream output) {
                 try (final ZipOutputStream zos = new ZipOutputStream(output)) {
-                    File dat = getDat(plot.getWorldName());
+                    Path dat = getDat(plot.getWorldName());
                     Location spawn = getSpawn(plot.getWorldName());
                     if (dat != null) {
-                        ZipEntry ze = new ZipEntry("world" + File.separator + dat.getName());
+                        ZipEntry ze = new ZipEntry("level.dat");
                         zos.putNextEntry(ze);
-                        try (NBTInputStream nis = new NBTInputStream(new GZIPInputStream(new FileInputStream(dat)))) {
-                            Map<String, Tag> tag = ((CompoundTag) nis.readNamedTag().getTag()).getValue();
-                            Map<String, Tag> newMap = new HashMap<>();
-                            for (Map.Entry<String, Tag> entry : tag.entrySet()) {
-                                if (!entry.getKey().equals("Data")) {
-                                    newMap.put(entry.getKey(), entry.getValue());
-                                    continue;
-                                }
-                                Map<String, Tag> data = new HashMap<>(((CompoundTag) entry.getValue()).getValue());
-                                data.put("SpawnX", new IntTag(home.getX()));
-                                data.put("SpawnY", new IntTag(home.getY()));
-                                data.put("SpawnZ", new IntTag(home.getZ()));
-                                newMap.put("Data", new CompoundTag(data));
-                            }
-                            try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-                                try (NBTOutputStream out = new NBTOutputStream(new GZIPOutputStream(baos, true))) {
-                                    //TODO Find what this should be called
-                                    out.writeNamedTag("Schematic????", new CompoundTag(newMap));
-                                }
-                                zos.write(baos.toByteArray());
+                        try (NBTInputStream nis = new NBTInputStream(new GZIPInputStream(Files.newInputStream(dat)))) {
+                            CompoundTag levelData = modifyLevelData((CompoundTag) nis.readNamedTag().getTag(), home);
+                            try (NBTOutputStream out =
+                                         new NBTOutputStream(new GZIPOutputStream(new CloseShieldOutputStream(zos), true))) {
+                                out.writeNamedTag("", levelData);
                             }
                         }
+                        zos.closeEntry();
                     }
                     setSpawn(spawn);
-                    byte[] buffer = new byte[1024];
                     Set<BlockVector2> added = new HashSet<>();
                     for (Plot current : plot.getConnectedPlots()) {
                         Location bot = current.getBottomAbs();
@@ -303,18 +297,13 @@ public abstract class WorldUtil {
                         for (BlockVector2 mca : files) {
                             if (mca.getX() >= brx && mca.getX() <= trx && mca.getZ() >= brz && mca.getZ() <= trz && !added.contains(
                                     mca)) {
-                                final File file = getMcr(plot.getWorldName(), mca.getX(), mca.getZ());
-                                if (file != null) {
-                                    //final String name = "r." + (x - cx) + "." + (z - cz) + ".mca";
-                                    String name = file.getName();
-                                    final ZipEntry ze = new ZipEntry("world" + File.separator + "region" + File.separator + name);
+                                final Path path = getMca(plot.getWorldName(), mca.getX(), mca.getZ());
+                                if (path != null) {
+                                    final ZipEntry ze = new ZipEntry(relativeMcaRoot + "/" + path.getFileName().toString());
                                     zos.putNextEntry(ze);
                                     added.add(mca);
-                                    try (FileInputStream in = new FileInputStream(file)) {
-                                        int len;
-                                        while ((len = in.read(buffer)) > 0) {
-                                            zos.write(buffer, 0, len);
-                                        }
+                                    try (InputStream in = Files.newInputStream(path)) {
+                                        in.transferTo(zos);
                                     }
                                     zos.closeEntry();
                                 }
@@ -331,49 +320,95 @@ public abstract class WorldUtil {
         }, whenDone));
     }
 
-    final @Nullable File getDat(final @NonNull String world) {
-        File file = new File(PlotSquared.platform().worldContainer() + File.separator + world + File.separator + "level.dat");
-        if (file.exists()) {
-            return file;
+    private @Nullable Path getDat(final @NonNull String world) {
+        Path path;
+        if (MinecraftVersion.current().isOlderOrEqualThan(MinecraftVersion.TINY_TAKEOVER)) {
+            // 26.1+ only has a global level.dat
+            path = PlotSquared.platform().worldContainer().toPath().resolve("world").resolve("level.dat");
+        } else {
+            path = PlotSquared.platform().worldContainer().toPath().resolve(world).resolve("level.dat");
         }
-        return null;
+        return Files.exists(path) ? path : null;
     }
 
     @Nullable
-    private File getMcr(final @NonNull String world, final int x, final int z) {
-        final File file =
-                new File(
-                        PlotSquared.platform().worldContainer(),
-                        world + File.separator + "region" + File.separator + "r." + x + '.' + z + ".mca"
-                );
-        if (file.exists()) {
-            return file;
+    private Path getMca(final @NonNull String world, final int x, final int z) {
+        Path path = PlotSquared.platform().getWorldPath(world).resolve("region").
+                resolve(String.format("r.%s.%s.mca", x, z));
+        return Files.exists(path) ? path : null;
+    }
+
+    private CompoundTag modifyLevelData(CompoundTag input, Location home) {
+        Map<String, Tag> root = input.getValue();
+        if (!(root.get("Data") instanceof CompoundTag data)) {
+            return input;
         }
-        return null;
+        CompoundTagBuilder dataBuilder = data.createBuilder();
+        if (MinecraftVersion.current().isNewerOrEqualThan(MinecraftVersion.TINY_TAKEOVER)) {
+            if (data.getValue().get("spawn") instanceof CompoundTag spawn) {
+                dataBuilder.put(
+                        "spawn", spawn.createBuilder()
+                                .putString("dimension", "minecraft:overworld")
+                                .putIntArray("pos", new int[]{home.getX(), home.getY(), home.getZ()})
+                                .build()
+                );
+            }
+        } else {
+            // legacy
+            dataBuilder
+                    .putInt("SpawnX", home.getX())
+                    .putInt("SpawnY", home.getY())
+                    .putInt("SpawnZ", home.getZ());
+        }
+        return input.createBuilder().put("Data", dataBuilder.build()).build();
     }
 
 
     public Set<BlockVector2> getChunkChunks(String world) {
-        File folder = new File(PlotSquared.platform().worldContainer(), world + File.separator + "region");
-        File[] regionFiles = folder.listFiles();
-        if (regionFiles == null) {
-            throw new RuntimeException("Could not find worlds folder: " + folder + " ? (no read access?)");
+        Path regionRoot = PlotSquared.platform().getWorldPath(world).resolve("region");
+        if (!Files.exists(regionRoot)) {
+            throw new RuntimeException("Could not find regions folder: " + regionRoot + " ? (no read access?)");
         }
-        HashSet<BlockVector2> chunks = new HashSet<>();
-        for (File file : regionFiles) {
-            String name = file.getName();
-            if (name.endsWith("mca")) {
-                String[] split = name.split("\\.");
-                try {
-                    int x = Integer.parseInt(split[1]);
-                    int z = Integer.parseInt(split[2]);
-                    BlockVector2 loc = BlockVector2.at(x, z);
-                    chunks.add(loc);
-                } catch (NumberFormatException ignored) {
-                }
-            }
+        try (Stream<Path> stream = Files.find(regionRoot, 1, WorldUtil::isMcaRegionFile)) {
+            return stream.map(Path::getFileName)
+                    .map(this::fromMcaFileName)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet());
+        } catch (IOException e) {
+            LOGGER.error("Failed to traverse region directory", e);
+            return Set.of();
         }
-        return chunks;
+    }
+
+    /**
+     * checks if the given file, by its path and BasicFileAttributes, is a mca region file
+     * @param path full path to file
+     * @param bfa attributes of the given file
+     * @return {@code true} if the given file is a seemingly valid mca region file. {@code false} otherwise
+     */
+    private static boolean isMcaRegionFile(Path path, BasicFileAttributes bfa) {
+        if (bfa.isDirectory()) {
+            return false;
+        }
+        String name = path.getFileName().toString();
+        return name.startsWith("r.") && name.endsWith(".mca");
+    }
+
+    /**
+     * Retrieves the coordinates from a region mca file
+     * @param filename the filename part of the full path ({@link Path#getFileName()})
+     * @return A BV2 containg the coordinates, or {@code null} if the filename does not match the expected format
+     */
+    private BlockVector2 fromMcaFileName(Path filename) {
+        String[] parts = filename.toString().split("\\.");
+        if (parts.length < 3) {
+            return null;
+        }
+        try {
+            return BlockVector2.at(Integer.parseInt(parts[1]), Integer.parseInt(parts[2]));
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
@@ -21,6 +21,7 @@ package com.plotsquared.core.util;
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.caption.Caption;
 import com.plotsquared.core.location.Location;
+import com.plotsquared.core.location.World;
 import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.util.task.RunnableVal;
@@ -31,7 +32,6 @@ import com.sk89q.jnbt.NBTOutputStream;
 import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.regions.CuboidRegion;
-import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
@@ -69,6 +69,8 @@ import java.util.zip.ZipOutputStream;
 public abstract class WorldUtil {
 
     private static final Logger LOGGER = LogManager.getLogger("PlotSquared/" + WorldUtil.class.getSimpleName());
+    private static final boolean MODERN_LEVEL_FORMAT =
+            MinecraftVersion.current().isNewerOrEqualThan(MinecraftVersion.TINY_TAKEOVER);
 
     /**
      * {@return whether the given location is valid in the world}
@@ -89,6 +91,16 @@ public abstract class WorldUtil {
      */
     public static void setBiome(String world, final CuboidRegion region, BiomeType biome) {
         PlotSquared.platform().worldUtil().setBiomes(world, region, biome);
+    }
+
+    /**
+     * Check if the server is using the modern world storage format introduced in 26.1.
+     *
+     * @return if the server is using the modern server level structure
+     * @since TODO
+     */
+    public static boolean isModernServerLevelStructure() {
+        return MODERN_LEVEL_FORMAT;
     }
 
     /**
@@ -234,7 +246,7 @@ public abstract class WorldUtil {
      * @param biome     New biome
      */
     public void setBiomes(@NonNull String worldName, @NonNull CuboidRegion region, @NonNull BiomeType biome) {
-        final World world = getWeWorld(worldName);
+        final com.sk89q.worldedit.world.World world = getWeWorld(worldName);
         region.forEach(bv -> world.setBiome(bv, biome));
     }
 
@@ -265,13 +277,13 @@ public abstract class WorldUtil {
             final @Nullable String file,
             final @NonNull RunnableVal<URL> whenDone
     ) {
-        boolean modern = MinecraftVersion.current().isNewerOrEqualThan(MinecraftVersion.TINY_TAKEOVER);
-        String relativeMcaRoot = modern ? "dimensions/minecraft/overworld/region" : "region";
+        World<?> world = PlotSquared.platform().getPlatformWorld(plot.getWorldName());
+        String relativeMcaRoot = MODERN_LEVEL_FORMAT ? "dimensions/minecraft/overworld/region" : "region";
         plot.getHome(home -> SchematicHandler.upload(uuid, file, "zip", new RunnableVal<>() {
             @Override
             public void run(OutputStream output) {
                 try (final ZipOutputStream zos = new ZipOutputStream(output)) {
-                    Path dat = getDat(plot.getWorldName());
+                    Path dat = getLevelData(world);
                     Location spawn = getSpawn(plot.getWorldName());
                     if (dat != null) {
                         ZipEntry ze = new ZipEntry("level.dat");
@@ -294,11 +306,11 @@ public abstract class WorldUtil {
                         int brz = bot.getZ() >> 9;
                         int trx = top.getX() >> 9;
                         int trz = top.getZ() >> 9;
-                        Set<BlockVector2> files = getChunkChunks(bot.getWorldName());
+                        Set<BlockVector2> files = getChunkChunks(world);
                         for (BlockVector2 mca : files) {
                             if (mca.getX() >= brx && mca.getX() <= trx && mca.getZ() >= brz && mca.getZ() <= trz && !added.contains(
                                     mca)) {
-                                final Path path = getMca(plot.getWorldName(), mca.getX(), mca.getZ());
+                                final Path path = getMca(world, mca.getX(), mca.getZ());
                                 if (path != null) {
                                     final ZipEntry ze = new ZipEntry(relativeMcaRoot + "/" + path.getFileName().toString());
                                     zos.putNextEntry(ze);
@@ -321,21 +333,14 @@ public abstract class WorldUtil {
         }, whenDone));
     }
 
-    private @Nullable Path getDat(final @NonNull String world) {
-        Path path;
-        if (MinecraftVersion.current().isOlderOrEqualThan(MinecraftVersion.TINY_TAKEOVER)) {
-            // 26.1+ only has a global level.dat
-            path = PlotSquared.platform().worldContainer().toPath().resolve("world").resolve("level.dat");
-        } else {
-            path = PlotSquared.platform().worldContainer().toPath().resolve(world).resolve("level.dat");
-        }
+    private @Nullable Path getLevelData(final @NonNull World<?> world) {
+        Path path = world.getWorldFolder().resolve("level.dat");
         return Files.exists(path) ? path : null;
     }
 
     @Nullable
-    private Path getMca(final @NonNull String world, final int x, final int z) {
-        Path path = PlotSquared.platform().getWorldPath(world).resolve("region").
-                resolve(String.format("r.%s.%s.mca", x, z));
+    private Path getMca(final @NonNull World<?> world, final int x, final int z) {
+        Path path = getRegionFolder(world).resolve("region").resolve(String.format("r.%s.%s.mca", x, z));
         return Files.exists(path) ? path : null;
     }
 
@@ -345,7 +350,7 @@ public abstract class WorldUtil {
             return input;
         }
         CompoundTagBuilder dataBuilder = data.createBuilder();
-        if (MinecraftVersion.current().isNewerOrEqualThan(MinecraftVersion.TINY_TAKEOVER)) {
+        if (MODERN_LEVEL_FORMAT) {
             if (data.getValue().get("spawn") instanceof CompoundTag spawn) {
                 dataBuilder.put(
                         "spawn", spawn.createBuilder()
@@ -365,8 +370,8 @@ public abstract class WorldUtil {
     }
 
 
-    public Set<BlockVector2> getChunkChunks(String world) {
-        Path regionRoot = PlotSquared.platform().getWorldPath(world).resolve("region");
+    public Set<BlockVector2> getChunkChunks(World<?> world) {
+        Path regionRoot = getRegionFolder(world);
         if (!Files.exists(regionRoot)) {
             throw new RuntimeException("Could not find regions folder: " + regionRoot + " ? (no read access?)");
         }
@@ -380,6 +385,14 @@ public abstract class WorldUtil {
             LOGGER.error("Failed to traverse region directory", e);
             return Set.of();
         }
+    }
+
+    private static Path getRegionFolder(World<?> world) {
+        Path root = world.getWorldFolder();
+        if (MODERN_LEVEL_FORMAT) {
+            root = root.resolve("dimensions").resolve(world.key().namespace()).resolve(world.key().value());
+        }
+        return root.resolve("region");
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
@@ -388,11 +388,7 @@ public abstract class WorldUtil {
     }
 
     private static Path getRegionFolder(World<?> world) {
-        Path root = world.getWorldFolder();
-        if (MODERN_LEVEL_FORMAT) {
-            root = root.resolve("dimensions").resolve(world.key().namespace()).resolve(world.key().value());
-        }
-        return root.resolve("region");
+        return world.getWorldFolder().resolve("region");
     }
 
     /**

--- a/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
@@ -392,7 +392,7 @@ public abstract class WorldUtil {
     }
 
     /**
-     * checks if the given file, by its path and BasicFileAttributes, is a mca region file
+     * Checks if the given file, by its path and BasicFileAttributes, is a mca region file.
      *
      * @param path full path to file
      * @param bfa attributes of the given file

--- a/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
@@ -407,7 +407,7 @@ public abstract class WorldUtil {
     }
 
     /**
-     * Retrieves the coordinates from a region mca file
+     * Retrieves the coordinates from a region mca file.
      *
      * @param filename the filename part of the full path ({@link Path#getFileName()})
      * @return A BV2 containg the coordinates, or {@code null} if the filename does not match the expected format

--- a/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
+++ b/Core/src/main/java/com/plotsquared/core/util/WorldUtil.java
@@ -340,7 +340,7 @@ public abstract class WorldUtil {
 
     @Nullable
     private Path getMca(final @NonNull World<?> world, final int x, final int z) {
-        Path path = getRegionFolder(world).resolve("region").resolve(String.format("r.%s.%s.mca", x, z));
+        Path path = getRegionFolder(world).resolve(String.format("r.%s.%s.mca", x, z));
         return Files.exists(path) ? path : null;
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,9 +114,10 @@ subprojects {
 
     signing {
         if (!project.hasProperty("skip.signing") && !version.toString().endsWith("-SNAPSHOT")) {
-            val signingKey: String? by project
-            val signingPassword: String? by project
-            useInMemoryPgpKeys(signingKey, signingPassword)
+            useInMemoryPgpKeys(
+                    project.findProperty("signingKey") as? String,
+                    project.findProperty("signingPassword") as? String
+            )
             signing.isRequired
             sign(publishing.publications)
         }
@@ -216,9 +217,11 @@ tasks.getByName<Jar>("jar") {
     enabled = false
 }
 
-val supportedVersions = listOf("1.19.4", "1.20.6", "1.21.11", "26.1.2")
+val supportedVersions = listOf("1.19.4", "1.20.6", "1.21.11", "26.1.2", "26.2")
 tasks {
-    register("cacheLatestFaweArtifact") {
+    val cacheLatestFaweArtifact = register("cacheLatestFaweArtifact") {
+        group = null
+        description = "retrieves the latest FAWE build and caches it for the runServer tasks"
         val lastSuccessfulBuildUrl = uri("https://ci.athion.net/job/FastAsyncWorldEdit/lastSuccessfulBuild/api/json").toURL()
         val artifact = ((JsonSlurper().parse(lastSuccessfulBuildUrl) as Map<*, *>)["artifacts"] as List<*>)
                 .map { it as Map<*, *> }
@@ -227,10 +230,11 @@ tasks {
         project.ext["faweArtifact"] = artifact
     }
 
-    supportedVersions.forEach {
-        register<RunServer>("runServer-$it") {
-            dependsOn(getByName("cacheLatestFaweArtifact"))
-            minecraftVersion(it)
+    supportedVersions.forEach { version ->
+        register<RunServer>("runServer-$version") {
+            description = "Run a Paper server version $version."
+            dependsOn(cacheLatestFaweArtifact)
+            minecraftVersion(version)
             pluginJars(project.files(
                 project(":plotsquared-bukkit").tasks.named<Jar>("shadowJar")
                 .map { it.archiveFile }
@@ -240,7 +244,12 @@ tasks {
                 url("https://ci.athion.net/job/FastAsyncWorldEdit/lastSuccessfulBuild/artifact/artifacts/${project.ext["faweArtifact"]}")
             }
             group = "run paper"
-            runDirectory.set(file("run-$it"))
+            javaToolchains {
+                launcherFor {
+                    languageVersion.set(JavaLanguageVersion.of(25))
+                }
+            }
+            runDirectory.set(file("run-$version"))
         }
     }
 }


### PR DESCRIPTION
## Overview

Fixes #4872

## Description
MC 26 changed the world /dimension / level folder structure quite drastically, which this PR attempts to implement. Trim works in the latest version. I also updated all other usages of I/O world access. download of world files should also work now (even though it's been deprecated for quite a while).

I've not tested the changes on older versions yet. Feel free to. 

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
