### PR TITLE
Fixed support for new egg types in 1.21.5 and later versions

### DIFF
--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -92,6 +92,7 @@ import net.kyori.adventure.text.minimessage.tag.standard.StandardTags;
 import org.bukkit.Bukkit;
 import org.bukkit.FluidCollisionMode;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
@@ -1310,16 +1311,20 @@ public class PlayerEventListener implements Listener {
                         }
                     }
                 }
+                // 1.21.5 (Spring to Life) introduced brown_egg and blue_egg.
+                // This new variable detects all current and future eggs.
+                // It could be replaced with an Item Tag or the exact Material in the future.
+                boolean isEgg = Optional.ofNullable(Bukkit.getTag(org.bukkit.Tag.REGISTRY_ITEMS, NamespacedKey.minecraft("eggs"), Material.class))
+                        .map(tag -> tag.isTagged(type))
+                        .orElse(type.name().endsWith("EGG"));
                 if (PaperLib.isPaper()) {
-                    if (MaterialTags.SPAWN_EGGS.isTagged(type) || Material.EGG.equals(type)) {
+                    if (MaterialTags.SPAWN_EGGS.isTagged(type) || isEgg) {
                         eventType = PlayerBlockEventType.SPAWN_MOB;
                         break;
                     }
-                } else {
-                    if (type.toString().toLowerCase().endsWith("egg")) {
-                        eventType = PlayerBlockEventType.SPAWN_MOB;
-                        break;
-                    }
+                } else if (isEgg) {
+                    eventType = PlayerBlockEventType.SPAWN_MOB;
+                    break;
                 }
                 if (type.isEdible()) {
                     //Allow all players to eat while also allowing the block place event to be fired

--- a/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
+++ b/Bukkit/src/main/java/com/plotsquared/bukkit/listener/PlayerEventListener.java
@@ -92,6 +92,7 @@ import net.kyori.adventure.text.minimessage.tag.standard.StandardTags;
 import org.bukkit.Bukkit;
 import org.bukkit.FluidCollisionMode;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
@@ -155,6 +156,7 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.Vector;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
@@ -291,6 +293,11 @@ public class PlayerEventListener implements Listener {
     private final WorldEdit worldEdit;
     private final PlotAreaManager plotAreaManager;
     private final PlotListener plotListener;
+    private final org.bukkit.@Nullable Tag<Material> eggTag = Bukkit.getTag(
+            org.bukkit.Tag.REGISTRY_ITEMS,
+            NamespacedKey.minecraft("eggs"),
+            Material.class
+    );
     // To prevent recursion
     private boolean tmpTeleport = true;
     private Field fieldPlayer;
@@ -1310,16 +1317,20 @@ public class PlayerEventListener implements Listener {
                         }
                     }
                 }
+                // 1.21.5 (Spring to Life) introduced brown_egg and blue_egg.
+                // This new variable detects all current and future eggs.
+                // It could be replaced with an Item Tag or the exact Material in the future.
+                boolean isEgg = Optional.ofNullable(eggTag)
+                        .map(tag -> tag.isTagged(type))
+                        .orElse(type.name().endsWith("EGG"));
                 if (PaperLib.isPaper()) {
-                    if (MaterialTags.SPAWN_EGGS.isTagged(type) || Material.EGG.equals(type)) {
+                    if (MaterialTags.SPAWN_EGGS.isTagged(type) || isEgg) {
                         eventType = PlayerBlockEventType.SPAWN_MOB;
                         break;
                     }
-                } else {
-                    if (type.toString().toLowerCase().endsWith("egg")) {
-                        eventType = PlayerBlockEventType.SPAWN_MOB;
-                        break;
-                    }
+                } else if (isEgg) {
+                    eventType = PlayerBlockEventType.SPAWN_MOB;
+                    break;
                 }
                 if (type.isEdible()) {
                     //Allow all players to eat while also allowing the block place event to be fired
@@ -2054,3 +2065,5 @@ public class PlayerEventListener implements Listener {
     }
 
 }
+
+


### PR DESCRIPTION
## Overview
Fixes an issue where blue and brown eggs aren't treated the same as regular eggs. 

## Description
Includes a new variable to detect all eggs in game and treat them the same. 

### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
