### PR TITLE
Improving protection check for bucket usage

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -1426,8 +1426,7 @@ public class PlayerEventListener implements Listener {
             if (blockTypeWrapper.accepts(BlockTypes.AIR) || blockTypeWrapper.accepts(type)) {
                 // Allows this event for blocks that can be interacted with using a bucket without it being considered
                 // as "building" (= make it waterlogged or drop the block by flooding it)
-                if (type == BlockTypes.CAULDRON || type == BlockTypes.WATER_CAULDRON || type == BlockTypes.LAVA_CAULDRON
-                        || type == BlockTypes.SPONGE || type == BlockTypes.WET_SPONGE) {
+                if (type == BlockTypes.CAULDRON || type == BlockTypes.WATER_CAULDRON || type == BlockTypes.LAVA_CAULDRON) {
                     return;
                 }
             }
@@ -1511,8 +1510,7 @@ public class PlayerEventListener implements Listener {
             if (blockTypeWrapper.accepts(BlockTypes.AIR) || blockTypeWrapper.accepts(type)) {
                 // Allows this event for blocks that can be interacted with using a bucket without it being considered
                 // as "building" (= make it waterlogged or drop the block by flooding it)
-                if (type == BlockTypes.CAULDRON || type == BlockTypes.WATER_CAULDRON || type == BlockTypes.LAVA_CAULDRON
-                        || type == BlockTypes.SPONGE || type == BlockTypes.WET_SPONGE) {
+                if (type == BlockTypes.CAULDRON || type == BlockTypes.WATER_CAULDRON || type == BlockTypes.LAVA_CAULDRON) {
                     return;
                 }
             }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -1423,9 +1423,13 @@ public class PlayerEventListener implements Listener {
                         area.getFlag(UseFlag.class) : Collections.emptyList());
         BlockType type = BukkitAdapter.asBlockType(block.getType());
         for (final BlockTypeWrapper blockTypeWrapper : use) {
-            if (blockTypeWrapper.accepts(BlockTypes.AIR) || blockTypeWrapper
-                    .accepts(type)) {
-                return;
+            if (blockTypeWrapper.accepts(BlockTypes.AIR) || blockTypeWrapper.accepts(type)) {
+                // Allows this event for blocks that can be interacted with using a bucket without it being considered
+                // as "building" (= make it waterlogged or drop the block by flooding it)
+                if (type == BlockTypes.CAULDRON || type == BlockTypes.WATER_CAULDRON || type == BlockTypes.LAVA_CAULDRON
+                        || type == BlockTypes.SPONGE || type == BlockTypes.WET_SPONGE) {
+                    return;
+                }
             }
         }
         if (plot == null) {
@@ -1490,8 +1494,8 @@ public class PlayerEventListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBucketFill(PlayerBucketFillEvent event) {
-        Block blockClicked = event.getBlockClicked();
-        Location location = BukkitUtil.adapt(blockClicked.getLocation());
+        Block block = event.getBlock();
+        Location location = BukkitUtil.adapt(block.getLocation());
         PlotArea area = location.getPlotArea();
         if (area == null) {
             return;
@@ -1502,11 +1506,15 @@ public class PlayerEventListener implements Listener {
         final List<BlockTypeWrapper> use =
                 Optional.ofNullable(plot).map(p -> p.getFlag(UseFlag.class)).orElse(area.isRoadFlags() ?
                         area.getFlag(UseFlag.class) : Collections.emptyList());
-        BlockType type = BukkitAdapter.asBlockType(blockClicked.getType());
+        BlockType type = BukkitAdapter.asBlockType(block.getType());
         for (final BlockTypeWrapper blockTypeWrapper : use) {
-            if (blockTypeWrapper.accepts(BlockTypes.AIR) || blockTypeWrapper
-                    .accepts(type)) {
-                return;
+            if (blockTypeWrapper.accepts(BlockTypes.AIR) || blockTypeWrapper.accepts(type)) {
+                // Allows this event for blocks that can be interacted with using a bucket without it being considered
+                // as "building" (= make it waterlogged or drop the block by flooding it)
+                if (type == BlockTypes.CAULDRON || type == BlockTypes.WATER_CAULDRON || type == BlockTypes.LAVA_CAULDRON
+                        || type == BlockTypes.SPONGE || type == BlockTypes.WET_SPONGE) {
+                    return;
+                }
             }
         }
         if (plot == null) {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -1426,7 +1426,7 @@ public class PlayerEventListener implements Listener {
             if (blockTypeWrapper.accepts(BlockTypes.AIR) || blockTypeWrapper.accepts(type)) {
                 // Allows this event for blocks that can be interacted with using a bucket without it being considered
                 // as "building" (= make it waterlogged or drop the block by flooding it)
-                if (type == BlockTypes.CAULDRON || type == BlockTypes.WATER_CAULDRON || type == BlockTypes.LAVA_CAULDRON) {
+                if (type.getId().equals("minecraft:cauldron") || type.getId().endsWith("_cauldron")) {
                     return;
                 }
             }
@@ -1510,7 +1510,7 @@ public class PlayerEventListener implements Listener {
             if (blockTypeWrapper.accepts(BlockTypes.AIR) || blockTypeWrapper.accepts(type)) {
                 // Allows this event for blocks that can be interacted with using a bucket without it being considered
                 // as "building" (= make it waterlogged or drop the block by flooding it)
-                if (type == BlockTypes.CAULDRON || type == BlockTypes.WATER_CAULDRON || type == BlockTypes.LAVA_CAULDRON) {
+                if (type.getId().equals("minecraft:cauldron") || type.getId().endsWith("_cauldron")) {
                     return;
                 }
             }


### PR DESCRIPTION
## Overview
Fixes #4851

The code change adds a specific block-filter to include only blocks that contain the "use" flag result in combination with "normal" bucket interactions. **No waterlogging, no flooding allowed here**, if it's not a plot-owner / member.

> The new restriction was tested in-game.

## Description

### Improving protection check

We've had a [bug](https://github.com/IntellectualSites/PlotSquared/issues/3069) with bucket handling in the past. This was [fixed](https://github.com/IntellectualSites/PlotSquared/pull/3375/changes) by removing the "use" flag request. Then we get a [bug report](https://github.com/IntellectualSites/PlotSquared/issues/4677) for the "use" flag and _dordsor_ re-added a similar "use" flag check in [PR 4673](https://github.com/IntellectualSites/PlotSquared/pull/4673/changes).

Checking the "use" flag makes sense. However, there are blocks that are interactive(!), and waterloggable, or that drop when water is placed into the hitbox(!). We need to prevent that from happening.

**Example:** `lever`
- right click: interact, if the USE flag is set or you have build permissions
- shift + right click: place `water` (lever drops), only if you have build permissions

Since this interaction only involves _CAULDRON_ types, I don't currently see a need for a separate flag to define the blocks.

### Change of requested block

```java
    public void onBucketFill(PlayerBucketFillEvent event) {
        Block block = event.getBlock();
````

In addition, I've adjusted the query here to target the block that was modified, which in this event is usually the same as the block being interacted with (the clicked block). It seems more logical to me to check here which block contains the final change.

- `getClicketBLock` = the interaction
- `getBlock` = the block for the final block change by bucket interaction (may be different for the `PlayerBucketEmptyEvent` and mostly the same for the `PlayerBucketFillEvent`)

<!-- Please describe what this pull request does. -->

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
