### PR TITLE
fix: prevent NullPointerException in world setup when getWorld returns null

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
@@ -315,7 +315,11 @@ public class BukkitUtil extends WorldUtil {
 
     @Override
     public @NonNull Location getSpawn(final @NonNull String world) {
-        final org.bukkit.Location temp = getWorld(world).getSpawnLocation();
+        final World bukkitWorld = getWorld(world);
+        if (bukkitWorld == null) {
+            return Location.at(world, 0, 64, 0);
+        }
+        final org.bukkit.Location temp = bukkitWorld.getSpawnLocation();
         return Location.at(world, temp.getBlockX(), temp.getBlockY(), temp.getBlockZ(), temp.getYaw(), temp.getPitch());
     }
 


### PR DESCRIPTION
### Description

Fixes a `NullPointerException` that occurs during `/plot setup` when `BukkitUtil.getSpawn()` is called for a world that has not yet been registered with Bukkit.

### Root Cause

`BukkitUtil.getSpawn()` called `getWorld(world).getSpawnLocation()` without a null check. During the plot setup process, the world may not yet be available via `Bukkit.getWorld()`, causing:

```
java.lang.NullPointerException: Cannot invoke "org.bukkit.World.getSpawnLocation()"
because the return value of "com.plotsquared.bukkit.util.BukkitUtil.getWorld(String)" is null
  at BukkitUtil.getSpawn(BukkitUtil.java:318)
  at CommonSetupSteps.java:231
```

### Fix

Added a null check in `BukkitUtil.getSpawn()`, returning a safe fallback spawn location at `(0, 64, 0)` when the world is not yet available. This is consistent with the existing null-safe pattern already used in `setSpawn()`.

### Related

- Reported in https://gist.github.com/byJoonas/98c4d355da6ee885bbd65d3a25e42ae0