### PR TITLE
fix: include lightning rod in copper oxide flag

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener117.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/BlockEventListener117.java
@@ -163,7 +163,8 @@ public class BlockEventListener117 implements Listener {
         if (plot == null) {
             return;
         }
-        if (event.getNewState().getType().name().contains("COPPER")) {
+        String newTypeName = event.getNewState().getType().name();
+        if (newTypeName.contains("COPPER") || newTypeName.contains("LIGHTNING_ROD")) {
             if (!plot.getFlag(CopperOxideFlag.class)) {
                 plot.debug("Copper could not oxide because copper-oxide = false");
                 event.setCancelled(true);


### PR DESCRIPTION
## Overview
Since Minecraft 1.21.11, they can oxide as well.

## Description
Adds another check for lightning rods to the block form event for 1.17+ servers.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
