### PR TITLE
chore/fix: compare patch version in MinecraftVersion

### DIFF
--- a/Core/src/main/java/com/plotsquared/core/util/MinecraftVersion.java
+++ b/Core/src/main/java/com/plotsquared/core/util/MinecraftVersion.java
@@ -18,6 +18,7 @@
  */
 package com.plotsquared.core.util;
 
+import com.google.common.base.Preconditions;
 import com.plotsquared.core.PlotSquared;
 import org.jetbrains.annotations.NotNull;
 
@@ -25,16 +26,18 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 /**
- * Represents a minecraft version. For simplicity, and compatibility with modern versions, the `1.` prefix of older versions is
+ * Represents a Minecraft version. For simplicity, and compatibility with modern versions, the `1.` prefix of older versions is
  * ignored and the minor version part becomes the major version part.
  * <p>
  * <ul>
- *     <li>`1.17.0` -> `(17, 0)`</li>
- *     <li>`26.2` -> `(26, 2)`</li>
+ *     <li>`1.17.0` -> `(17, 0, 0)`</li>
+ *     <li>`26.2` -> `(26, 2, 0)`</li>
+ *     <li>`26.1.2` -> `(26, 1, 2)`</li>
  * </ul>
  *
- * @param major the major part of the version string. For versions pre 26.1 this is the minor version part
- * @param minor the minor part of the version string. For versions pre 26.1 this is the patch version part
+ * @param major the major part of the version string. For versions pre 26 this is the minor version part
+ * @param minor the minor part of the version string. For versions pre 26 this is the patch version part
+ * @param patch the patch part of the version string. For versions pre 26 this is always {@code 0}
  */
 public record MinecraftVersion(int major, int minor, int patch) implements Comparable<MinecraftVersion> {
 
@@ -65,7 +68,9 @@ public record MinecraftVersion(int major, int minor, int patch) implements Compa
 
     private static final Comparator<MinecraftVersion> COMPARATOR = Comparator
             .comparingInt(MinecraftVersion::major)
-            .thenComparingInt(MinecraftVersion::minor);
+            .thenComparingInt(MinecraftVersion::minor)
+            .thenComparingInt(MinecraftVersion::patch);
+
     private static MinecraftVersion current;
 
     public static MinecraftVersion current() {
@@ -87,30 +92,27 @@ public record MinecraftVersion(int major, int minor, int patch) implements Compa
         return current;
     }
 
+    public MinecraftVersion {
+        Preconditions.checkArgument(this.major() > -1, "major version part must be positive or 0");
+        Preconditions.checkArgument(this.minor() > -1, "major version part must be positive or 0");
+        Preconditions.checkArgument(this.patch() > -1, "major version part must be positive or 0");
+    }
+
     @Override
     public int compareTo(@NotNull final MinecraftVersion o) {
         return COMPARATOR.compare(this, o);
     }
 
     public boolean isNewerOrEqualThan(MinecraftVersion other) {
-        if (this.major() > other.major()) {
-            return true;
-        }
-        return this.major() == other.major() && this.minor() >= other.minor();
+        return this.compareTo(other) >= 0;
     }
 
     public boolean isOlderOrEqualThan(MinecraftVersion other) {
-        if (this.major() < other.major()) {
-            return true;
-        }
-        return this.major() == other.major() && this.minor() <= other.minor();
+        return this.compareTo(other) <= 0;
     }
 
     public boolean isOlderThan(MinecraftVersion other) {
-        if (this.major() < other.major()) {
-            return true;
-        }
-        return this.major() == other.major() && this.minor() < other.minor();
+        return this.compareTo(other) < 0;
     }
 
     public boolean isNewerOrEqualThan(int otherMajor) {

--- a/Core/src/test/java/com/plotsquared/core/util/MinecraftVersionTest.java
+++ b/Core/src/test/java/com/plotsquared/core/util/MinecraftVersionTest.java
@@ -1,0 +1,88 @@
+/*
+ * PlotSquared, a land and world management plugin for Minecraft.
+ * Copyright (C) IntellectualSites <https://intellectualsites.com>
+ * Copyright (C) IntellectualSites team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.core.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MinecraftVersionTest {
+
+    @Test
+    @DisplayName("isNewerOrEqualThan(MinecraftVersion)")
+    void isNewerOrEqualThan() {
+        assertTrue(MinecraftVersion.TINY_TAKEOVER.isNewerOrEqualThan(MinecraftVersion.TRICKY_TRIALS));
+        assertTrue(MinecraftVersion.TINY_TAKEOVER.isNewerOrEqualThan(MinecraftVersion.TINY_TAKEOVER));
+        assertTrue(new MinecraftVersion(1, 2, 3).isNewerOrEqualThan(new MinecraftVersion(1, 2, 2)));
+        assertFalse(MinecraftVersion.CAVES_AND_CLIFFS.isNewerOrEqualThan(MinecraftVersion.CAVES_AND_CLIFFS_2));
+    }
+
+    @Test
+    @DisplayName("isOlderOrEqualThan(MinecraftVersion)")
+    void isOlderOrEqualThan() {
+        assertTrue(MinecraftVersion.TRICKY_TRIALS.isOlderOrEqualThan(MinecraftVersion.TINY_TAKEOVER));
+        assertTrue(MinecraftVersion.TRICKY_TRIALS.isOlderOrEqualThan(MinecraftVersion.TRICKY_TRIALS));
+        assertTrue(new MinecraftVersion(1, 2, 2).isOlderOrEqualThan(new MinecraftVersion(1, 2, 3)));
+        assertFalse(MinecraftVersion.CAVES_AND_CLIFFS_2.isOlderOrEqualThan(MinecraftVersion.CAVES_AND_CLIFFS));
+    }
+
+    @Test
+    @DisplayName("isOlderThan(MinecraftVersion)")
+    void isOlderThan() {
+        assertTrue(MinecraftVersion.TRICKY_TRIALS.isOlderThan(MinecraftVersion.TINY_TAKEOVER));
+        assertTrue(new MinecraftVersion(1, 2, 2).isOlderThan(new MinecraftVersion(1, 2, 3)));
+        assertFalse(MinecraftVersion.TINY_TAKEOVER.isOlderThan(MinecraftVersion.TRICKY_TRIALS));
+    }
+
+    @Test
+    @DisplayName("isNewerOrEqualThan(int)")
+    void isNewerOrEqualThanPrimitiveMajor() {
+        assertTrue(MinecraftVersion.TINY_TAKEOVER.isNewerOrEqualThan(25));
+        assertTrue(new MinecraftVersion(4, 5, 6).isNewerOrEqualThan(3));
+        assertFalse(MinecraftVersion.TINY_TAKEOVER.isNewerOrEqualThan(27));
+    }
+
+    @Test
+    @DisplayName("isNewerOrEqualThan(int, int)")
+    void isNewerOrEqualThanPrimitiveMajorMinor() {
+        assertTrue(MinecraftVersion.TINY_TAKEOVER.isNewerOrEqualThan(25, 69));
+        assertTrue(MinecraftVersion.TINY_TAKEOVER.isNewerOrEqualThan(26, 1));
+        assertTrue(new MinecraftVersion(4, 5, 6).isNewerOrEqualThan(4, 5));
+        assertFalse(MinecraftVersion.TINY_TAKEOVER.isNewerOrEqualThan(26, 2));
+    }
+
+    @Test
+    @DisplayName("isOlderOrEqualThan(int)")
+    void isOlderOrEqualThanPrimitiveMajor() {
+        assertTrue(MinecraftVersion.TINY_TAKEOVER.isOlderOrEqualThan(27));
+        assertTrue(new MinecraftVersion(4, 5, 6).isOlderOrEqualThan(5));
+        assertFalse(MinecraftVersion.TINY_TAKEOVER.isOlderOrEqualThan(20));
+    }
+
+    @Test
+    @DisplayName("isOlderOrEqualThan(int, int)")
+    void isOlderOrEqualThanPrimitiveMajorMinor() {
+        assertTrue(MinecraftVersion.TINY_TAKEOVER.isOlderOrEqualThan(27, 69));
+        assertTrue(MinecraftVersion.TINY_TAKEOVER.isOlderOrEqualThan(26, 2));
+        assertTrue(new MinecraftVersion(4, 5, 6).isOlderOrEqualThan(4, 5));
+        assertFalse(MinecraftVersion.TINY_TAKEOVER.isOlderOrEqualThan(26, 0));
+    }
+
+}


### PR DESCRIPTION
## Overview

Follow-up to https://github.com/IntellectualSites/PlotSquared/pull/4871

## Description
I've added a field for the patch version, but did not compare it yet (added afterwards, as I did not know that the newer versions actually have patch versions). Given patch versions are not relevant (yet), the current code is not inherently broken - just not fully correct.
- Added documentation on how (and if) patch version parts are provided.
- Use compareTo for object comparisions.
- Validate version parts (non-negative).
- Added basic tests for comparison methods (compareTo is implicitly tested).

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
