### PR TITLE
fix: replace broken PaperLib

### DIFF
--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -38,7 +38,6 @@ dependencies {
 
     // Paper
     compileOnly(libs.paper)
-    implementation(libs.paperlib)
 
     // Plugins
     compileOnly(libs.worldeditBukkit)
@@ -78,7 +77,6 @@ tasks.named<ShadowJar>("shadowJar") {
     relocate("net.kyori.option", "com.plotsquared.core.configuration.option")
     relocate("net.kyori.adventure", "com.plotsquared.core.configuration.adventure")
     relocate("net.kyori.examination", "com.plotsquared.core.configuration.examination")
-    relocate("io.papermc.lib", "com.plotsquared.bukkit.paperlib")
     relocate("org.bstats", "com.plotsquared.metrics")
     relocate("org.enginehub", "com.plotsquared.squirrelid")
     relocate("org.khelekore.prtree", "com.plotsquared.prtree")

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/BukkitPlatform.java
@@ -48,6 +48,7 @@ import com.plotsquared.bukkit.placeholder.PlaceholderFormatter;
 import com.plotsquared.bukkit.player.BukkitPlayerManager;
 import com.plotsquared.bukkit.util.BukkitUtil;
 import com.plotsquared.bukkit.util.BukkitWorld;
+import com.plotsquared.bukkit.util.PaperSupport;
 import com.plotsquared.bukkit.util.SetGenCB;
 import com.plotsquared.bukkit.util.TranslationUpdateManager;
 import com.plotsquared.bukkit.util.UpdateUtility;
@@ -114,7 +115,6 @@ import com.plotsquared.core.uuid.UUIDPipeline;
 import com.plotsquared.core.uuid.offline.OfflineModeUUIDService;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import io.papermc.lib.PaperLib;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
@@ -269,7 +269,7 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
         this.pluginName = getDescription().getName();
 
         final TaskTime.TimeConverter timeConverter;
-        if (PaperLib.isPaper()) {
+        if (PaperSupport.isPaper()) {
             timeConverter = new PaperTimeConverter();
         } else {
             timeConverter = new SpigotTimeConverter();
@@ -384,7 +384,7 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
             getServer().getPluginManager().registerEvents(injector().getInstance(ProjectileEventListener.class), this);
             getServer().getPluginManager().registerEvents(injector().getInstance(ServerListener.class), this);
             getServer().getPluginManager().registerEvents(injector().getInstance(EntitySpawnListener.class), this);
-            if (PaperLib.isPaper() && Settings.Paper_Components.PAPER_LISTENERS) {
+            if (PaperSupport.isPaper() && Settings.Paper_Components.PAPER_LISTENERS) {
                 getServer().getPluginManager().registerEvents(injector().getInstance(PaperListener.class), this);
             } else {
                 getServer().getPluginManager().registerEvents(injector().getInstance(SpigotListener.class), this);
@@ -507,7 +507,7 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
 
         if (!Settings.UUID.OFFLINE) {
             // If running Paper we'll also try to use their profiles
-            if (Bukkit.getOnlineMode() && PaperLib.isPaper() && Settings.UUID.SERVICE_PAPER) {
+            if (Bukkit.getOnlineMode() && PaperSupport.isPaper() && Settings.UUID.SERVICE_PAPER) {
                 final PaperUUIDService paperUUIDService = new PaperUUIDService();
                 this.impromptuPipeline.registerService(paperUUIDService);
                 this.backgroundPipeline.registerService(paperUUIDService);
@@ -793,7 +793,7 @@ public final class BukkitPlatform extends JavaPlugin implements Listener, PlotPl
                 while (iterator.hasNext()) {
                     Entity entity = iterator.next();
                     //noinspection ConstantValue - getEntitySpawnReason annotated as NotNull, but is not NotNull. lol.
-                    if (PaperLib.isPaper() && entity.getEntitySpawnReason() != null && "CUSTOM".equals(entity.getEntitySpawnReason().name())) {
+                    if (PaperSupport.isPaper() && entity.getEntitySpawnReason() != null && "CUSTOM".equals(entity.getEntitySpawnReason().name())) {
                         continue;
                     }
                     // Fallback for Spigot not having Entity#getEntitySpawnReason

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/generator/BukkitAugmentedGenerator.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/generator/BukkitAugmentedGenerator.java
@@ -50,7 +50,7 @@ public class BukkitAugmentedGenerator extends BlockPopulator {
     @Override
     public void populate(@NonNull World world, @NonNull Random random, @NonNull Chunk source) {
         QueueCoordinator queue = PlotSquared.platform().globalBlockQueue().getNewQueue(BukkitAdapter.adapt(world));
-        // The chunk is already loaded and we do not want to load the chunk in "fully" by using any PaperLib methods.
+        // The chunk is already loaded and we do not want to load the chunk in "fully" by using any Paper methods.
         queue.setForceSync(true);
         queue.setSideEffectSet(SideEffectSet.none());
         queue.setBiomesEnabled(false);

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/ChunkListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/ChunkListener.java
@@ -19,6 +19,7 @@
 package com.plotsquared.bukkit.listener;
 
 import com.google.inject.Inject;
+import com.plotsquared.bukkit.util.PaperSupport;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.location.Location;
 import com.plotsquared.core.plot.Plot;
@@ -33,7 +34,6 @@ import com.plotsquared.core.util.ReflectionUtils.RefMethod;
 import com.plotsquared.core.util.task.PlotSquaredTask;
 import com.plotsquared.core.util.task.TaskManager;
 import com.plotsquared.core.util.task.TaskTime;
-import io.papermc.lib.PaperLib;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
@@ -216,7 +216,7 @@ public class ChunkListener implements Listener {
     }
 
     private void onInternalEntitySpawn(EntitySpawnEvent event) {
-        PaperLib.getChunkAtAsync(event.getLocation()).thenAccept(chunk -> {
+        PaperSupport.getChunkAtAsync(event.getLocation()).thenAccept(chunk -> {
             if (chunk == this.lastChunk) {
                 event.getEntity().remove();
                 event.setCancelled(true);

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntityEventListener.java
@@ -23,6 +23,7 @@ import com.plotsquared.bukkit.BukkitPlatform;
 import com.plotsquared.bukkit.player.BukkitPlayer;
 import com.plotsquared.bukkit.util.BukkitEntityUtil;
 import com.plotsquared.bukkit.util.BukkitUtil;
+import com.plotsquared.bukkit.util.PaperSupport;
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.listener.PlayerBlockEventType;
@@ -44,7 +45,6 @@ import com.plotsquared.core.util.PlotFlagUtil;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.util.Enums;
 import com.sk89q.worldedit.world.block.BlockType;
-import io.papermc.lib.PaperLib;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.World;
@@ -180,7 +180,7 @@ public class EntityEventListener implements Listener {
                     return;
                 }
                 // No need to clutter metadata if running paper
-                if (!PaperLib.isPaper()) {
+                if (!PaperSupport.isPaper()) {
                     entity.setMetadata("ps_custom_spawned", new FixedMetadataValue(this.platform, true));
                 }
                 return; // Don't cancel if mob spawning is disabled

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/EntitySpawnListener.java
@@ -20,13 +20,13 @@ package com.plotsquared.bukkit.listener;
 
 import com.plotsquared.bukkit.util.BukkitEntityUtil;
 import com.plotsquared.bukkit.util.BukkitUtil;
+import com.plotsquared.bukkit.util.PaperSupport;
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.location.Location;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
 import com.plotsquared.core.plot.flag.implementations.DoneFlag;
-import io.papermc.lib.PaperLib;
 import org.bukkit.Chunk;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -99,7 +99,7 @@ public class EntitySpawnListener implements Listener {
                         }
                         try {
                             ignoreTP = true;
-                            PaperLib.teleportAsync(entity, origin);
+                            PaperSupport.teleportAsync(entity, origin);
                         } finally {
                             ignoreTP = false;
                         }
@@ -125,7 +125,7 @@ public class EntitySpawnListener implements Listener {
         if (!location.isPlotArea() || area == null) {
             return;
         }
-        if (PaperLib.isPaper()) {
+        if (PaperSupport.isPaper()) {
             //noinspection ConstantValue - getEntitySpawnReason annotated as NotNull, but is not NotNull. lol.
             if (area.isSpawnCustom() && entity.getEntitySpawnReason() != null && "CUSTOM".equals(entity.getEntitySpawnReason().name())) {
                 return;

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -24,6 +24,7 @@ import com.google.inject.Inject;
 import com.plotsquared.bukkit.player.BukkitPlayer;
 import com.plotsquared.bukkit.util.BukkitEntityUtil;
 import com.plotsquared.bukkit.util.BukkitUtil;
+import com.plotsquared.bukkit.util.PaperSupport;
 import com.plotsquared.bukkit.util.UpdateUtility;
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.Settings;
@@ -83,7 +84,6 @@ import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.util.Enums;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
-import io.papermc.lib.PaperLib;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.Tag;
@@ -692,7 +692,7 @@ public class PlayerEventListener implements Listener {
                     if (dest != null) {
                         vehicle.eject();
                         vehicle.setVelocity(new Vector(0d, 0d, 0d));
-                        PaperLib.teleportAsync(vehicle, dest);
+                        PaperSupport.teleportAsync(vehicle, dest);
                         passengers.forEach(vehicle::addPassenger);
                         return;
                     }
@@ -1310,7 +1310,7 @@ public class PlayerEventListener implements Listener {
                         }
                     }
                 }
-                if (PaperLib.isPaper()) {
+                if (PaperSupport.isPaper()) {
                     if (MaterialTags.SPAWN_EGGS.isTagged(type) || Material.EGG.equals(type)) {
                         eventType = PlayerBlockEventType.SPAWN_MOB;
                         break;

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/player/BukkitPlayer.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/player/BukkitPlayer.java
@@ -20,6 +20,7 @@ package com.plotsquared.bukkit.player;
 
 import com.google.common.base.Charsets;
 import com.plotsquared.bukkit.util.BukkitUtil;
+import com.plotsquared.bukkit.util.PaperSupport;
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.Settings;
 import com.plotsquared.core.events.TeleportCause;
@@ -38,7 +39,6 @@ import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.item.ItemTypes;
-import io.papermc.lib.PaperLib;
 import net.kyori.adventure.audience.Audience;
 import org.bukkit.GameMode;
 import org.bukkit.Sound;
@@ -233,7 +233,7 @@ public class BukkitPlayer extends PlotPlayer<Player> {
                 new org.bukkit.Location(BukkitUtil.getWorld(location.getWorldName()), location.getX() + 0.5,
                         location.getY(), location.getZ() + 0.5, location.getYaw(), location.getPitch()
                 );
-        PaperLib.teleportAsync(player, bukkitLocation, getTeleportCause(cause));
+        PaperSupport.teleportAsync(player, bukkitLocation, getTeleportCause(cause));
     }
 
     @Override

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/queue/BukkitChunkCoordinator.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/queue/BukkitChunkCoordinator.java
@@ -21,6 +21,7 @@ package com.plotsquared.bukkit.queue;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import com.plotsquared.bukkit.BukkitPlatform;
+import com.plotsquared.bukkit.util.PaperSupport;
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.queue.ChunkCoordinator;
 import com.plotsquared.core.queue.subscriber.ProgressSubscriber;
@@ -29,7 +30,6 @@ import com.plotsquared.core.util.task.TaskManager;
 import com.plotsquared.core.util.task.TaskTime;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.world.World;
-import io.papermc.lib.PaperLib;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
@@ -222,10 +222,9 @@ public final class BukkitChunkCoordinator extends ChunkCoordinator {
      */
     private void requestBatch() {
         for (int i = 0; i < this.batchSize && this.requestedChunks.peek() != null; i++) {
-            // This required PaperLib to be bumped to version 1.0.4 to mark the request as urgent
             final BlockVector2 chunk = this.requestedChunks.poll();
             loadingChunks.incrementAndGet();
-            PaperLib
+            PaperSupport
                     .getChunkAtAsync(this.bukkitWorld, chunk.getX(), chunk.getZ(), shouldGen, true)
                     .orTimeout(10L, TimeUnit.SECONDS)
                     .whenComplete((chunkObject, throwable) -> {
@@ -258,11 +257,6 @@ public final class BukkitChunkCoordinator extends ChunkCoordinator {
      * server's main thread.
      */
     private void processChunk(final @NonNull Chunk chunk) {
-        /* Chunk#isLoaded does not necessarily return true shortly after PaperLib#getChunkAtAsync completes, but the chunk is
-        still loaded.
-        if (!chunk.isLoaded()) {
-            throw new IllegalArgumentException(String.format("Chunk %d;%d is is not loaded", chunk.getX(), chunk.getZ());
-        }*/
         if (finished) {
             return;
         }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/schematic/StateWrapper.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/schematic/StateWrapper.java
@@ -21,6 +21,7 @@ package com.plotsquared.bukkit.schematic;
 import com.destroystokyo.paper.profile.PlayerProfile;
 import com.destroystokyo.paper.profile.ProfileProperty;
 import com.plotsquared.bukkit.util.BukkitUtil;
+import com.plotsquared.bukkit.util.PaperSupport;
 import com.sk89q.jnbt.ByteTag;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.jnbt.ListTag;
@@ -30,7 +31,6 @@ import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.world.item.ItemType;
-import io.papermc.lib.PaperLib;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
@@ -270,7 +270,7 @@ public class StateWrapper {
                     if (textureValue == null) {
                         return false;
                     }
-                    if (!PaperLib.isPaper()) {
+                    if (!PaperSupport.isPaper()) {
                         if (!paperErrorTextureSent) {
                             paperErrorTextureSent = true;
                             LOGGER.error("Failed to populate skull data in your road schematic - This is a Spigot limitation.");

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitChunkManager.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitChunkManager.java
@@ -22,7 +22,6 @@ import com.google.inject.Singleton;
 import com.plotsquared.core.util.ChunkManager;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.regions.CuboidRegion;
-import io.papermc.lib.PaperLib;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -38,7 +37,7 @@ public class BukkitChunkManager extends ChunkManager {
 
     @Override
     public CompletableFuture<?> loadChunk(String world, BlockVector2 chunkLoc, boolean force) {
-        return PaperLib.getChunkAtAsync(BukkitUtil.getWorld(world), chunkLoc.getX(), chunkLoc.getZ(), force);
+        return PaperSupport.getChunkAtAsync(BukkitUtil.getWorld(world), chunkLoc.getX(), chunkLoc.getZ(), force);
     }
 
 }

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitRegionManager.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitRegionManager.java
@@ -41,7 +41,6 @@ import com.sk89q.worldedit.bukkit.BukkitWorld;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockTypes;
-import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.World;
@@ -126,7 +125,7 @@ public class BukkitRegionManager extends RegionManager {
         if (doWhole) {
             for (Entity entity : entities) {
                 org.bukkit.Location location = entity.getLocation();
-                PaperLib.getChunkAtAsync(location).thenAccept(chunk -> {
+                PaperSupport.getChunkAtAsync(location).thenAccept(chunk -> {
                     if (chunks.contains(chunk)) {
                         int X = chunk.getX();
                         int Z = chunk.getZ();

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/BukkitUtil.java
@@ -43,7 +43,6 @@ import com.sk89q.worldedit.world.block.BlockCategories;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
-import io.papermc.lib.PaperLib;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
@@ -192,12 +191,12 @@ public class BukkitUtil extends WorldUtil {
             final int z,
             final @NonNull Consumer<Chunk> chunkConsumer
     ) {
-        PaperLib.getChunkAtAsync(Objects.requireNonNull(getWorld(world)), x >> 4, z >> 4, true)
+        PaperSupport.getChunkAtAsync(Objects.requireNonNull(getWorld(world)), x >> 4, z >> 4, true)
                 .thenAccept(chunk -> ensureMainThread(chunkConsumer, chunk));
     }
 
     private static void ensureLoaded(final @NonNull Location location, final @NonNull Consumer<Chunk> chunkConsumer) {
-        PaperLib.getChunkAtAsync(adapt(location), true).thenAccept(chunk -> ensureMainThread(chunkConsumer, chunk));
+        PaperSupport.getChunkAtAsync(adapt(location)).thenAccept(chunk -> ensureMainThread(chunkConsumer, chunk));
     }
 
     private static <T> void ensureMainThread(final @NonNull Consumer<T> consumer, final @NonNull T value) {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/PaperSupport.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/PaperSupport.java
@@ -70,9 +70,7 @@ public enum PaperSupport {
         if (isPaper()) {
             return world.getChunkAtAsync(cx, cz, gen, urgent);
         } else {
-            CompletableFuture<Chunk> future = new CompletableFuture<>();
-            future.complete(world.getChunkAt(cx, cz, gen));
-            return future;
+            return CompletableFuture.completedFuture(world.getChunkAt(cx, cz, gen));
         }
     }
 

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/PaperSupport.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/PaperSupport.java
@@ -1,0 +1,87 @@
+/*
+ * PlotSquared, a land and world management plugin for Minecraft.
+ * Copyright (C) IntellectualSites <https://intellectualsites.com>
+ * Copyright (C) IntellectualSites team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.bukkit.util;
+
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Not for external use. May change at any point.
+ */
+@ApiStatus.Internal
+public enum PaperSupport {
+    ;
+    public static final boolean PAPER;
+
+    static {
+        PAPER = hasClass("com.destroystokyo.paper.PaperConfig")
+            || hasClass("io.papermc.paper.configuration.Configuration");
+    }
+
+    public static boolean isPaper() {
+        return PAPER;
+    }
+
+    public static CompletableFuture<Boolean> teleportAsync(Entity entity, Location location) {
+        if (isPaper()) {
+            return entity.teleportAsync(location);
+        }
+        return CompletableFuture.completedFuture(entity.teleport(location));
+    }
+
+    public static CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, PlayerTeleportEvent.TeleportCause cause) {
+        if (isPaper()) {
+            return entity.teleportAsync(location, cause);
+        }
+        return CompletableFuture.completedFuture(entity.teleport(location));
+    }
+
+    public static CompletableFuture<Chunk> getChunkAtAsync(Location location) {
+        return getChunkAtAsync(location.getWorld(), location.getBlockX() >> 4, location.getBlockZ() >> 4, true);
+    }
+
+    public static CompletableFuture<Chunk> getChunkAtAsync(World world, int cx, int cz, boolean gen) {
+        return getChunkAtAsync(world, cx, cz, gen, false);
+    }
+
+    public static CompletableFuture<Chunk> getChunkAtAsync(World world, int cx, int cz, boolean gen, boolean urgent) {
+        if (isPaper()) {
+            return world.getChunkAtAsync(cx, cz, gen, urgent);
+        } else {
+            CompletableFuture<Chunk> future = new CompletableFuture<>();
+            future.complete(world.getChunkAt(cx, cz, gen));
+            return future;
+        }
+    }
+
+    private static boolean hasClass(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/PaperSupport.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/PaperSupport.java
@@ -55,7 +55,7 @@ public enum PaperSupport {
         if (isPaper()) {
             return entity.teleportAsync(location, cause);
         }
-        return CompletableFuture.completedFuture(entity.teleport(location));
+        return CompletableFuture.completedFuture(entity.teleport(location, cause));
     }
 
     public static CompletableFuture<Chunk> getChunkAtAsync(Location location) {

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/util/PaperSupport.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/util/PaperSupport.java
@@ -70,7 +70,7 @@ public enum PaperSupport {
         if (isPaper()) {
             return world.getChunkAtAsync(cx, cz, gen, urgent);
         } else {
-            return CompletableFuture.completedFuture(world.getChunkAt(cx, cz, gen));
+            return CompletableFuture.completedFuture(world.getChunkAt(cx, cz));
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,6 @@ arkitektonika = "2.1.4"
 squirrelid = "0.3.2"
 paster = "1.1.7"
 bstats = "3.2.1"
-paperlib = "1.0.8"
 informative-annotations = "1.6"
 vault = "1.7.1"
 serverlib = "2.3.7"
@@ -73,7 +72,6 @@ arkitektonika = { group = "com.intellectualsites.arkitektonika", name = "Arkitek
 paster = { group = "com.intellectualsites.paster", name = "Paster", version.ref = "paster" }
 bstatsBukkit = { group = "org.bstats", name = "bstats-bukkit", version.ref = "bstats" }
 informativeAnnotations = { group = "com.intellectualsites.informative-annotations", name = "informative-annotations", version.ref = "informative-annotations" }
-paperlib = { group = "io.papermc", name = "paperlib", version.ref = "paperlib" }
 vault = { group = "com.github.MilkBowl", name = "VaultAPI", version.ref = "vault" }
 serverlib = { group = "dev.notmyfault.serverlib", name = "ServerLib", version.ref = "serverlib" }
 


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #4905

## Description
<!-- Please describe what this pull request does. -->

PaperLib's version detection is broken, therefore some implementations fall back to whatever Spigot provides.

The fix is just reimplementing the required features in PlotSquared directly. That's pretty much straightforward. The relevant class is marked internal. We can also remove the PaperLib dependency now.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
